### PR TITLE
validate metadata using joi bundled with eas-build-job

### DIFF
--- a/packages/eas-build-job/src/index.ts
+++ b/packages/eas-build-job/src/index.ts
@@ -1,7 +1,7 @@
 export * as Android from './android';
 export * as Ios from './ios';
 export { ArchiveSourceType, ArchiveSource, Env, Workflow, Platform, Cache } from './common';
-export { Job, JobSchema, sanitizeJob } from './job';
-export { Metadata, MetadataSchema } from './metadata';
+export { Job, sanitizeJob } from './job';
+export { Metadata, sanitizeMetadata } from './metadata';
 export * from './logs';
 export * as errors from './errors';

--- a/packages/eas-build-job/src/job.ts
+++ b/packages/eas-build-job/src/job.ts
@@ -4,9 +4,9 @@ import { Platform } from './common';
 import * as Android from './android';
 import * as Ios from './ios';
 
-type Job = Android.Job | Ios.Job;
+export type Job = Android.Job | Ios.Job;
 
-const JobSchema = Joi.object<Job>({
+export const JobSchema = Joi.object<Job>({
   platform: Joi.string()
     .valid(...Object.values(Platform))
     .required(),
@@ -14,7 +14,7 @@ const JobSchema = Joi.object<Job>({
   .when(Joi.object({ platform: Platform.ANDROID }).unknown(), { then: Android.JobSchema })
   .when(Joi.object({ platform: Platform.IOS }).unknown(), { then: Ios.JobSchema });
 
-function sanitizeJob(job: object): Job {
+export function sanitizeJob(job: object): Job {
   const { value, error } = JobSchema.validate(job, {
     stripUnknown: true,
     convert: true,
@@ -26,5 +26,3 @@ function sanitizeJob(job: object): Job {
     return value;
   }
 }
-
-export { Job, JobSchema, sanitizeJob };

--- a/packages/eas-build-job/src/metadata.ts
+++ b/packages/eas-build-job/src/metadata.ts
@@ -127,3 +127,16 @@ export const MetadataSchema = Joi.object({
   username: Joi.string(),
   iosEnterpriseProvisioning: Joi.string().valid('adhoc', 'universal'),
 });
+
+export function sanitizeMetadata(metadata: object): Metadata {
+  const { value, error } = MetadataSchema.validate(metadata, {
+    stripUnknown: true,
+    convert: true,
+    abortEarly: false,
+  });
+  if (error) {
+    throw error;
+  } else {
+    return value;
+  }
+}


### PR DESCRIPTION
# Why

do not export schemas, if they are used with the wrong version of joi then it can fail in unexpected ways

# How

- remove exports
- add validator function

# Test Plan


