### PR TITLE
[build-tools] fix display bug

### DIFF
--- a/packages/build-tools/src/utils/expoUpdates.ts
+++ b/packages/build-tools/src/utils/expoUpdates.ts
@@ -1,6 +1,7 @@
 import assert from 'assert';
 
 import { Platform, Job } from '@expo/eas-build-job';
+import { getRuntimeVersionNullable } from '@expo/config-plugins/build/utils/Updates';
 
 import {
   androidSetChannelNativelyAsync,
@@ -17,7 +18,6 @@ import {
 import { BuildContext } from '../context';
 
 import isExpoUpdatesInstalledAsync from './isExpoUpdatesInstalled';
-import { getRuntimeVersionNullable } from '@expo/config-plugins/build/utils/Updates';
 
 /**
  * Used for when Expo Updates is pointed at an EAS server.
@@ -130,13 +130,10 @@ export const configureExpoUpdatesIfInstalledAsync = async (
     return;
   }
 
-  const appConfingRuntimeVersion = getRuntimeVersionNullable(ctx.appConfig,ctx.job.platform)
-  if (
-    ctx.metadata?.runtimeVersion &&
-    ctx.metadata?.runtimeVersion !== appConfingRuntimeVersion
-  ) {
+  const appConfigRuntimeVersion = getRuntimeVersionNullable(ctx.appConfig, ctx.job.platform);
+  if (ctx.metadata?.runtimeVersion && ctx.metadata?.runtimeVersion !== appConfigRuntimeVersion) {
     ctx.logger.warn(
-      `Runtime version from the app config evaluated on your local machine (${ctx.metadata.runtimeVersion}) does not match the one resolved here (${appConfingRuntimeVersion}).`
+      `Runtime version from the app config evaluated on your local machine (${ctx.metadata.runtimeVersion}) does not match the one resolved here (${appConfigRuntimeVersion}).`
     );
     ctx.logger.warn(
       "If you're using conditional app configs, e.g. depending on an environment variable, make sure to set the variable in eas.json or configure it with EAS Secret."

--- a/packages/build-tools/src/utils/expoUpdates.ts
+++ b/packages/build-tools/src/utils/expoUpdates.ts
@@ -17,6 +17,7 @@ import {
 import { BuildContext } from '../context';
 
 import isExpoUpdatesInstalledAsync from './isExpoUpdatesInstalled';
+import { getRuntimeVersionNullable } from '@expo/config-plugins/build/utils/Updates';
 
 /**
  * Used for when Expo Updates is pointed at an EAS server.
@@ -129,12 +130,13 @@ export const configureExpoUpdatesIfInstalledAsync = async (
     return;
   }
 
+  const appConfingRuntimeVersion = getRuntimeVersionNullable(ctx.appConfig,ctx.job.platform)
   if (
     ctx.metadata?.runtimeVersion &&
-    ctx.metadata?.runtimeVersion !== ctx.appConfig.runtimeVersion
+    ctx.metadata?.runtimeVersion !== appConfingRuntimeVersion
   ) {
     ctx.logger.warn(
-      `Runtime version from the app config evaluated on your local machine (${ctx.metadata.runtimeVersion}) does not match the one resolved here (${ctx.appConfig.runtimeVersion}).`
+      `Runtime version from the app config evaluated on your local machine (${ctx.metadata.runtimeVersion}) does not match the one resolved here (${appConfingRuntimeVersion}).`
     );
     ctx.logger.warn(
       "If you're using conditional app configs, e.g. depending on an environment variable, make sure to set the variable in eas.json or configure it with EAS Secret."


### PR DESCRIPTION
# Why

Fix this display bug:

![image](https://user-images.githubusercontent.com/1220444/146407641-3059f64a-ee38-4ab5-9c9e-ca1869aec9e5.png)

# How

the app config may have runtime version *objects* as well as strings, so we should use `getRuntimeVersionNullable` to process it.

