### PR TITLE
[eas-build-job] add iosEnterpriseProvisioning to metadata

### DIFF
--- a/packages/eas-build-job/src/__tests__/metadata.test.ts
+++ b/packages/eas-build-job/src/__tests__/metadata.test.ts
@@ -15,6 +15,7 @@ describe('MetadataSchema', () => {
       trackingContext: {},
       workflow: 'generic',
       username: 'notdominik',
+      iosEnterpriseProvisioning: 'adhoc',
     };
     const { value, error } = MetadataSchema.validate(metadata, {
       stripUnknown: true,

--- a/packages/eas-build-job/src/metadata.ts
+++ b/packages/eas-build-job/src/metadata.ts
@@ -98,6 +98,12 @@ export type Metadata = {
    * Username of the initiating user
    */
   username?: string;
+
+  /**
+   * Indicates what type of an enterprise provisioning profile was used to build the app.
+   * It's either adhoc or universal
+   */
+  iosEnterpriseProvisioning?: 'adhoc' | 'universal';
 };
 
 export const MetadataSchema = Joi.object({
@@ -119,4 +125,5 @@ export const MetadataSchema = Joi.object({
   buildProfile: Joi.string(),
   gitCommitHash: Joi.string().length(40).hex(),
   username: Joi.string(),
+  iosEnterpriseProvisioning: Joi.string().valid('adhoc', 'universal'),
 });


### PR DESCRIPTION
# Why

For https://linear.app/expo/issue/ENG-1292/account-for-universal-enterprise-distribution-in-install-modal

# How

Added `iosEnterpriseProvisioning` to build metadata

# Test Plan

Unit test