### PR TITLE
rename developmentClient -> useDevelopmentClient

### DIFF
--- a/packages/build-tools/src/builders/android.ts
+++ b/packages/build-tools/src/builders/android.ts
@@ -71,7 +71,7 @@ export default async function androidBuilder(ctx: BuildContext<Android.Job>): Pr
 function resolveGradleCommand(job: Android.Job): string {
   if (job.gradleCommand) {
     return job.gradleCommand;
-  } else if (job.developmentClient) {
+  } else if (job.useDevelopmentClient) {
     return ':app:assembleDebug';
   } else if (!job.buildType) {
     return ':app:bundleRelease';

--- a/packages/build-tools/src/builders/ios.ts
+++ b/packages/build-tools/src/builders/ios.ts
@@ -113,7 +113,7 @@ function resolveArtifactPath(ctx: BuildContext<Ios.Job>): string {
 function resolveBuildConfiguration(ctx: BuildContext<Ios.Job>): string {
   if (ctx.job.buildConfiguration) {
     return ctx.job.buildConfiguration;
-  } else if (ctx.job.developmentClient) {
+  } else if (ctx.job.useDevelopmentClient) {
     return 'Debug';
   } else {
     return 'Release';

--- a/packages/eas-build-job/src/android.ts
+++ b/packages/eas-build-job/src/android.ts
@@ -75,7 +75,7 @@ export interface Job {
   };
   builderEnvironment?: BuilderEnvironment;
   cache: Cache;
-  developmentClient?: boolean;
+  useDevelopmentClient?: boolean;
 
   // generic
   gradleCommand?: string;
@@ -103,7 +103,7 @@ export const JobSchema = Joi.object({
   }).required(),
   builderEnvironment: BuilderEnvironmentSchema,
   cache: CacheSchema.default(),
-  developmentClient: Joi.boolean(),
+  useDevelopmentClient: Joi.boolean(),
 
   gradleCommand: Joi.string(),
   artifactPath: Joi.string(),

--- a/packages/eas-build-job/src/ios.ts
+++ b/packages/eas-build-job/src/ios.ts
@@ -94,7 +94,7 @@ export interface Job {
   };
   builderEnvironment?: BuilderEnvironment;
   cache: Cache;
-  developmentClient?: boolean;
+  useDevelopmentClient?: boolean;
   simulator?: boolean;
 
   scheme?: string;
@@ -121,7 +121,7 @@ export const JobSchema = Joi.object({
   }).required(),
   builderEnvironment: BuilderEnvironmentSchema,
   cache: CacheSchema.default(),
-  developmentClient: Joi.boolean(),
+  useDevelopmentClient: Joi.boolean(),
   simulator: Joi.boolean(),
 
   // generic


### PR DESCRIPTION
# Why

https://github.com/expo/universe/pull/8322#discussion_r733243031

# How

Rename `developmentClient` to `useDevelopmentClient`.

# Test Plan

None.