### PR TITLE
[build-tools] configure build.gradle when building android projects

### DIFF
--- a/packages/build-tools/src/android/gradleConfig.ts
+++ b/packages/build-tools/src/android/gradleConfig.ts
@@ -1,0 +1,55 @@
+import path from 'path';
+
+import { AndroidConfig } from '@expo/config-plugins';
+import { Android } from '@expo/eas-build-job';
+import fs from 'fs-extra';
+
+import { BuildContext } from '../context';
+
+const EAS_BUILD_GRADLE_TEMPLATE_PATH = path.join(__dirname, '../../templates/eas-build.gradle');
+const APPLY_EAS_BUILD_GRADLE_LINE = 'apply from: "./eas-build.gradle"';
+
+export async function configureBuildGradle(ctx: BuildContext<Android.Job>): Promise<void> {
+  ctx.logger.info('Injecting signing config into build.gradle');
+  await deleteEasBuildGradle(ctx.reactNativeProjectDirectory);
+  await createEasBuildGradle(ctx.reactNativeProjectDirectory);
+  await addApplyToBuildGradle(ctx.reactNativeProjectDirectory);
+}
+
+async function deleteEasBuildGradle(projectRoot: string): Promise<void> {
+  const easBuildGradlePath = getEasBuildGradlePath(projectRoot);
+  await fs.remove(easBuildGradlePath);
+}
+
+function getEasBuildGradlePath(projectRoot: string): string {
+  return path.join(projectRoot, 'android/app/eas-build.gradle');
+}
+
+async function createEasBuildGradle(projectRoot: string): Promise<void> {
+  const easBuildGradlePath = getEasBuildGradlePath(projectRoot);
+  await fs.copy(EAS_BUILD_GRADLE_TEMPLATE_PATH, easBuildGradlePath);
+}
+
+async function addApplyToBuildGradle(projectRoot: string): Promise<void> {
+  const buildGradlePath = AndroidConfig.Paths.getAppBuildGradleFilePath(projectRoot);
+  const buildGradleContents = await fs.readFile(path.join(buildGradlePath), 'utf8');
+
+  if (hasLine(buildGradleContents, APPLY_EAS_BUILD_GRADLE_LINE)) {
+    return;
+  }
+
+  await fs.writeFile(
+    buildGradlePath,
+    `${buildGradleContents.trim()}\n${APPLY_EAS_BUILD_GRADLE_LINE}\n`
+  );
+}
+
+function hasLine(haystack: string, needle: string): boolean {
+  return (
+    haystack
+      .replace(/\r\n/g, '\n')
+      .split('\n')
+      // Check for both single and double quotes
+      .some((line) => line === needle || line === needle.replace(/"/g, "'"))
+  );
+}

--- a/packages/build-tools/templates/eas-build.gradle
+++ b/packages/build-tools/templates/eas-build.gradle
@@ -1,0 +1,51 @@
+// Build integration with EAS
+
+import java.nio.file.Paths
+
+android {
+  signingConfigs {
+    release {
+      // This is necessary to avoid needing the user to define a release signing config manually
+      // If no release config is defined, and this is not present, build for assembleRelease will crash
+    }
+  }
+
+  buildTypes {
+    release {
+      // This is necessary to avoid needing the user to define a release build type manually
+    }
+    debug {
+      // This is necessary to avoid needing the user to define a debug build type manually
+    }
+  }
+}
+
+tasks.whenTaskAdded {
+  android.signingConfigs.release {
+    def credentialsJson = rootProject.file("../credentials.json");
+    def credentials = new groovy.json.JsonSlurper().parse(credentialsJson)
+    def keystorePath = Paths.get(credentials.android.keystore.keystorePath);
+    def storeFilePath = keystorePath.isAbsolute()
+      ? keystorePath
+      : rootProject.file("..").toPath().resolve(keystorePath);
+
+    storeFile storeFilePath.toFile()
+    storePassword credentials.android.keystore.keystorePassword
+    keyAlias credentials.android.keystore.keyAlias
+    if (credentials.android.keystore.containsKey("keyPassword")) {
+      keyPassword credentials.android.keystore.keyPassword
+    } else {
+      // key password is required by Gradle, but PKCS keystores don't have one
+      // using the keystore password seems to satisfy the requirement
+      keyPassword credentials.android.keystore.keystorePassword
+    }
+  }
+
+  android.buildTypes.release {
+    signingConfig android.signingConfigs.release
+  }
+
+  android.buildTypes.debug {
+    signingConfig android.signingConfigs.release
+  }
+}


### PR DESCRIPTION
# Why

We want to get rid of `eas build:configure`. Because of that, we need to inject signing config into `build.gradl` in `@expo/build-tools`.

# How

- Basically copy-paste logic from EAS CLI/`@expo/config-plugins`:
   - Remove `eas-build.gradle` from project if it already exists.
   - Create a new `eas-build.gradle` from the template.
   - Add the `apply ...` line to `build.gradle` if it's not there yet.
- The above logic is only executed if build credentials exist.

# Test Plan

Tested locally with https://github.com/expo/eas-cli/pull/888