### PR TITLE
unify detecting native code in cli and on worker

### DIFF
--- a/packages/build-tools/src/builders/android.ts
+++ b/packages/build-tools/src/builders/android.ts
@@ -1,6 +1,5 @@
 import { AndroidConfig } from '@expo/config-plugins';
-import { Android, BuildPhase } from '@expo/eas-build-job';
-import fs from 'fs-extra';
+import { Android, BuildPhase, Workflow } from '@expo/eas-build-job';
 
 import { BuildContext } from '../context';
 import { configureExpoUpdatesIfInstalledAsync } from '../utils/expoUpdates';
@@ -12,7 +11,7 @@ import { restoreCredentials } from '../android/credentials';
 
 export default async function androidBuilder(ctx: BuildContext<Android.Job>): Promise<string[]> {
   await setup(ctx);
-  const hasNativeCode = await hasNativeCodeAsync(ctx.reactNativeProjectDirectory);
+  const hasNativeCode = ctx.job.type === Workflow.GENERIC;
 
   if (hasNativeCode) {
     await ctx.runBuildPhase(BuildPhase.FIX_GRADLEW, async () => {
@@ -89,16 +88,4 @@ function resolveGradleCommand(job: Android.Job): string {
 async function ejectProject(ctx: BuildContext<Android.Job>): Promise<void> {
   await ctx.ejectProvider.runEject(ctx);
   await AndroidConfig.EasBuild.configureEasBuildAsync(ctx.reactNativeProjectDirectory);
-}
-
-// TODO move to config-plugins
-async function hasNativeCodeAsync(reactNativeProjectDirectory: string): Promise<boolean> {
-  try {
-    const androidManifestPath = await AndroidConfig.Paths.getAndroidManifestAsync(
-      reactNativeProjectDirectory
-    );
-    return await fs.pathExists(androidManifestPath);
-  } catch {
-    return false;
-  }
 }

--- a/packages/build-tools/src/builders/ios.ts
+++ b/packages/build-tools/src/builders/ios.ts
@@ -1,8 +1,7 @@
 import assert from 'assert';
 
-import fs from 'fs-extra';
 import { IOSConfig } from '@expo/config-plugins';
-import { BuildPhase, Ios } from '@expo/eas-build-job';
+import { BuildPhase, Ios, Workflow } from '@expo/eas-build-job';
 
 import { BuildContext } from '../context';
 import { configureExpoUpdatesIfInstalledAsync } from '../utils/expoUpdates';
@@ -16,7 +15,7 @@ import { installPods } from '../ios/pod';
 
 export default async function iosBuilder(ctx: BuildContext<Ios.Job>): Promise<string[]> {
   await setup(ctx);
-  const hasNativeCode = await hasNativeCodeAsync(ctx.reactNativeProjectDirectory);
+  const hasNativeCode = ctx.job.type === Workflow.GENERIC;
 
   const credentialsManager = new CredentialsManager(ctx);
   try {
@@ -117,14 +116,4 @@ function resolveBuildConfiguration(ctx: BuildContext<Ios.Job>): string {
     return 'Debug';
   }
   return 'Release';
-}
-
-// TODO move to config-plugins
-export async function hasNativeCodeAsync(projectRoot: string): Promise<boolean> {
-  try {
-    const pbxprojPath = IOSConfig.Paths.getXcodeProjectPath(projectRoot);
-    return await fs.pathExists(pbxprojPath);
-  } catch {
-    return false;
-  }
 }


### PR DESCRIPTION
# Why

Field `type` in job object becomes unnecessary after both managed and bare projects both support the same config options. It can be repurposed to define whether or not project has native code

# How

decide based on type field whether project has native code

# Test Plan


