### PR TITLE
support builtType option for iOS Managed builds

### DIFF
--- a/packages/build-tools/src/builders/iosManaged.ts
+++ b/packages/build-tools/src/builders/iosManaged.ts
@@ -54,6 +54,8 @@ export default async function iosManagedBuilder(
       await runFastlaneGym(ctx, {
         credentials,
         scheme: resolveScheme(ctx),
+        buildConfiguration:
+          ctx.job.buildType === Ios.ManagedBuildType.DEVELOPMENT_CLIENT ? 'Debug' : 'Release',
       });
     });
 


### PR DESCRIPTION
# Why

Add supports for building dev client

# How

Pass different scheme depending on the option

# Test Plan

