### PR TITLE
[build-tools] replace double quotes with single quotes

### DIFF
--- a/packages/build-tools/src/android/__tests__/expoUpdates.test.ts
+++ b/packages/build-tools/src/android/__tests__/expoUpdates.test.ts
@@ -113,7 +113,7 @@ describe(androidSetChannelNativelyAsync, () => {
       AndroidMetadataName.UPDATES_CONFIGURATION_REQUEST_HEADERS_KEY
     );
     expect(newValue).toBeDefined();
-    expect(JSON.parse(newValue!)).toEqual({ 'expo-channel-name': channel });
+    expect(newValue).toEqual(JSON.stringify({ 'expo-channel-name': channel }).replace(/"/g, "'"));
   });
 });
 describe(androidGetNativelyDefinedClassicReleaseChannelAsync, () => {

--- a/packages/build-tools/src/android/expoUpdates.ts
+++ b/packages/build-tools/src/android/expoUpdates.ts
@@ -29,13 +29,19 @@ export async function androidSetChannelNativelyAsync(ctx: BuildContext<Job>): Pr
     androidManifest,
     AndroidMetadataName.UPDATES_CONFIGURATION_REQUEST_HEADERS_KEY
   );
+
+  // apkanalyzer unescapes double quotes before parsing. This leads to crashes.
+  // Luckily, we can replace the double quotes with single quotes and it will
+  // still be parsed as a JSON by the expo-updates client
+  const singleQuotedStringifiedUpdatesRequestHeaders = JSON.stringify({
+    ...JSON.parse(stringifiedUpdatesRequestHeaders ?? '{}'),
+    'expo-channel-name': ctx.job.updates.channel,
+  }).replace(/"/g, "'");
+
   AndroidConfig.Manifest.addMetaDataItemToMainApplication(
     mainApp,
     AndroidMetadataName.UPDATES_CONFIGURATION_REQUEST_HEADERS_KEY,
-    JSON.stringify({
-      ...JSON.parse(stringifiedUpdatesRequestHeaders ?? '{}'),
-      'expo-channel-name': ctx.job.updates.channel,
-    }),
+    singleQuotedStringifiedUpdatesRequestHeaders,
     'value'
   );
   await AndroidConfig.Manifest.writeAndroidManifestAsync(manifestPath, androidManifest);


### PR DESCRIPTION
# Why

apkanalyzer unescapes double quotes before parsing. This makes it unable parse manifests with double quotes in there values. Submissions are broken because of this:

https://exponent-internal.slack.com/archives/C9PRD479V/p1643844774057369

# How

I tried a variety of different escapes for the double quoting:

1.`{\\“expo-channel-name\\“:\\“${ctx.job.updates.channel}\\“}`
3. `{\\0022expo-channel-name\\0022:\\0022${ctx.job.updates.channel}\\0022}`
4. `{&quot;expo-channel-name&quot;:&quot;${ctx.job.updates.channel}&quot;`
And they ail break the apkanalyzer manifest application-id build.apk

Luckily the client is able to parse a single quoted JSON, so we can just replace the double quotes with a single quote.

# Test Plan

easp build --profile production --platform android --local

to build an apk with the proposed changes. Then confirmed:

1. `apkanalyzer manifest application-id  build.apk` works.
2. installed the apk on an emulator and then published an update to the channel.