### PR TITLE
change license for @expo/eas-build-job

### DIFF
--- a/LICENSE-eas-build-job
+++ b/LICENSE-eas-build-job
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2020-present 650 Industries, Inc. (aka Expo)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/eas-build-job/package.json
+++ b/packages/eas-build-job/package.json
@@ -16,7 +16,7 @@
   },
   "author": "Expo <support@expo.io>",
   "bugs": "https://github.com/expo/eas-build/issues",
-  "license": "BUSL-1.1",
+  "license": "MIT",
   "devDependencies": {
     "@types/jest": "^26.0.20",
     "@types/node": "^14.14.31",


### PR DESCRIPTION
# Why

We use this package in eas-cli, it might be confusing for users if they see in dependencies "BUSL" license. This package contains only types and schemas so it does not matter much on what license is published from our perspective, plus it also does not depend on any other package from this repo so it should be clear what license applies to which package

