### PR TITLE
Support empty passwords in pkcs kesytores

### DIFF
--- a/packages/build-tools/src/ios/credentials/distributionCertificate.ts
+++ b/packages/build-tools/src/ios/credentials/distributionCertificate.ts
@@ -14,7 +14,11 @@ function getCertData(certificateBase64: string, password: string): any {
   const p12Asn1 = forge.asn1.fromDer(p12Der);
   let p12: forge.pkcs12.Pkcs12Pfx;
   try {
-    p12 = forge.pkcs12.pkcs12FromAsn1(p12Asn1, password);
+    if (password) {
+      p12 = forge.pkcs12.pkcs12FromAsn1(p12Asn1, password);
+    } else {
+      p12 = forge.pkcs12.pkcs12FromAsn1(p12Asn1);
+    }
   } catch (_error) {
     const error: Error = _error;
     if (/Invalid password/.exec(error.message)) {

--- a/packages/eas-build-job/src/ios.ts
+++ b/packages/eas-build-job/src/ios.ts
@@ -17,7 +17,7 @@ const TargetCredentialsSchema = Joi.object().keys({
   provisioningProfileBase64: Joi.string().required(),
   distributionCertificate: Joi.object({
     dataBase64: Joi.string().required(),
-    password: Joi.string().required(),
+    password: Joi.string().allow('').required(),
   }).required(),
 });
 


### PR DESCRIPTION
# Why

Support empty passwords in pkcs keystores for ios builds

# How

- allow empty string in joi schema
- call pkcs12FromAsn1 with strict set to false and no value provided as a password
  - old implementation worked with p12 generated with openssl but I didn't work with one exported from keychain


# Test Plan

eas build --local
