### PR TITLE
add APPLE_TEAM_ID env to prebuild phase

### DIFF
--- a/packages/build-tools/src/managed/EjectProvider.ts
+++ b/packages/build-tools/src/managed/EjectProvider.ts
@@ -2,8 +2,10 @@ import { Job } from '@expo/eas-build-job';
 
 import { BuildContext } from '../context';
 
-interface EjectProvider<TJob extends Job> {
-  runEject(ctx: BuildContext<TJob>): Promise<void>;
+export interface EjectOptions {
+  extraEnvs?: Record<string, string>;
 }
 
-export { EjectProvider };
+export interface EjectProvider<TJob extends Job> {
+  runEject(ctx: BuildContext<TJob>, options?: EjectOptions): Promise<void>;
+}

--- a/packages/build-tools/src/managed/NpxExpoCliEject.ts
+++ b/packages/build-tools/src/managed/NpxExpoCliEject.ts
@@ -6,18 +6,21 @@ import fs from 'fs-extra';
 
 import { BuildContext } from '../context';
 
-import { EjectProvider } from './EjectProvider';
+import { EjectProvider, EjectOptions } from './EjectProvider';
 
 type ManagedJob = Android.ManagedJob | Ios.ManagedJob;
 
 class NpxExpoCliEjectProvider implements EjectProvider<ManagedJob> {
-  async runEject(ctx: BuildContext<ManagedJob>): Promise<void> {
+  async runEject(ctx: BuildContext<ManagedJob>, options?: EjectOptions): Promise<void> {
     const { logger, job } = ctx;
 
     const spawnOptions = {
       cwd: ctx.buildDirectory,
       logger,
-      env: ctx.env,
+      env: {
+        ...options?.extraEnvs,
+        ...ctx.env,
+      },
     };
 
     await fs.remove(path.join(ctx.reactNativeProjectDirectory, 'android'));


### PR DESCRIPTION
# Why

https://linear.app/expo/issue/ENG-1191/automatically-populate-apple-team-id-env-var-in-eas-build-jobs

# How

move credentials prepare phase at the begging
pass teamId if available to the rebuild phase

# Test Plan

TODO
