### PR TITLE
[build-tools] create .npmrc if NPM_TOKEN is set

### DIFF
--- a/packages/build-tools/src/utils/npmrc.ts
+++ b/packages/build-tools/src/utils/npmrc.ts
@@ -1,0 +1,21 @@
+import path from 'path';
+
+import { Job } from '@expo/eas-build-job';
+import fs from 'fs-extra';
+
+import { BuildContext } from '../context';
+
+const NPMRC_TEMPLATE_PATH = path.join(__dirname, '../../templates/npmrc');
+
+export async function createNpmrcIfNotExistsAsync(ctx: BuildContext<Job>): Promise<void> {
+  ctx.logger.info('We detected that you set the NPM_TOKEN environment variable');
+  const projectNpmrcPath = path.join(ctx.buildDirectory, '.npmrc');
+  if (await fs.pathExists(projectNpmrcPath)) {
+    ctx.logger.info('.npmrc already exists in your project directory, skipping generation');
+  } else {
+    const npmrcContents = await fs.readFile(NPMRC_TEMPLATE_PATH, 'utf8');
+    ctx.logger.info('Creating .npmrc in your project directory with the following contents:');
+    ctx.logger.info(npmrcContents);
+    await fs.copy(NPMRC_TEMPLATE_PATH, projectNpmrcPath);
+  }
+}

--- a/packages/build-tools/src/utils/project.ts
+++ b/packages/build-tools/src/utils/project.ts
@@ -8,11 +8,15 @@ import fs from 'fs-extra';
 import { BuildContext } from '../context';
 
 import { Hook, runHookIfPresent } from './hooks';
+import { createNpmrcIfNotExistsAsync } from './npmrc';
 import { findPackagerRootDir } from './packageManager';
 
 export async function setup<TJob extends Job>(ctx: BuildContext<TJob>): Promise<void> {
   await ctx.runBuildPhase(BuildPhase.PREPARE_PROJECT, async () => {
     await downloadAndUnpackProject(ctx);
+    if (ctx.env.NPM_TOKEN) {
+      await createNpmrcIfNotExistsAsync(ctx);
+    }
   });
 
   await ctx.runBuildPhase(BuildPhase.PRE_INSTALL_HOOK, async () => {
@@ -57,9 +61,7 @@ async function installDependencies<TJob extends Job>(ctx: BuildContext<TJob>): P
       ctx.buildDirectory,
       ctx.reactNativeProjectDirectory
     );
-    ctx.logger.info(
-      `We have detected that '${relativeReactNativeProjectDirectory}' is a workspace`
-    );
+    ctx.logger.info(`We detected that '${relativeReactNativeProjectDirectory}' is a workspace`);
   }
 
   const relativePackagerRunDir = path.relative(ctx.buildDirectory, packagerRunDir);

--- a/packages/build-tools/templates/npmrc
+++ b/packages/build-tools/templates/npmrc
@@ -1,0 +1,2 @@
+//registry.npmjs.org/:_authToken=${NPM_TOKEN}
+registry=https://registry.npmjs.org/


### PR DESCRIPTION
# Why

https://linear.app/expo/issue/ENG-2086/create-npmrc-and-set-registry-when-npm-token-is-present

# How

Detect if `NPM_TOKEN` is set and create `.npmrc` in the project root dir if it does not exist.

# Test Plan

Tested locally by building a project with a private package published to npm.