### PR TITLE
[build-tools] set iCloudContainerEnvironment in Gymfile when com.apple.developer.icloud-container-environment entitlement is set

### DIFF
--- a/packages/build-tools/src/ios/fastlane.ts
+++ b/packages/build-tools/src/ios/fastlane.ts
@@ -17,14 +17,22 @@ export async function runFastlaneGym<TJob extends Ios.Job>(
     scheme,
     buildConfiguration,
     credentials,
+    entitlements,
   }: {
     scheme: string;
     buildConfiguration?: string;
     credentials: Credentials | null;
+    entitlements: object | null;
   }
 ): Promise<void> {
   const logsDirectory = path.join(ctx.workingdir, 'logs');
-  await ensureGymfileExists(ctx, { scheme, buildConfiguration, credentials, logsDirectory });
+  await ensureGymfileExists(ctx, {
+    scheme,
+    buildConfiguration,
+    credentials,
+    logsDirectory,
+    entitlements,
+  });
   const buildLogger = new XcodeBuildLogger(ctx.logger, ctx.reactNativeProjectDirectory);
   void buildLogger.watchLogFiles(logsDirectory);
   try {
@@ -45,11 +53,13 @@ async function ensureGymfileExists<TJob extends Ios.Job>(
     buildConfiguration,
     credentials,
     logsDirectory,
+    entitlements,
   }: {
     scheme: string;
     buildConfiguration?: string;
     credentials: Credentials | null;
     logsDirectory: string;
+    entitlements: object | null;
   }
 ): Promise<void> {
   const gymfilePath = path.join(ctx.reactNativeProjectDirectory, 'ios/Gymfile');
@@ -78,6 +88,7 @@ async function ensureGymfileExists<TJob extends Ios.Job>(
       outputDirectory: './build',
       clean: false,
       logsDirectory,
+      entitlements: entitlements ?? undefined,
     });
   }
   ctx.logger.info('Gymfile created');

--- a/packages/build-tools/src/ios/gymfile.ts
+++ b/packages/build-tools/src/ios/gymfile.ts
@@ -19,6 +19,7 @@ interface ArchiveBuildOptions {
   outputDirectory: string;
   clean: boolean;
   logsDirectory: string;
+  entitlements?: object;
 }
 
 interface SimulatorBuildOptions {
@@ -36,6 +37,7 @@ export async function createGymfileForArchiveBuild({
   credentials,
   scheme,
   buildConfiguration,
+  entitlements,
   outputDirectory,
   logsDirectory,
 }: ArchiveBuildOptions): Promise<void> {
@@ -48,6 +50,11 @@ export async function createGymfileForArchiveBuild({
       UUID: profile.uuid,
     });
   }
+
+  const ICLOUD_CONTAINER_ENVIRONMENT = (entitlements as Record<
+    string,
+    string | Record<string, string>
+  >)?.['com.apple.developer.icloud-container-environment'] as string | undefined;
 
   await fs.mkdirp(logsDirectory);
   await createGymfile({
@@ -62,6 +69,7 @@ export async function createGymfileForArchiveBuild({
       CLEAN: String(clean),
       LOGS_DIRECTORY: logsDirectory,
       PROFILES,
+      ICLOUD_CONTAINER_ENVIRONMENT,
     },
   });
 }

--- a/packages/build-tools/templates/Gymfile.archive.template
+++ b/packages/build-tools/templates/Gymfile.archive.template
@@ -10,7 +10,9 @@ export_options({
   method: "<%- EXPORT_METHOD %>",
   provisioningProfiles: {<% _.forEach(PROFILES, function(profile) { %>
     "<%- profile.BUNDLE_ID %>" => "<%- profile.UUID %>",<% }); %>
-  }
+  }<% if (ICLOUD_CONTAINER_ENVIRONMENT) { %>,
+  iCloudContainerEnvironment: "<%- ICLOUD_CONTAINER_ENVIRONMENT %>"
+<% } %>
 })
 
 export_xcargs "OTHER_CODE_SIGN_FLAGS=\"--keychain <%- KEYCHAIN_PATH %>\""


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/eas-cli/issues/693

# How

Check the entitlements file and see if `com.apple.developer.icloud-container-environment` is set. If so, add `iCloudContainerEnvironment` to the `export_options` in Gymfile.

# Test Plan

Will test on staging.
