### PR TITLE
Update expo-cli and @expo/config-plugins

### DIFF
--- a/packages/build-tools/package.json
+++ b/packages/build-tools/package.json
@@ -19,7 +19,7 @@
   "bugs": "https://github.com/expo/eas-build/issues",
   "license": "MIT",
   "dependencies": {
-    "@expo/config-plugins": "1.0.27",
+    "@expo/config-plugins": "1.0.28",
     "@expo/downloader": "0.0.15",
     "@expo/eas-build-job": "0.2.26",
     "@expo/fastlane": "0.0.23",

--- a/packages/local-build-plugin/package.json
+++ b/packages/local-build-plugin/package.json
@@ -26,7 +26,7 @@
     "@expo/turtle-spawn": "0.0.20",
     "@hapi/joi": "^17.1.1",
     "chalk": "^4.1.0",
-    "expo-cli": "4.4.2",
+    "expo-cli": "4.4.3",
     "fs-extra": "^9.1.0",
     "lodash": "^4.17.21",
     "semver": "^7.3.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1182,10 +1182,10 @@
     mv "~2"
     safe-json-stringify "~1"
 
-"@expo/config-plugins@1.0.27":
-  version "1.0.27"
-  resolved "https://registry.yarnpkg.com/@expo/config-plugins/-/config-plugins-1.0.27.tgz#e1a8d2cc1d31f1fc21695cd4c4b6b05afbcc8519"
-  integrity sha512-rdLykx/RgcfYmJEZ23+d1wH6RxifMsPh+q8TSzsBb3yXQPU/oCz14/RFLgNojWvKTAjTo9kNu5erIVlwDIJHxQ==
+"@expo/config-plugins@1.0.28":
+  version "1.0.28"
+  resolved "https://registry.yarnpkg.com/@expo/config-plugins/-/config-plugins-1.0.28.tgz#6c3911d493bc329bf9ef5c99585564539b1a57e1"
+  integrity sha512-i5SpC6U3LjRQlwi1xM4SRj8dR2Qm+0dykPo0GeesByB7IvT36AT1ZjI7VjecuoZ6yKbLpaa5tWvU3JGObxIPSw==
   dependencies:
     "@expo/config-types" "^40.0.0-beta.2"
     "@expo/configure-splash-screen" "0.3.4"
@@ -1207,16 +1207,16 @@
   resolved "https://registry.yarnpkg.com/@expo/config-types/-/config-types-40.0.0-beta.2.tgz#4fea4ef5654d02218b02b0b3772529a9ce5b0471"
   integrity sha512-t9pHCQMXOP4nwd7LGXuHkLlFy0JdfknRSCAeVF4Kw2/y+5OBbR9hW9ZVnetpBf0kORrekgiI7K/qDaa3hh5+Qg==
 
-"@expo/config@3.3.37":
-  version "3.3.37"
-  resolved "https://registry.yarnpkg.com/@expo/config/-/config-3.3.37.tgz#918b40f2ab8f419180febc619b3f572d631a13e1"
-  integrity sha512-RJrGwjEWGvRVo9zZ4T0q/5bwW6ewf2FsIS5Cj79IOS9AFu1LNJpUuI6PdJ6VX6O4xR3BDxCtL713rWgihQfbmg==
+"@expo/config@3.3.38":
+  version "3.3.38"
+  resolved "https://registry.yarnpkg.com/@expo/config/-/config-3.3.38.tgz#cdda7307600d185eb5d7b37ce8e47dcb8df6a4cd"
+  integrity sha512-0SsvF7yTy+kdJaAc2W75yhwnaXIRasnA1Vygna83tlPhCx6ynIBzTbJAvdkddSk5euUTJpXc5nePaflGvNboXw==
   dependencies:
     "@babel/core" "7.9.0"
     "@babel/plugin-proposal-class-properties" "~7.12.13"
     "@babel/preset-env" "~7.12.13"
     "@babel/preset-typescript" "~7.12.13"
-    "@expo/config-plugins" "1.0.27"
+    "@expo/config-plugins" "1.0.28"
     "@expo/config-types" "^40.0.0-beta.2"
     "@expo/json-file" "8.2.29"
     fs-extra "9.0.0"
@@ -1243,24 +1243,24 @@
     xcode "^3.0.0"
     xml-js "^1.6.11"
 
-"@expo/dev-server@0.1.63":
-  version "0.1.63"
-  resolved "https://registry.yarnpkg.com/@expo/dev-server/-/dev-server-0.1.63.tgz#de211243b531fcf431e26aedef31a7db551bce63"
-  integrity sha512-UIjfhc7vg/ThIRdQKg90QoK0KnjqgugZ0pBdhOIT7FVWPjaadhopfY3B7JTDuQp8Bja83KwKw968OiMSTwgUqA==
+"@expo/dev-server@0.1.64":
+  version "0.1.64"
+  resolved "https://registry.yarnpkg.com/@expo/dev-server/-/dev-server-0.1.64.tgz#4513f25d3a9273a84ee0199de8838be854746aac"
+  integrity sha512-6yRkV0qVyz0bZsfPkpPsDRmMIHQQ9Lw3Nn5BAgCNvo7SzjINeNfcpWJXvwcxrU76kKUS+r5NaXNCRlDUkqGTHg==
   dependencies:
     "@expo/bunyan" "4.0.0"
-    "@expo/metro-config" "0.1.63"
+    "@expo/metro-config" "0.1.64"
     "@react-native-community/cli-server-api" "4.9.0"
     body-parser "1.19.0"
     resolve-from "^5.0.0"
     serialize-error "6.0.0"
 
-"@expo/dev-tools@0.13.93":
-  version "0.13.93"
-  resolved "https://registry.yarnpkg.com/@expo/dev-tools/-/dev-tools-0.13.93.tgz#9bd584dec72630f442470d58bfa82864d8dd6035"
-  integrity sha512-5CpT35efBNyku1h7myljnx6+eI/J6Em27f7eiGGusw+Y8M5FNccIuFg+RDzltDR7XQ0mji6Zf2hoj+CbtUzV2g==
+"@expo/dev-tools@0.13.94":
+  version "0.13.94"
+  resolved "https://registry.yarnpkg.com/@expo/dev-tools/-/dev-tools-0.13.94.tgz#e7f5094909ac58d491fce76067dc9bad376005f2"
+  integrity sha512-T3jIIGB1yLk+1JVcOG3VJI5CTFcOoWEOT4e0/3hONp6CnDQG0L2qpuzd4ypWO411iZ5q3aCyYKNN10AIEZLqzA==
   dependencies:
-    "@expo/config" "3.3.37"
+    "@expo/config" "3.3.38"
     base64url "3.0.1"
     express "4.16.4"
     freeport-async "2.0.0"
@@ -1327,12 +1327,12 @@
     json5 "^1.0.1"
     write-file-atomic "^2.3.0"
 
-"@expo/metro-config@0.1.63":
-  version "0.1.63"
-  resolved "https://registry.yarnpkg.com/@expo/metro-config/-/metro-config-0.1.63.tgz#cc502e8f14b90908b4a37db2caf3e45355acb4b2"
-  integrity sha512-NIJ4vvVwyHaOlkFAvP17bSazc+vmAX7wyQ/sT85DEIbwxltfEXxZIcJUGxObf5SgR5V5iPurwrGyS/7HPcA7eA==
+"@expo/metro-config@0.1.64":
+  version "0.1.64"
+  resolved "https://registry.yarnpkg.com/@expo/metro-config/-/metro-config-0.1.64.tgz#f889f1383db145923d364c956e2c25e0465d49fd"
+  integrity sha512-ooD+XOVGnKPIIZbyfVTvMeQ3p9HpRt4aNCehSM6H1ueQm8+IpVwrhw8sJjL5xr+FVxFqj0+Ga9DI8d0AXS8U4g==
   dependencies:
-    "@expo/config" "3.3.37"
+    "@expo/config" "3.3.38"
     chalk "^4.1.0"
     getenv "^1.0.0"
     metro-react-native-babel-transformer "^0.59.0"
@@ -1421,21 +1421,21 @@
   dependencies:
     cross-spawn "^6.0.5"
 
-"@expo/webpack-config@0.12.67":
-  version "0.12.67"
-  resolved "https://registry.yarnpkg.com/@expo/webpack-config/-/webpack-config-0.12.67.tgz#99fcb744482c2c5ed072f88f109cc88736dd7aac"
-  integrity sha512-Gnq88l+Tu5JDexlPTHF8BoGkb2lgZE2I0xL/xa3qiG4hi5rZLXFf7y2grWa4Il+YpKT+ZmrHGCWkNBD5SlUDKg==
+"@expo/webpack-config@0.12.68":
+  version "0.12.68"
+  resolved "https://registry.yarnpkg.com/@expo/webpack-config/-/webpack-config-0.12.68.tgz#185f440a484f69a1a8885c042ce0555c554a00c6"
+  integrity sha512-GS15Vd/VkaITWnQYe4qROGHi95R6HF8x8vDZ1msxfYEVSjdXMU9eo8BPiyTtLTIAaCyNUQEOX5N+91mKHXJPeQ==
   dependencies:
     "@babel/core" "7.9.0"
     "@babel/runtime" "7.9.0"
-    "@expo/config" "3.3.37"
+    "@expo/config" "3.3.38"
     "@pmmmwh/react-refresh-webpack-plugin" "^0.3.3"
     babel-loader "8.1.0"
     chalk "^4.0.0"
     clean-webpack-plugin "^3.0.0"
     copy-webpack-plugin "~6.0.3"
     css-loader "~3.6.0"
-    expo-pwa "0.0.73"
+    expo-pwa "0.0.74"
     file-loader "~6.0.0"
     find-yarn-workspace-root "~2.0.0"
     getenv "^1.0.0"
@@ -6907,16 +6907,16 @@ expect@^26.6.2:
     jest-message-util "^26.6.2"
     jest-regex-util "^26.0.0"
 
-expo-cli@4.4.2:
-  version "4.4.2"
-  resolved "https://registry.yarnpkg.com/expo-cli/-/expo-cli-4.4.2.tgz#27affcd8e2e3b1e3449365759490cbe2dedb0c01"
-  integrity sha512-oapzsY4C4Zo3WdEuon5spXt5zbiyMt2Y22xviPeeGdo4GDnzauQsbKtsPqHGOtf70wdE42if3dB8dJH0MaIeUQ==
+expo-cli@4.4.3:
+  version "4.4.3"
+  resolved "https://registry.yarnpkg.com/expo-cli/-/expo-cli-4.4.3.tgz#2f2e658d7010c82fc16046573535dd384cfee469"
+  integrity sha512-wSap0vOOFRgg+SUrB4QPNdJH7FeTZAXgEIdrQIayoliRe+e/466Buh1j9v5g0CE6INhRjX+Ak2u9z5pVJxa4MQ==
   dependencies:
     "@expo/apple-utils" "0.0.0-alpha.17"
     "@expo/bunyan" "4.0.0"
-    "@expo/config" "3.3.37"
-    "@expo/config-plugins" "1.0.27"
-    "@expo/dev-tools" "0.13.93"
+    "@expo/config" "3.3.38"
+    "@expo/config-plugins" "1.0.28"
+    "@expo/dev-tools" "0.13.94"
     "@expo/json-file" "8.2.29"
     "@expo/osascript" "2.0.26"
     "@expo/package-manager" "0.0.41"
@@ -6972,14 +6972,14 @@ expo-cli@4.4.2:
     url-join "4.0.0"
     uuid "^8.0.0"
     wrap-ansi "^7.0.0"
-    xdl "59.0.33"
+    xdl "59.0.34"
 
-expo-pwa@0.0.73:
-  version "0.0.73"
-  resolved "https://registry.yarnpkg.com/expo-pwa/-/expo-pwa-0.0.73.tgz#2cf4606649e9b4be4664a4b2d9155d0167848f15"
-  integrity sha512-XOlntkmEM1wzsVuH9Dr837sG6TIBcsXQUT8bwaCyWNDTnA1S4E8sWkHwY/By+moABL7ndr2XCFKShKQGrrB2Ww==
+expo-pwa@0.0.74:
+  version "0.0.74"
+  resolved "https://registry.yarnpkg.com/expo-pwa/-/expo-pwa-0.0.74.tgz#624ae389399f9d499b2fd611a3c3e682bb6a8c4e"
+  integrity sha512-Y3lzJl9Q+0KuYt6003eacwpfoEYzO+w2R3oBDtfwGU16KbQkm2O6zGAYluBGnlPoph+fCUmyi2mT2ucd5KSlDQ==
   dependencies:
-    "@expo/config" "3.3.37"
+    "@expo/config" "3.3.38"
     "@expo/image-utils" "0.3.13"
     chalk "^4.0.0"
     commander "2.20.0"
@@ -16004,15 +16004,15 @@ xcode@^3.0.0, xcode@^3.0.1:
     simple-plist "^1.1.0"
     uuid "^7.0.3"
 
-xdl@59.0.33:
-  version "59.0.33"
-  resolved "https://registry.yarnpkg.com/xdl/-/xdl-59.0.33.tgz#2327941e4af0f5463a3f0c0fb10f9bdcc5a57c7c"
-  integrity sha512-u/u7/+tWzIw5tD3T7KBeowEdt1KWt2ENy9JeYOEfyMKXHgDi+sJgRl2KQQFV+PWtNlSIVVKR5CvDfZL08/IOQQ==
+xdl@59.0.34:
+  version "59.0.34"
+  resolved "https://registry.yarnpkg.com/xdl/-/xdl-59.0.34.tgz#60648e69150ec85e43aa3b381541b2b85da37086"
+  integrity sha512-gcnWDPydwr/0JAwTv0vbWU8PaYjiRWSSjwzsIcnqlh5aZZdMfEle+TwfXRhPwJm5jut4BgnzOfQqMV8CfXKbXQ==
   dependencies:
     "@expo/bunyan" "4.0.0"
-    "@expo/config" "3.3.37"
-    "@expo/config-plugins" "1.0.27"
-    "@expo/dev-server" "0.1.63"
+    "@expo/config" "3.3.38"
+    "@expo/config-plugins" "1.0.28"
+    "@expo/dev-server" "0.1.64"
     "@expo/devcert" "^1.0.0"
     "@expo/json-file" "8.2.29"
     "@expo/osascript" "2.0.26"
@@ -16020,7 +16020,7 @@ xdl@59.0.33:
     "@expo/plist" "0.0.12"
     "@expo/schemer" "1.3.28"
     "@expo/spawn-async" "1.5.0"
-    "@expo/webpack-config" "0.12.67"
+    "@expo/webpack-config" "0.12.68"
     "@hapi/joi" "^17.1.1"
     analytics-node "3.5.0"
     axios "0.21.1"


### PR DESCRIPTION
This fixes an issue where `prebuild` doesn't set the proper `userInterfaceStyle` if the field is not provided in app.json