### PR TITLE
Allow Metadata.trackingContext to include `boolean` fields

### DIFF
--- a/packages/eas-build-job/src/metadata.ts
+++ b/packages/eas-build-job/src/metadata.ts
@@ -7,7 +7,7 @@ export type Metadata = {
    * Tracking context
    * It's used to track build process across different Expo services and tools.
    */
-  trackingContext: Record<string, string | number>;
+  trackingContext: Record<string, string | number | boolean>;
 
   /**
    * Application version:


### PR DESCRIPTION
# Why

Used in https://github.com/expo/eas-cli/pull/454.

# How

Added `boolean` to the union of types in `trackingContext`.

# Test Plan

TypeScript should compile without errors.