### PR TITLE
add custom prebuild command to job api

### DIFF
--- a/packages/eas-build-job/src/android.ts
+++ b/packages/eas-build-job/src/android.ts
@@ -94,6 +94,10 @@ export interface Job {
   // managed
   buildType?: BuildType;
   username?: string;
+
+  experimental?: {
+    prebuildCommand?: string;
+  };
 }
 
 export const JobSchema = Joi.object({
@@ -120,4 +124,8 @@ export const JobSchema = Joi.object({
 
   buildType: Joi.string().valid(...Object.values(BuildType)),
   username: Joi.string(),
+
+  experimental: Joi.object({
+    prebuildCommand: Joi.string(),
+  }),
 }).oxor('releaseChannel', 'updates.channel');

--- a/packages/eas-build-job/src/ios.ts
+++ b/packages/eas-build-job/src/ios.ts
@@ -102,6 +102,10 @@ export interface Job {
   artifactPath?: string;
 
   username?: string;
+
+  experimental?: {
+    prebuildCommand?: string;
+  };
 }
 
 export const JobSchema = Joi.object({
@@ -131,4 +135,8 @@ export const JobSchema = Joi.object({
 
   // managed
   username: Joi.string(),
+
+  experimental: Joi.object({
+    prebuildCommand: Joi.string(),
+  }),
 }).oxor('releaseChannel', 'updates.channel');

--- a/packages/local-build-plugin/src/eject.ts
+++ b/packages/local-build-plugin/src/eject.ts
@@ -37,19 +37,23 @@ export class LocalExpoCliEjectProvider implements EjectProvider<Job> {
   private getPrebuildCommand(job: Job): string {
     let prebuildCommand =
       job.experimental?.prebuildCommand ?? `prebuild --non-interactive --platform ${job.platform}`;
-    if (!prebuildCommand.match(/--platform/)) {
+    if (!prebuildCommand.match(/(?:--platform| -p)/)) {
       prebuildCommand = `${prebuildCommand} --platform ${job.platform}`;
     }
     if (!prebuildCommand.match(/--non-interactive/)) {
       prebuildCommand = `${prebuildCommand} --non-interactive`;
     }
+    const npxCommandPrefix = 'npx ';
     const expoCommandPrefix = 'expo ';
     const expoCliCommandPrefix = 'expo-cli ';
+    if (prebuildCommand.startsWith(npxCommandPrefix)) {
+      prebuildCommand = prebuildCommand.substr(npxCommandPrefix.length).trim();
+    }
     if (prebuildCommand.startsWith(expoCommandPrefix)) {
-      prebuildCommand = prebuildCommand.substr(expoCommandPrefix.length);
+      prebuildCommand = prebuildCommand.substr(expoCommandPrefix.length).trim();
     }
     if (prebuildCommand.startsWith(expoCliCommandPrefix)) {
-      prebuildCommand = prebuildCommand.substr(expoCliCommandPrefix.length);
+      prebuildCommand = prebuildCommand.substr(expoCliCommandPrefix.length).trim();
     }
     return prebuildCommand;
   }

--- a/packages/local-build-plugin/src/eject.ts
+++ b/packages/local-build-plugin/src/eject.ts
@@ -21,19 +21,36 @@ export class LocalExpoCliEjectProvider implements EjectProvider<Job> {
 
     const expoCliBinPath =
       process.env.EXPO_CLI_PATH ?? path.resolve(path.dirname(expoCliPackage), '../bin/expo.js');
-    logger.debug(`${expoCliBinPath} prebuild --non-interactive --platform ${job.platform}`);
-    await spawnAsync(
-      expoCliBinPath,
-      ['prebuild', '--non-interactive', '--platform', job.platform],
-      {
-        ...spawnOptions,
-        cwd: ctx.reactNativeProjectDirectory,
-      }
-    );
+    const prebuildCommand = this.getPrebuildCommand(job);
+    logger.debug(`${expoCliBinPath} ${prebuildCommand}`);
+    await spawnAsync('bash', ['-c', `${expoCliBinPath} ${prebuildCommand}`], {
+      ...spawnOptions,
+      cwd: ctx.reactNativeProjectDirectory,
+    });
 
     await spawnAsync(ctx.packageManager, ['install'], {
       ...spawnOptions,
       cwd: ctx.reactNativeProjectDirectory,
     });
+  }
+
+  private getPrebuildCommand(job: Job): string {
+    let prebuildCommand =
+      job.experimental?.prebuildCommand ?? `prebuild --non-interactive --platform ${job.platform}`;
+    if (!prebuildCommand.match(/--platform/)) {
+      prebuildCommand = `${prebuildCommand} --platform ${job.platform}`;
+    }
+    if (!prebuildCommand.match(/--non-interactive/)) {
+      prebuildCommand = `${prebuildCommand} --non-interactive`;
+    }
+    const expoCommandPrefix = 'expo ';
+    const expoCliCommandPrefix = 'expo-cli ';
+    if (prebuildCommand.startsWith(expoCommandPrefix)) {
+      prebuildCommand = prebuildCommand.substr(expoCommandPrefix.length);
+    }
+    if (prebuildCommand.startsWith(expoCliCommandPrefix)) {
+      prebuildCommand = prebuildCommand.substr(expoCliCommandPrefix.length);
+    }
+    return prebuildCommand;
   }
 }


### PR DESCRIPTION
# Why

To support custom options for the prebuild command

# How

add an experimental field to the job object
use new option when running prebuild command for local builds

prebuildCommand can be in form
  - `expo prebuild --template sjdlkhfjlksd`
  - `expo-cli prebuild --template sjdlkhfjlksd`
  - `prebuild --template sjdlkhfjlksd`
  
  if platform or non interactive is not specified is added to the command

# Test Plan

run local build with custom prebuild option