### PR TITLE
[eas-build-job] Add expoCli parameter to environment.

### DIFF
--- a/packages/eas-build-job/src/android.ts
+++ b/packages/eas-build-job/src/android.ts
@@ -36,6 +36,7 @@ export interface BuilderEnvironment {
   image: typeof builderBaseImages[number];
   node?: string;
   yarn?: string;
+  expoCli?: string;
   ndk?: string;
   env?: Env;
 }
@@ -46,6 +47,7 @@ const BuilderEnvironmentSchema = Joi.object({
     .default('default'),
   node: Joi.string(),
   yarn: Joi.string(),
+  expoCli: Joi.string(),
   ndk: Joi.string(),
   env: EnvSchema,
 });

--- a/packages/eas-build-job/src/ios.ts
+++ b/packages/eas-build-job/src/ios.ts
@@ -51,6 +51,7 @@ export interface BuilderEnvironment {
   image: typeof builderBaseImages[number];
   node?: string;
   yarn?: string;
+  expoCli?: string;
   bundler?: string;
   fastlane?: string;
   cocoapods?: string;
@@ -63,6 +64,7 @@ const BuilderEnvironmentSchema = Joi.object({
     .default('default'),
   node: Joi.string(),
   yarn: Joi.string(),
+  expoCli: Joi.string(),
   bundler: Joi.string(),
   fastlane: Joi.string(),
   cocoapods: Joi.string(),


### PR DESCRIPTION
# Why

To allow build jobs to specify the version of the Expo CLI to use.

# How

Add `expoCli` to BuilderEnvironments for Android and iOS.

# Test Plan