### PR TITLE
unify eas.json and build job format

### DIFF
--- a/packages/build-tools/src/builders/android.ts
+++ b/packages/build-tools/src/builders/android.ts
@@ -71,19 +71,14 @@ export default async function androidBuilder(ctx: BuildContext<Android.Job>): Pr
 function resolveGradleCommand(job: Android.Job): string {
   if (job.gradleCommand) {
     return job.gradleCommand;
-  }
-  if (!job.buildType) {
+  } else if (job.developmentClient) {
+    return ':app:assembleDebug';
+  } else if (!job.buildType) {
     return ':app:bundleRelease';
-  }
-  switch (job.buildType) {
-    case Android.BuildType.APK:
-      return ':app:assembleRelease';
-    case Android.BuildType.APP_BUNDLE:
-      return ':app:bundleRelease';
-    case Android.BuildType.DEVELOPMENT_CLIENT:
-      return ':app:assembleDebug';
-    default:
-      throw new Error(`unknown artifact type ${job.buildType}`);
+  } else if (job.buildType === Android.BuildType.APK) {
+    return ':app:assembleRelease';
+  } else {
+    return ':app:bundleRelease';
   }
 }
 

--- a/packages/build-tools/src/builders/ios.ts
+++ b/packages/build-tools/src/builders/ios.ts
@@ -103,19 +103,19 @@ function resolveScheme(ctx: BuildContext<Ios.Job>): string {
 function resolveArtifactPath(ctx: BuildContext<Ios.Job>): string {
   if (ctx.job.artifactPath) {
     return ctx.job.artifactPath;
-  }
-  if (ctx.job.distribution === 'simulator') {
+  } else if (ctx.job.simulator) {
     return 'ios/build/Build/Products/*-iphonesimulator/*.app';
+  } else {
+    return 'ios/build/*.ipa';
   }
-  return 'ios/build/*.ipa';
 }
 
 function resolveBuildConfiguration(ctx: BuildContext<Ios.Job>): string {
   if (ctx.job.buildConfiguration) {
     return ctx.job.buildConfiguration;
-  }
-  if (ctx.job.buildType === Ios.BuildType.DEVELOPMENT_CLIENT) {
+  } else if (ctx.job.developmentClient) {
     return 'Debug';
+  } else {
+    return 'Release';
   }
-  return 'Release';
 }

--- a/packages/build-tools/src/ios/credentials/manager.ts
+++ b/packages/build-tools/src/ios/credentials/manager.ts
@@ -32,7 +32,7 @@ export default class IosCredentialsManager<TJob extends Ios.Job> {
   constructor(private readonly ctx: BuildContext<TJob>) {}
 
   public async prepare(): Promise<Credentials | null> {
-    if (this.ctx.job.distribution === 'simulator') {
+    if (this.ctx.job.simulator) {
       return null;
     }
 

--- a/packages/build-tools/src/ios/fastlane.ts
+++ b/packages/build-tools/src/ios/fastlane.ts
@@ -60,7 +60,7 @@ async function ensureGymfileExists<TJob extends Ios.Job>(
   }
 
   ctx.logger.info('Creating Gymfile');
-  if (ctx.job.distribution === 'simulator') {
+  if (ctx.job.simulator) {
     await createGymfileForSimulatorBuild({
       outputFile: gymfilePath,
       scheme,

--- a/packages/eas-build-job/src/__tests__/ios.test.ts
+++ b/packages/eas-build-job/src/__tests__/ios.test.ts
@@ -32,7 +32,6 @@ describe('Ios.JobSchema', () => {
         url: 'http://localhost:3000',
       },
       projectRootDirectory: '.',
-      distribution: 'store',
       scheme: 'testapp',
       buildConfiguration: 'Release',
       artifactPath: 'ios/build/*.ipa',
@@ -66,7 +65,6 @@ describe('Ios.JobSchema', () => {
         url: 'url',
       },
       projectRootDirectory: '.',
-      distribution: 'store',
       uknownField: 'field',
     };
 
@@ -87,8 +85,6 @@ describe('Ios.JobSchema', () => {
         url: 'http://localhost:3000',
       },
       projectRootDirectory: '.',
-      distribution: 'store',
-      buildType: Ios.BuildType.RELEASE,
       username: 'turtle-tutorial',
       releaseChannel: 'default',
       builderEnvironment: {
@@ -120,7 +116,6 @@ describe('Ios.JobSchema', () => {
         url: 'url',
       },
       projectRootDirectory: 312,
-      distribution: 'store',
       uknownField: 'field',
     };
 
@@ -145,7 +140,6 @@ describe('Ios.JobSchema', () => {
         url: 'http://localhost:3000',
       },
       projectRootDirectory: '.',
-      distribution: 'store',
     };
 
     const { value, error } = Ios.JobSchema.validate(managedJob, joiOptions);
@@ -168,7 +162,6 @@ describe('Ios.JobSchema', () => {
         url: 'http://localhost:3000',
       },
       projectRootDirectory: '.',
-      distribution: 'store',
     };
 
     const { error } = Ios.JobSchema.validate(managedJob, joiOptions);

--- a/packages/eas-build-job/src/android.ts
+++ b/packages/eas-build-job/src/android.ts
@@ -28,7 +28,6 @@ const KeystoreSchema = Joi.object({
 export enum BuildType {
   APK = 'apk',
   APP_BUNDLE = 'app-bundle',
-  DEVELOPMENT_CLIENT = 'development-client',
 }
 
 export const builderBaseImages = [
@@ -76,6 +75,7 @@ export interface Job {
   };
   builderEnvironment?: BuilderEnvironment;
   cache: Cache;
+  developmentClient?: boolean;
 
   // generic
   gradleCommand?: string;
@@ -103,6 +103,7 @@ export const JobSchema = Joi.object({
   }).required(),
   builderEnvironment: BuilderEnvironmentSchema,
   cache: CacheSchema.default(),
+  developmentClient: Joi.boolean(),
 
   gradleCommand: Joi.string(),
   artifactPath: Joi.string(),

--- a/packages/eas-build-job/src/ios.ts
+++ b/packages/eas-build-job/src/ios.ts
@@ -39,11 +39,6 @@ export interface DistributionCertificate {
   password: string;
 }
 
-export enum BuildType {
-  RELEASE = 'release',
-  DEVELOPMENT_CLIENT = 'development-client',
-}
-
 export const builderBaseImages = [
   'default',
   'latest',
@@ -93,19 +88,19 @@ export interface Job {
   updates?: {
     channel?: string;
   };
-  distribution?: DistributionType;
   secrets: {
     buildCredentials?: BuildCredentials;
     environmentSecrets?: Env;
   };
   builderEnvironment?: BuilderEnvironment;
   cache: Cache;
+  developmentClient?: boolean;
+  simulator?: boolean;
 
   scheme?: string;
   buildConfiguration?: string;
   artifactPath?: string;
 
-  buildType?: BuildType;
   username?: string;
 }
 
@@ -120,13 +115,14 @@ export const JobSchema = Joi.object({
   updates: Joi.object({
     channel: Joi.string(),
   }),
-  distribution: Joi.string().valid('store', 'internal', 'simulator'),
   secrets: Joi.object({
     buildCredentials: BuildCredentialsSchema,
     environmentSecrets: EnvSchema,
   }).required(),
   builderEnvironment: BuilderEnvironmentSchema,
   cache: CacheSchema.default(),
+  developmentClient: Joi.boolean(),
+  simulator: Joi.boolean(),
 
   // generic
   scheme: Joi.string(),
@@ -134,6 +130,5 @@ export const JobSchema = Joi.object({
   artifactPath: Joi.string(),
 
   // managed
-  buildType: Joi.string().valid(...Object.values(BuildType)),
   username: Joi.string(),
 }).oxor('releaseChannel', 'updates.channel');


### PR DESCRIPTION
# Why

We (not-that-)recently changed the eas.json format but the API build job object stayed the same.
This PR unifies the eas.json and build job formats. 

# How

Android:
- Deprecate the `DEVELOPMENT_CLIENT` value for `buildType`.
- Add `developmentClient: boolean`.

iOS:
- Drop `buildType`.
- Drop `distribution`.
- Add `developmentClient: boolean`.
- Add `simulator: boolean`.

# Test Plan

None