### PR TITLE
[build-tools] set correct cwd when reading app config

### DIFF
--- a/packages/build-tools/src/utils/appConfig.ts
+++ b/packages/build-tools/src/utils/appConfig.ts
@@ -5,6 +5,7 @@ import { bunyan, LoggerLevel } from '@expo/logger';
 export function readAppConfig(projectDir: string, env: Env, logger: bunyan): ProjectConfig {
   const originalProcessEnv: NodeJS.ProcessEnv = process.env;
   const originalProcessExit = process.exit;
+  const originalProcessCwd = process.cwd;
   const originalStdoutWrite = process.stdout.write;
   const originalStderrWrite = process.stderr.write;
 
@@ -14,6 +15,7 @@ export function readAppConfig(projectDir: string, env: Env, logger: bunyan): Pro
     process.exit = () => {
       throw new Error('Failed to evaluate app config file');
     };
+    process.cwd = () => projectDir;
     process.stdout.write = function (...args: any) {
       stdoutStore.push({ text: String(args[0]), level: LoggerLevel.INFO });
       return originalStdoutWrite.apply(process.stdout, args);
@@ -36,6 +38,7 @@ export function readAppConfig(projectDir: string, env: Env, logger: bunyan): Pro
   } finally {
     process.env = originalProcessEnv;
     process.exit = originalProcessExit;
+    process.cwd = originalProcessCwd;
     process.stdout.write = originalStdoutWrite;
     process.stderr.write = originalStderrWrite;
   }


### PR DESCRIPTION
# Why

`process.cwd` returns wrong value when resolving app config.

# How

Override `process.cwd` so it returns the project dir.

# Test Plan

Will test on staging.