### PR TITLE
[ENG-1279][build-tools] fix setting provisioning profile for build config other than Release

### DIFF
--- a/packages/build-tools/src/builders/iosGeneric.ts
+++ b/packages/build-tools/src/builders/iosGeneric.ts
@@ -34,7 +34,10 @@ export default async function iosGenericBuilder(
     });
     if (credentials) {
       await ctx.runBuildPhase(BuildPhase.CONFIGURE_XCODE_PROJECT, async () => {
-        await configureXcodeProject(ctx, credentials);
+        await configureXcodeProject(ctx, {
+          credentials,
+          buildConfiguration: ctx.job.buildConfiguration,
+        });
       });
     }
 

--- a/packages/build-tools/src/builders/iosManaged.ts
+++ b/packages/build-tools/src/builders/iosManaged.ts
@@ -39,9 +39,11 @@ export default async function iosManagedBuilder(
     const credentials = await ctx.runBuildPhase(BuildPhase.PREPARE_CREDENTIALS, async () => {
       return await credentialsManager.prepare();
     });
+    const buildConfiguration =
+      ctx.job.buildType === Ios.ManagedBuildType.DEVELOPMENT_CLIENT ? 'Debug' : 'Release';
     if (credentials) {
       await ctx.runBuildPhase(BuildPhase.CONFIGURE_XCODE_PROJECT, async () => {
-        await configureXcodeProject(ctx, credentials);
+        await configureXcodeProject(ctx, { credentials, buildConfiguration });
       });
     }
 
@@ -53,8 +55,7 @@ export default async function iosManagedBuilder(
       await runFastlaneGym(ctx, {
         credentials,
         scheme: resolveScheme(ctx),
-        buildConfiguration:
-          ctx.job.buildType === Ios.ManagedBuildType.DEVELOPMENT_CLIENT ? 'Debug' : 'Release',
+        buildConfiguration,
       });
     });
 

--- a/packages/build-tools/src/ios/configure.ts
+++ b/packages/build-tools/src/ios/configure.ts
@@ -7,7 +7,13 @@ import { Credentials } from './credentials/manager';
 
 async function configureXcodeProject<TJob extends Ios.Job>(
   ctx: BuildContext<TJob>,
-  credentials: Credentials
+  {
+    credentials,
+    buildConfiguration,
+  }: {
+    credentials: Credentials;
+    buildConfiguration?: string;
+  }
 ): Promise<void> {
   ctx.logger.info('Configuring Xcode project');
   const targetNames = Object.keys(credentials.targetProvisioningProfiles);
@@ -22,6 +28,7 @@ async function configureXcodeProject<TJob extends Ios.Job>(
         targetName,
         profileName: profile.name,
         appleTeamId: profile.teamId,
+        buildConfiguration,
       }
     );
   }


### PR DESCRIPTION
# Why

Fixes https://linear.app/expo/issue/ENG-1279/ios-buildtype-development-client-aka-debug-builds-provisioning-profile

In https://github.com/expo/expo-cli/commit/469200aad32dda02c9287e3e27d86c5fb8ea8e8e#diff-72d30ed76162667f0c9856f147538dba4ae18e1b65ff05472bfe13a7fdd0e10eR26 I made `setProvisioningProfileForPbxproj` set the provisioning profile only for one specific build configuration. It turns out I forgot to pass the value to the function.

# How

I passed the appropriate `buildConfiguration` to `setProvisioningProfileForPbxproj` and updated the iOS generic and managed builders.

# Test Plan

I'll follow the repro steps on staging.