### PR TITLE
[local-build-plugin] add explicit dependency to env-paths

### DIFF
--- a/packages/local-build-plugin/package.json
+++ b/packages/local-build-plugin/package.json
@@ -25,6 +25,7 @@
     "@expo/spawn-async": "^1.5.0",
     "@expo/turtle-spawn": "0.0.21",
     "chalk": "^4.1.0",
+    "env-paths": "2.2.0",
     "expo-cli": "5.0.5",
     "fs-extra": "^9.1.0",
     "joi": "^17.4.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5284,6 +5284,11 @@ env-editor@^0.4.1:
   resolved "https://registry.yarnpkg.com/env-editor/-/env-editor-0.4.2.tgz#4e76568d0bd8f5c2b6d314a9412c8fe9aa3ae861"
   integrity sha512-ObFo8v4rQJAE59M69QzwloxPZtd33TpYEIjtKD1rrFDcM1Gd7IkDxEBU+HriziN6HSHQnBJi8Dmy+JWkav5HKA==
 
+env-paths@2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/env-paths/-/env-paths-2.2.0.tgz#cdca557dc009152917d6166e2febe1f039685e43"
+  integrity sha512-6u0VYSCo/OW6IoD5WCLLy9JUGARbamfSavcNXry/eu8aHVFei6CD3Sw+VGX5alea1i9pgPHW0mbu6Xj0uBh7gA==
+
 env-paths@^2.2.0:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/env-paths/-/env-paths-2.2.1.tgz#420399d416ce1fbe9bc0a07c62fa68d67fd0f8f2"


### PR DESCRIPTION
# Why

`local-build-plugin` depended on `eas-cli` to have `env-paths` in its dependencies.

# How

Added the dependency to `package.json`

# Test Plan

N/A