### PR TITLE
auto-detect default android image

### DIFF
--- a/packages/eas-build-job/src/android.ts
+++ b/packages/eas-build-job/src/android.ts
@@ -60,9 +60,7 @@ export interface BuilderEnvironment {
 }
 
 const BuilderEnvironmentSchema = Joi.object({
-  image: Joi.string()
-    .valid(...builderBaseImages)
-    .default('default'),
+  image: Joi.string().valid(...builderBaseImages),
   node: Joi.string(),
   yarn: Joi.string(),
   expoCli: Joi.string(),

--- a/packages/eas-build-job/src/job.ts
+++ b/packages/eas-build-job/src/job.ts
@@ -40,7 +40,7 @@ export function sanitizeJob(
 }
 
 function setAndroidBuilderImage(job: Job, reactNativeVersion?: string): void {
-  if (!(!job.builderEnvironment?.image && reactNativeVersion)) {
+  if (job.builderEnvironment?.image || !reactNativeVersion) {
     return;
   }
 
@@ -57,7 +57,7 @@ function setAndroidBuilderImage(job: Job, reactNativeVersion?: string): void {
 }
 
 function setIosBuilderImageForManagedJob(job: Job, sdkVersion?: string): void {
-  if (!(job.type === Workflow.MANAGED && !job.builderEnvironment?.image && sdkVersion)) {
+  if (job.type !== Workflow.MANAGED || job.builderEnvironment?.image || !sdkVersion) {
     return;
   }
 

--- a/packages/eas-build-job/src/job.ts
+++ b/packages/eas-build-job/src/job.ts
@@ -15,7 +15,10 @@ export const JobSchema = Joi.object<Job>({
   .when(Joi.object({ platform: Platform.ANDROID }).unknown(), { then: Android.JobSchema })
   .when(Joi.object({ platform: Platform.IOS }).unknown(), { then: Ios.JobSchema });
 
-export function sanitizeJob(rawJob: object, { sdkVersion }: { sdkVersion?: string } = {}): Job {
+export function sanitizeJob(
+  rawJob: object,
+  { sdkVersion, reactNativeVersion }: { reactNativeVersion?: string; sdkVersion?: string } = {}
+): Job {
   const { value, error } = JobSchema.validate(rawJob, {
     stripUnknown: true,
     convert: true,
@@ -23,7 +26,11 @@ export function sanitizeJob(rawJob: object, { sdkVersion }: { sdkVersion?: strin
   });
 
   const job: Job = value;
-  setIosBuilderImageForManagedJob(job, sdkVersion);
+  if (job.platform === Platform.IOS) {
+    setIosBuilderImageForManagedJob(job, sdkVersion);
+  } else if (job.platform === Platform.ANDROID) {
+    setAndroidBuilderImage(job, reactNativeVersion);
+  }
 
   if (error) {
     throw error;
@@ -32,15 +39,25 @@ export function sanitizeJob(rawJob: object, { sdkVersion }: { sdkVersion?: strin
   }
 }
 
+function setAndroidBuilderImage(job: Job, reactNativeVersion?: string): void {
+  if (!(!job.builderEnvironment?.image && reactNativeVersion)) {
+    return;
+  }
+
+  const ranges = Object.keys(Android.reactNativeVersionToDefaultBuilderImage);
+  const matchingRange = ranges.find((range) => semver.satisfies(reactNativeVersion, range));
+  if (!matchingRange) {
+    return;
+  }
+  const image = Android.reactNativeVersionToDefaultBuilderImage[matchingRange];
+  job.builderEnvironment = {
+    image,
+    ...job.builderEnvironment,
+  };
+}
+
 function setIosBuilderImageForManagedJob(job: Job, sdkVersion?: string): void {
-  if (
-    !(
-      job.platform === Platform.IOS &&
-      job.type === Workflow.MANAGED &&
-      !job.builderEnvironment?.image &&
-      sdkVersion
-    )
-  ) {
+  if (!(job.type === Workflow.MANAGED && !job.builderEnvironment?.image && sdkVersion)) {
     return;
   }
 

--- a/packages/eas-build-job/src/metadata.ts
+++ b/packages/eas-build-job/src/metadata.ts
@@ -61,6 +61,11 @@ export type Metadata = {
   releaseChannel?: string;
 
   /**
+   * Version of the react-native package used in the project.
+   */
+  reactNativeVersion?: string;
+
+  /**
    * Channel (for Expo Updates when it is configured for for use with EAS)
    * It's undefined if the expo-updates package is not configured for use with EAS.
    */


### PR DESCRIPTION
# Why

In previous PR I didn't realize that image detection is part of eas-build-job package

# How



# Test Plan

will test after publish
