### PR TITLE
specify custom artifact path via env

### DIFF
--- a/packages/local-build-plugin/package.json
+++ b/packages/local-build-plugin/package.json
@@ -25,7 +25,6 @@
     "@expo/spawn-async": "^1.5.0",
     "@expo/turtle-spawn": "0.0.21",
     "chalk": "^4.1.0",
-    "dateformat": "^4.6.2",
     "expo-cli": "5.0.2",
     "fs-extra": "^9.1.0",
     "joi": "^17.4.2",
@@ -35,7 +34,6 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@types/dateformat": "^3.0.1",
     "@types/fs-extra": "^9.0.9",
     "@types/hapi__joi": "^17.1.6",
     "@types/lodash": "^4.14.168",

--- a/packages/local-build-plugin/src/buildArtifact.ts
+++ b/packages/local-build-plugin/src/buildArtifact.ts
@@ -2,7 +2,6 @@ import path from 'path';
 
 import { BuildContext } from '@expo/build-tools';
 import { Job } from '@expo/eas-build-job';
-import dateFormat from 'dateformat';
 import fs from 'fs-extra';
 import tar from 'tar';
 
@@ -39,8 +38,8 @@ export async function prepareBuildArtifact(
     suffix = '.tar.gz';
     localPath = archivePath;
   }
-  const artifactName = `build-${formatDateForFilename(new Date())}${suffix}`;
-  const destPath = path.join(config.artifactsDir, artifactName);
+  const artifactName = `build-${Date.now()}${suffix}`;
+  const destPath = config.artifactPath ?? path.join(config.artifactsDir, artifactName);
   await fs.copy(localPath, destPath);
   ctx.logger.info({ phase: 'PREPARE_ARTIFACTS' }, `Writing artifacts to ${destPath}`);
   return destPath;
@@ -57,8 +56,4 @@ function getCommonParentDir(path1: string, path2: string): string {
     current = path.dirname(current);
   }
   return '/';
-}
-
-function formatDateForFilename(date: Date): string {
-  return dateFormat(date, 'dd-mm-yyyy-HH:MM');
 }

--- a/packages/local-build-plugin/src/config.ts
+++ b/packages/local-build-plugin/src/config.ts
@@ -10,6 +10,7 @@ const envWorkingdir = process.env.EAS_LOCAL_BUILD_WORKINGDIR;
 const envSkipCleanup = process.env.EAS_LOCAL_BUILD_SKIP_CLEANUP;
 const envSkipNativeBuild = process.env.EAS_LOCAL_BUILD_SKIP_NATIVE_BUILD;
 const envArtifactsDir = process.env.EAS_LOCAL_BUILD_ARTIFACTS_DIR;
+const envArtifactPath = process.env.EAS_LOCAL_BUILD_ARTIFACT_PATH;
 
 if (envLoggerLevel && !['debug', 'info', 'warn', 'error'].includes(envLoggerLevel)) {
   throw new Error(
@@ -22,6 +23,7 @@ export default {
   skipCleanup: envSkipCleanup === '1',
   skipNativeBuild: envSkipNativeBuild === '1',
   artifactsDir: envArtifactsDir ?? process.cwd(),
+  artifactPath: envArtifactPath,
   logger: {
     level: (envLoggerLevel ?? 'info') as 'debug' | 'info' | 'warn' | 'error',
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2107,11 +2107,6 @@
     "@types/node" "*"
     "@types/responselike" "*"
 
-"@types/dateformat@^3.0.1":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@types/dateformat/-/dateformat-3.0.1.tgz#98d747a2e5e9a56070c6bf14e27bff56204e34cc"
-  integrity sha512-KlPPdikagvL6ELjWsljbyDIPzNCeliYkqRpI+zea99vBBbCIA5JNshZAwQKTON139c87y9qvTFVgkFd14rtS4g==
-
 "@types/fs-extra@^9.0.1":
   version "9.0.11"
   resolved "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-9.0.11.tgz#8cc99e103499eab9f347dbc6ca4e99fb8d2c2b87"
@@ -4736,11 +4731,6 @@ dateformat@3.0.3, dateformat@^3.0.0:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-3.0.3.tgz#a6e37499a4d9a9cf85ef5872044d62901c9889ae"
   integrity sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==
-
-dateformat@^4.6.2:
-  version "4.6.3"
-  resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-4.6.3.tgz#556fa6497e5217fedb78821424f8a1c22fa3f4b5"
-  integrity sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==
 
 debug@2, debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.9:
   version "2.6.9"


### PR DESCRIPTION
# Why

- support `--output` flag in `eas-cli`
- closes #64 

# How

add env variable that overrides artifact name
change default name (using timestamp instead of formated time is less human-readable but name look cleaner without all those `:`/`-`)

# Test Plan

run local build