### PR TITLE
[eas-build-job] remove support for catalina images

### DIFF
--- a/packages/eas-build-job/src/ios.ts
+++ b/packages/eas-build-job/src/ios.ts
@@ -43,18 +43,13 @@ export const builderBaseImages = [
   'default',
   'latest',
   'stable',
-  'macos-catalina-11.15-xcode-12.1', // incorrect name, keep for legacy cases
-  'macos-catalina-11.15-xcode-12.4', // incorrect name, keep for legacy cases
-  'macos-catalina-10.15-xcode-12.1',
-  'macos-catalina-10.15-xcode-12.4',
   'macos-big-sur-11.4-xcode-12.5',
   'macos-big-sur-11.4-xcode-13.0',
   'macos-monterey-12.1-xcode-13.2',
 ] as const;
 
 export const sdkVersionToDefaultBuilderImage: Record<string, typeof builderBaseImages[number]> = {
-  '<=41': 'macos-catalina-10.15-xcode-12.1',
-  '42': 'macos-big-sur-11.4-xcode-12.5',
+  '<=42': 'macos-big-sur-11.4-xcode-12.5',
   '43': 'macos-big-sur-11.4-xcode-13.0',
 };
 


### PR DESCRIPTION
# Why

We want to drop support for macOS Catalina images.

# How

Drop support for macOS Catalina images.

# Test Plan

I will test it with turtle-api changes.