### PR TITLE
support pkcs keystores for android builds

### DIFF
--- a/packages/build-tools/src/android/credentials.ts
+++ b/packages/build-tools/src/android/credentials.ts
@@ -14,7 +14,7 @@ async function restoreCredentials(ctx: BuildContext<Android.Job>): Promise<void>
   }
   ctx.logger.info("Writing secrets to the project's directory");
   const projectDir = ctx.reactNativeProjectDirectory;
-  const keystorePath = `keystore-${uuidv4()}.jks`;
+  const keystorePath = `keystore-${uuidv4()}`;
   await fs.writeFile(
     path.join(projectDir, keystorePath),
     Buffer.from(buildCredentials.keystore.dataBase64, 'base64')

--- a/packages/eas-build-job/src/android.ts
+++ b/packages/eas-build-job/src/android.ts
@@ -15,14 +15,14 @@ export interface Keystore {
   dataBase64: string;
   keystorePassword: string;
   keyAlias: string;
-  keyPassword: string;
+  keyPassword?: string;
 }
 
 const KeystoreSchema = Joi.object({
   dataBase64: Joi.string().required(),
-  keystorePassword: Joi.string().required(),
+  keystorePassword: Joi.string().allow('').required(),
   keyAlias: Joi.string().required(),
-  keyPassword: Joi.string().required(),
+  keyPassword: Joi.string().allow(''),
 });
 
 export const builderBaseImages = [


### PR DESCRIPTION
# Why

Add support for pkcs keystores (no key password)
Allow empty keystore password

# How


# Test Plan

run builds with `eas build --local`  for those cases
run builds with `EXPO_LOCAL=1 eas build`  for those cases
