### PR TITLE
[eas-build-job] add versionCode and buildNumber to metadata

### DIFF
--- a/packages/eas-build-job/src/__tests__/metadata.test.ts
+++ b/packages/eas-build-job/src/__tests__/metadata.test.ts
@@ -13,6 +13,8 @@ describe('MetadataSchema', () => {
       trackingContext: {},
       workflow: 'generic',
       username: 'notdominik',
+      versionCode: 123,
+      buildNumber: '123',
     };
     const { value, error } = MetadataSchema.validate(metadata, {
       stripUnknown: true,
@@ -34,6 +36,8 @@ describe('MetadataSchema', () => {
       trackingContext: {},
       workflow: 'generic',
       username: 'notdominik',
+      versionCode: 123,
+      buildNumber: '123',
     };
     const { error } = MetadataSchema.validate(metadata, {
       stripUnknown: true,

--- a/packages/eas-build-job/src/metadata.ts
+++ b/packages/eas-build-job/src/metadata.ts
@@ -10,7 +10,11 @@ export type Metadata = {
   trackingContext: Record<string, string | number>;
 
   /**
-   * Application version (the expo.version key in app.json/app.config.js)
+   * Application version:
+   * - managed projects: expo.version in app.json/app.config.js
+   * - generic projects:
+   *   * iOS: CFBundleShortVersionString in Info.plist
+   *   * Android: versionName in build.gradle
    */
   appVersion?: string;
 
@@ -76,6 +80,16 @@ export type Metadata = {
    * Username of the initiating user
    */
   username?: string;
+
+  /**
+   * Android version code
+   */
+  versionCode?: number;
+
+  /**
+   * iOS build number
+   */
+  buildNumber?: string;
 };
 
 export const MetadataSchema = Joi.object({
@@ -92,4 +106,6 @@ export const MetadataSchema = Joi.object({
   buildProfile: Joi.string(),
   gitCommitHash: Joi.string().length(40).hex(),
   username: Joi.string(),
+  versionCode: Joi.number(),
+  buildNumber: Joi.string(),
 });


### PR DESCRIPTION
# Why

@jonsamp asked to add Android version code and iOS build number to build metadata.

# How

- I added those two keys to the metadata object.
- I also updated the description for `appVersion`.

# Test Plan

Updated test cases.