### PR TITLE
[build-tools] handle exit calls in app.config.js

### DIFF
--- a/packages/build-tools/src/context.ts
+++ b/packages/build-tools/src/context.ts
@@ -1,13 +1,14 @@
 import path from 'path';
 
 import { BuildPhase, Job, LogMarker, Env, errors, Metadata } from '@expo/eas-build-job';
-import { getConfig, ExpoConfig } from '@expo/config';
+import { ExpoConfig } from '@expo/config';
 import { bunyan } from '@expo/logger';
 
 import { PackageManager, resolvePackageManager } from './utils/packageManager';
 import { detectUserError } from './utils/detectUserError';
 import { EjectProvider } from './managed/EjectProvider';
 import { NpxExpoCliEjectProvider } from './managed/NpxExpoCliEject';
+import { readAppConfig } from './utils/appConfig';
 
 export interface CacheManager {
   saveCache(ctx: BuildContext<Job>): Promise<void>;
@@ -68,19 +69,7 @@ export class BuildContext<TJob extends Job> {
   }
   public get appConfig(): ExpoConfig {
     if (!this._appConfig) {
-      const originalProcessEnv: NodeJS.ProcessEnv = { ...process.env };
-      try {
-        for (const [key, value] of Object.entries(this.env)) {
-          process.env[key] = value;
-        }
-        const { exp } = getConfig(this.reactNativeProjectDirectory, {
-          skipSDKVersionRequirement: true,
-          isPublicConfig: true,
-        });
-        this._appConfig = exp;
-      } finally {
-        process.env = originalProcessEnv;
-      }
+      this._appConfig = readAppConfig(this.reactNativeProjectDirectory, this.env, this.logger).exp;
     }
     return this._appConfig;
   }

--- a/packages/build-tools/src/utils/appConfig.ts
+++ b/packages/build-tools/src/utils/appConfig.ts
@@ -1,0 +1,42 @@
+import { getConfig, ProjectConfig } from '@expo/config';
+import { Env } from '@expo/eas-build-job';
+import { bunyan, LoggerLevel } from '@expo/logger';
+
+export function readAppConfig(projectDir: string, env: Env, logger: bunyan): ProjectConfig {
+  const originalProcessEnv: NodeJS.ProcessEnv = process.env;
+  const originalProcessExit = process.exit;
+  const originalStdoutWrite = process.stdout.write;
+  const originalStderrWrite = process.stderr.write;
+
+  const stdoutStore: { text: string; level: LoggerLevel }[] = [];
+  try {
+    process.env = { ...env };
+    process.exit = () => {
+      throw new Error('Failed to evaluate app config file');
+    };
+    process.stdout.write = function (...args: any) {
+      stdoutStore.push({ text: String(args[0]), level: LoggerLevel.INFO });
+      return originalStdoutWrite.apply(process.stdout, args);
+    };
+    process.stderr.write = function (...args: any) {
+      stdoutStore.push({ text: String(args[0]), level: LoggerLevel.ERROR });
+      return originalStderrWrite.apply(process.stderr, args);
+    };
+    return getConfig(projectDir, {
+      skipSDKVersionRequirement: true,
+      isPublicConfig: true,
+    });
+  } catch (err) {
+    process.stdout.write = originalStdoutWrite;
+    process.stderr.write = originalStderrWrite;
+    stdoutStore.forEach(({ text, level }) => {
+      logger[level](text.trim());
+    });
+    throw err;
+  } finally {
+    process.env = originalProcessEnv;
+    process.exit = originalProcessExit;
+    process.stdout.write = originalStdoutWrite;
+    process.stderr.write = originalStderrWrite;
+  }
+}


### PR DESCRIPTION
# Why

process.exit called in app config crashes entire build process

# How

- replace process.exit with throw exception when evaluating app.config
- read stdout and stderr during config evaluation and print it in case of errors

# Test Plan

tested with `eas build --local` and local build with turtle
