### PR TITLE
build metadata: use single field (appBuildVersion) instead of versionCode and buildNumber

### DIFF
--- a/packages/eas-build-job/src/__tests__/metadata.test.ts
+++ b/packages/eas-build-job/src/__tests__/metadata.test.ts
@@ -5,6 +5,7 @@ describe('MetadataSchema', () => {
     const metadata = {
       appName: 'testapp',
       appVersion: '1.0.0',
+      appBuildVersion: '123',
       cliVersion: '1.2.3',
       buildProfile: 'release',
       credentialsSource: 'remote',
@@ -13,8 +14,6 @@ describe('MetadataSchema', () => {
       trackingContext: {},
       workflow: 'generic',
       username: 'notdominik',
-      versionCode: 123,
-      buildNumber: '123',
     };
     const { value, error } = MetadataSchema.validate(metadata, {
       stripUnknown: true,
@@ -28,6 +27,7 @@ describe('MetadataSchema', () => {
     const metadata = {
       appName: 'testapp',
       appVersion: '1.0.0',
+      appBuildVersion: '123',
       cliVersion: '1.2.3',
       buildProfile: 'release',
       credentialsSource: 'blah',
@@ -36,8 +36,6 @@ describe('MetadataSchema', () => {
       trackingContext: {},
       workflow: 'generic',
       username: 'notdominik',
-      versionCode: 123,
-      buildNumber: '123',
     };
     const { error } = MetadataSchema.validate(metadata, {
       stripUnknown: true,

--- a/packages/eas-build-job/src/metadata.ts
+++ b/packages/eas-build-job/src/metadata.ts
@@ -19,6 +19,13 @@ export type Metadata = {
   appVersion?: string;
 
   /**
+   * Application build version:
+   * - Android: version code
+   * - iOS: build number
+   */
+  appBuildVersion?: string;
+
+  /**
    * EAS CLI version
    */
   cliVersion?: string;
@@ -80,21 +87,12 @@ export type Metadata = {
    * Username of the initiating user
    */
   username?: string;
-
-  /**
-   * Android version code
-   */
-  versionCode?: number;
-
-  /**
-   * iOS build number
-   */
-  buildNumber?: string;
 };
 
 export const MetadataSchema = Joi.object({
   trackingContext: Joi.object().pattern(Joi.string(), [Joi.string(), Joi.number()]).required(),
   appVersion: Joi.string(),
+  appBuildVersion: Joi.string(),
   cliVersion: Joi.string(),
   workflow: Joi.string().valid('generic', 'managed'),
   distribution: Joi.string().valid('store', 'internal', 'simulator'),
@@ -106,6 +104,4 @@ export const MetadataSchema = Joi.object({
   buildProfile: Joi.string(),
   gitCommitHash: Joi.string().length(40).hex(),
   username: Joi.string(),
-  versionCode: Joi.number(),
-  buildNumber: Joi.string(),
 });


### PR DESCRIPTION
# Why

https://github.com/expo/universe/pull/7597#pullrequestreview-663472594

# How

I merged `versionCode` and `buildNumber` to single field - `appBuildVersion`.

# Test Plan

Updated unit tests.