### PR TITLE
support partial builds

### DIFF
--- a/packages/build-tools/src/builders/android.ts
+++ b/packages/build-tools/src/builders/android.ts
@@ -1,7 +1,7 @@
 import { AndroidConfig } from '@expo/config-plugins';
 import { Android, BuildPhase, Workflow } from '@expo/eas-build-job';
 
-import { BuildContext } from '../context';
+import { BuildContext, SkipNativeBuildError } from '../context';
 import { configureExpoUpdatesIfInstalledAsync } from '../utils/expoUpdates';
 import { runGradleCommand, ensureLFLineEndingsInGradlewScript } from '../android/gradle';
 import { setup } from '../utils/project';
@@ -40,6 +40,9 @@ export default async function androidBuilder(ctx: BuildContext<Android.Job>): Pr
     await configureExpoUpdatesIfInstalledAsync(ctx);
   });
 
+  if (ctx.skipNativeBuild) {
+    throw new SkipNativeBuildError('Skipping Gradle build');
+  }
   await ctx.runBuildPhase(BuildPhase.RUN_GRADLEW, async () => {
     const gradleCommand = resolveGradleCommand(ctx.job);
     await runGradleCommand(ctx, gradleCommand);

--- a/packages/build-tools/src/context.ts
+++ b/packages/build-tools/src/context.ts
@@ -27,8 +27,11 @@ export interface BuildContextOptions<TJob extends Job> {
   env: Env;
   cacheManager?: CacheManager;
   ejectProvider?: EjectProvider<TJob>;
+  skipNativeBuild?: boolean;
   metadata?: Metadata;
 }
+
+export class SkipNativeBuildError extends Error {}
 
 export class BuildContext<TJob extends Job> {
   public readonly workingdir: string;
@@ -38,6 +41,7 @@ export class BuildContext<TJob extends Job> {
   public readonly cacheManager?: CacheManager;
   public readonly ejectProvider: EjectProvider<TJob>;
   public readonly metadata?: Metadata;
+  public readonly skipNativeBuild?: boolean;
 
   private readonly defaultLogger: bunyan;
   private buildPhase?: BuildPhase;
@@ -51,6 +55,7 @@ export class BuildContext<TJob extends Job> {
     this.cacheManager = options.cacheManager;
     this.ejectProvider = options.ejectProvider ?? new NpxExpoCliEjectProvider();
     this.metadata = options.metadata;
+    this.skipNativeBuild = options.skipNativeBuild;
     this.env = {
       ...options.env,
       ...job?.builderEnvironment?.env,

--- a/packages/build-tools/src/index.ts
+++ b/packages/build-tools/src/index.ts
@@ -2,5 +2,5 @@ import * as Builders from './builders';
 
 export { Builders };
 
-export { BuildContext, CacheManager, LogBuffer } from './context';
+export { BuildContext, CacheManager, LogBuffer, SkipNativeBuildError } from './context';
 export { EjectProvider, EjectOptions } from './managed/EjectProvider';

--- a/packages/build-tools/src/ios/fastlane.ts
+++ b/packages/build-tools/src/ios/fastlane.ts
@@ -5,7 +5,7 @@ import fastlane from '@expo/fastlane';
 import fs from 'fs-extra';
 import nullthrows from 'nullthrows';
 
-import { BuildContext } from '../context';
+import { BuildContext, SkipNativeBuildError } from '../context';
 
 import { createGymfileForArchiveBuild, createGymfileForSimulatorBuild } from './gymfile';
 import { Credentials } from './credentials/manager';
@@ -33,6 +33,9 @@ export async function runFastlaneGym<TJob extends Ios.Job>(
     logsDirectory,
     entitlements,
   });
+  if (ctx.skipNativeBuild) {
+    throw new SkipNativeBuildError('Skipping fastlane build');
+  }
   const buildLogger = new XcodeBuildLogger(ctx.logger, ctx.reactNativeProjectDirectory);
   void buildLogger.watchLogFiles(logsDirectory);
   try {

--- a/packages/local-build-plugin/src/android.ts
+++ b/packages/local-build-plugin/src/android.ts
@@ -6,6 +6,7 @@ import { LocalExpoCliEjectProvider } from './eject';
 import logger, { logBuffer } from './logger';
 import { BuildParams } from './types';
 import { prepareBuildArtifact } from './buildArtifact';
+import config from './config';
 
 export async function buildAndroidAsync(
   job: Android.Job,
@@ -17,6 +18,7 @@ export async function buildAndroidAsync(
     logBuffer,
     ejectProvider: new LocalExpoCliEjectProvider(),
     env,
+    skipNativeBuild: config.skipNativeBuild,
   });
 
   await ctx.runBuildPhase(BuildPhase.START_BUILD, async () => {

--- a/packages/local-build-plugin/src/config.ts
+++ b/packages/local-build-plugin/src/config.ts
@@ -8,6 +8,7 @@ const { temp } = envPaths('eas-build-local');
 const envLoggerLevel = process.env.EAS_LOCAL_BUILD_LOGGER_LEVEL;
 const envWorkingdir = process.env.EAS_LOCAL_BUILD_WORKINGDIR;
 const envSkipCleanup = process.env.EAS_LOCAL_BUILD_SKIP_CLEANUP;
+const envSkipNativeBuild = process.env.EAS_LOCAL_BUILD_SKIP_NATIVE_BUILD;
 const envArtifactsDir = process.env.EAS_LOCAL_BUILD_ARTIFACTS_DIR;
 
 if (envLoggerLevel && !['debug', 'info', 'warn', 'error'].includes(envLoggerLevel)) {
@@ -19,6 +20,7 @@ if (envLoggerLevel && !['debug', 'info', 'warn', 'error'].includes(envLoggerLeve
 export default {
   workingdir: envWorkingdir ?? path.join(temp, uuidv4()),
   skipCleanup: envSkipCleanup === '1',
+  skipNativeBuild: envSkipNativeBuild === '1',
   artifactsDir: envArtifactsDir ?? process.cwd(),
   logger: {
     level: (envLoggerLevel ?? 'info') as 'debug' | 'info' | 'warn' | 'error',

--- a/packages/local-build-plugin/src/ios.ts
+++ b/packages/local-build-plugin/src/ios.ts
@@ -6,6 +6,7 @@ import { LocalExpoCliEjectProvider } from './eject';
 import logger, { logBuffer } from './logger';
 import { BuildParams } from './types';
 import { prepareBuildArtifact } from './buildArtifact';
+import config from './config';
 
 export async function buildIosAsync(
   job: Ios.Job,
@@ -17,6 +18,7 @@ export async function buildIosAsync(
     logBuffer,
     ejectProvider: new LocalExpoCliEjectProvider(),
     env,
+    skipNativeBuild: config.skipNativeBuild,
   });
 
   await ctx.runBuildPhase(BuildPhase.START_BUILD, async () => {

--- a/packages/local-build-plugin/src/parseInput.ts
+++ b/packages/local-build-plugin/src/parseInput.ts
@@ -60,7 +60,7 @@ function validateParams(params: object): Params {
       chalk.red(
         `Job object has incorrect format, update to latest versions of ${chalk.bold(
           'eas-cli'
-        )} and ${chalk.bold(packageJson.name)} to make sure you are using comaptibile packages.`
+        )} and ${chalk.bold(packageJson.name)} to make sure you are using compatible packages.`
       )
     );
     throw err;
@@ -69,7 +69,7 @@ function validateParams(params: object): Params {
 
 function displayHelp(): void {
   console.log(
-    `This tool is not intedend for standalone use, it will be used internally by ${chalk.bold(
+    `This tool is not intended for standalone use, it will be used internally by ${chalk.bold(
       'eas-cli'
     )} when building with flag ${chalk.bold('--local')}.`
   );


### PR DESCRIPTION
# Why

Support partial builds that can be used to implement inspect functionality in eas-cli

# How



# Test Plan

run build and build:inspect with various options
