### PR TITLE
[build-tools] fix reading entitlements file

### DIFF
--- a/packages/build-tools/src/builders/ios.ts
+++ b/packages/build-tools/src/builders/ios.ts
@@ -106,9 +106,10 @@ function resolveScheme(ctx: BuildContext<Ios.Job>): string {
 
 async function readEntitlementsAsync(ctx: BuildContext<Ios.Job>): Promise<object | null> {
   try {
-    const entitlementsPath = IOSConfig.Entitlements.getEntitlementsPath(
-      ctx.reactNativeProjectDirectory
-    );
+    const entitlementsPath = IOSConfig.Paths.getEntitlementsPath(ctx.reactNativeProjectDirectory);
+    if (!entitlementsPath) {
+      return null;
+    }
     const entitlementsRaw = await fs.readFile(entitlementsPath, 'utf8');
     return plist.parse(entitlementsRaw);
   } catch (err) {


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/eas-cli/issues/793

# How

Use `IOSConfig.Paths.getEntitlementsPath` instead of `IOSConfig.Entitlements.getEntitlementsPath`. The latter has side effects.

# Test Plan

None.