### PR TITLE
Use expo run formatter/logger

### DIFF
--- a/packages/build-tools/package.json
+++ b/packages/build-tools/package.json
@@ -28,7 +28,7 @@
     "@expo/plist": "^0.0.11",
     "@expo/template-file": "0.1.19",
     "@expo/turtle-spawn": "0.0.21",
-    "@expo/xcpretty": "^2.0.1",
+    "@expo/xcpretty": "^3.0.0",
     "fast-glob": "^3.2.5",
     "find-yarn-workspace-root": "^2.0.0",
     "fs-extra": "^9.0.0",

--- a/packages/build-tools/src/ios/xcpretty.ts
+++ b/packages/build-tools/src/ios/xcpretty.ts
@@ -8,7 +8,6 @@ import fg from 'fast-glob';
 
 const CHECK_FILE_INTERVAL_MS = 1000;
 
-
 export class XcodeBuildLogger {
   private loggerError?: Error;
   private flushing: boolean = false;
@@ -46,8 +45,8 @@ export class XcodeBuildLogger {
 
   private async startBuildLogger(logsPath: string): Promise<void> {
     try {
-      const formatter = ExpoRunFormatter.create(this.projectRoot, { 
-        isDebug: false  
+      const formatter = ExpoRunFormatter.create(this.projectRoot, {
+        isDebug: false,
         // TODO: Can provide xcode project name for better parsing
       });
       this.logReaderPromise = spawnAsync('tail', ['-n', '+0', '-f', logsPath], { stdio: 'pipe' });

--- a/packages/build-tools/src/ios/xcpretty.ts
+++ b/packages/build-tools/src/ios/xcpretty.ts
@@ -2,21 +2,12 @@ import assert from 'assert';
 import path from 'path';
 
 import { bunyan } from '@expo/logger';
-import { Formatter } from '@expo/xcpretty';
+import { ExpoRunFormatter } from '@expo/xcpretty';
 import spawnAsync, { SpawnPromise, SpawnResult } from '@expo/spawn-async';
 import fg from 'fast-glob';
 
 const CHECK_FILE_INTERVAL_MS = 1000;
 
-class CustomFormatter extends Formatter {
-  public shouldShowCompileWarning(
-    filePath: string,
-    _lineNumber?: string,
-    _columnNumber?: string
-  ): boolean {
-    return !filePath.match(/node_modules/) && !filePath.match(/\/ios\/Pods\//);
-  }
-}
 
 export class XcodeBuildLogger {
   private loggerError?: Error;
@@ -55,7 +46,10 @@ export class XcodeBuildLogger {
 
   private async startBuildLogger(logsPath: string): Promise<void> {
     try {
-      const formatter = new CustomFormatter({ projectRoot: this.projectRoot });
+      const formatter = ExpoRunFormatter.create(this.projectRoot, { 
+        isDebug: false  
+        // TODO: Can provide xcode project name for better parsing
+      });
       this.logReaderPromise = spawnAsync('tail', ['-n', '+0', '-f', logsPath], { stdio: 'pipe' });
       assert(this.logReaderPromise.child.stdout, 'stdout is not available');
       this.logReaderPromise.child.stdout.on('data', (data: string) => {
@@ -65,6 +59,8 @@ export class XcodeBuildLogger {
         }
       });
       await this.logReaderPromise;
+
+      this.logger.info(formatter.getBuildSummary());
     } catch (err) {
       if (!this.flushing) {
         this.loggerError = err;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1478,7 +1478,17 @@
     workbox-webpack-plugin "^3.6.3"
     worker-loader "^2.0.0"
 
-"@expo/xcpretty@^2.0.1", "@expo/xcpretty@~2.0.1":
+"@expo/xcpretty@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@expo/xcpretty/-/xcpretty-3.0.0.tgz#d019ca42fe810f4379c12299f7a625b7cf8e8312"
+  integrity sha512-SqU9EZFEWlCl0Et5XWQtATO+HPhfbbgiS+mZDYTnjDJoSgJNcObyO+gEoQl0yYYXeZF+j13J5mXs/mRXwynyGg==
+  dependencies:
+    "@babel/code-frame" "7.10.4"
+    chalk "^4.1.0"
+    find-up "^5.0.0"
+    js-yaml "^4.1.0"
+
+"@expo/xcpretty@~2.0.1":
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@expo/xcpretty/-/xcpretty-2.0.1.tgz#2c912166ca50a88f710cfe3b6b441144f5df14a2"
   integrity sha512-fyQbzvZpLiKpx68QDzeLlL1AtFhhEW35dqxIqb4QQ6e3iofu57NdWBQTmIAQzDOPcNNXUR9SFncu3M4iyWwQ7Q==
@@ -3869,6 +3879,11 @@ argparse@^1.0.7:
   integrity sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==
   dependencies:
     sprintf-js "~1.0.2"
+
+argparse@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
+  integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
 
 arr-diff@^4.0.0:
   version "4.0.0"
@@ -9452,6 +9467,13 @@ js-yaml@^3.13.1:
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
+
+js-yaml@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.0.tgz#c1fb65f8f5017901cdd2c951864ba18458a10602"
+  integrity sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==
+  dependencies:
+    argparse "^2.0.1"
 
 jsbn@~0.1.0:
   version "0.1.1"


### PR DESCRIPTION
# Why

Split the `expo run:ios` formatter into `@expo/xcpretty` so we can properly format metro build errors and other optimizations.

- https://github.com/expo/expo-cli/pull/3538
- https://github.com/expo/third-party/pull/49
- Fixes https://exponent-internal.slack.com/archives/C02123T524U/p1622334291038200

Locally:

## Before

<img width="1691" alt="Screen Shot 2021-06-01 at 3 51 08 PM" src="https://user-images.githubusercontent.com/9664363/120400927-7d099e80-c304-11eb-966a-df5ecedc65bf.png">

## After

<img width="1691" alt="Screen Shot 2021-06-01 at 3 51 05 PM" src="https://user-images.githubusercontent.com/9664363/120400931-7f6bf880-c304-11eb-94db-4d80a3612da8.png">
