### PR TITLE
Update license badge in README and pricing URL in license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -17,7 +17,7 @@ Change Date:          2024-11-02
 Change License:       MIT
 
 For information about alternative licensing arrangements for the Software,
-please visit: https://expo.io/pricing/
+please visit: https://expo.dev/pricing/
 
 Notice
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <a href="https://expo.io/">
+  <a href="https://expo.dev/">
     <img alt="expo" height="128" src="assets/banner.png">
     <h1 align="center">Expo</h1>
   </a>
@@ -9,6 +9,6 @@
 [![License](https://img.shields.io/badge/license-BSL-green.svg?style=flat)](https://github.com/expo/turtle/blob/master/LICENSE)
 
 [![Expo Developers Discord](https://img.shields.io/badge/Expo%20Developers-e01563.svg?logo=discord)](https://discord.gg/4gtbPAdpaE)
-[![Expo Forums](https://img.shields.io/badge/Expo%20Forums-blue.svg)](https://forums.expo.io/)
+[![Expo Forums](https://img.shields.io/badge/Expo%20Forums-blue.svg)](https://forums.expo.dev/)
 
 This repository contains a set of libraries used by EAS Build service to process builds.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 </p>
 
 [![NPM](https://img.shields.io/npm/v/eas-cli-local-build-plugin/latest.svg)](https://npmjs.com/package/eas-cli-local-build-plugin)
-[![License](https://img.shields.io/badge/license-MIT-green.svg?style=flat)](https://github.com/expo/turtle/blob/master/LICENSE)
+[![License](https://img.shields.io/badge/license-BSL-green.svg?style=flat)](https://github.com/expo/turtle/blob/master/LICENSE)
 
 [![Expo Developers Discord](https://img.shields.io/badge/Expo%20Developers-e01563.svg?logo=discord)](https://discord.gg/4gtbPAdpaE)
 [![Expo Forums](https://img.shields.io/badge/Expo%20Forums-blue.svg)](https://forums.expo.io/)


### PR DESCRIPTION
# Why/How

* The badge on the README said MIT. Changed it to BSL, the main license here.
* The link in the readme pointed to expo.io instead of expo.dev.

There are no actual license changes, just cosmetics.
