### PR TITLE
[build-tools] store release channel name as a string resource

### DIFF
--- a/packages/build-tools/src/android/__tests__/expoUpdates.test.ts
+++ b/packages/build-tools/src/android/__tests__/expoUpdates.test.ts
@@ -47,7 +47,7 @@ describe(androidSetClassicReleaseChannelNativelyAsync, () => {
   test('sets the release channel', async () => {
     const reactNativeProjectDirectory = fs.mkdtempSync('/expo-project-');
     fs.ensureDirSync(reactNativeProjectDirectory);
-    const releaseChannel = 'default';
+    const releaseChannel = 'blah';
     const ctx = {
       reactNativeProjectDirectory,
       job: { releaseChannel },
@@ -75,7 +75,15 @@ describe(androidSetClassicReleaseChannelNativelyAsync, () => {
         newAndroidManifest,
         AndroidMetadataName.RELEASE_CHANNEL
       )
-    ).toBe(releaseChannel);
+    ).toBe('@string/release_channel');
+
+    const stringResourcePath = await AndroidConfig.Strings.getProjectStringsXMLPathAsync(
+      reactNativeProjectDirectory
+    );
+    const stringResourceObject = await AndroidConfig.Resources.readResourcesXMLAsync({
+      path: stringResourcePath,
+    });
+    expect((stringResourceObject.resources.string as any)[0]['_']).toBe(releaseChannel);
   });
 });
 describe(androidSetChannelNativelyAsync, () => {

--- a/packages/build-tools/src/android/expoUpdates.ts
+++ b/packages/build-tools/src/android/expoUpdates.ts
@@ -45,9 +45,7 @@ export async function androidSetClassicReleaseChannelNativelyAsync(
   ctx: BuildContext<Job>
 ): Promise<void> {
   const { releaseChannel } = ctx.job;
-  if (!releaseChannel) {
-    throw Error('releaseChannel must be defined');
-  }
+  assert(releaseChannel, 'releaseChannel must be defined');
   const escapedReleaseChannel = XML.escapeAndroidString(releaseChannel);
 
   const manifestPath = await AndroidConfig.Paths.getAndroidManifestAsync(

--- a/packages/build-tools/src/android/expoUpdates.ts
+++ b/packages/build-tools/src/android/expoUpdates.ts
@@ -1,7 +1,7 @@
 import assert from 'assert';
 
 import fs from 'fs-extra';
-import { AndroidConfig } from '@expo/config-plugins';
+import { AndroidConfig, XML } from '@expo/config-plugins';
 import { Job } from '@expo/eas-build-job';
 
 import { BuildContext } from '../context';
@@ -44,7 +44,11 @@ export async function androidSetChannelNativelyAsync(ctx: BuildContext<Job>): Pr
 export async function androidSetClassicReleaseChannelNativelyAsync(
   ctx: BuildContext<Job>
 ): Promise<void> {
-  assert(ctx.job.releaseChannel, 'releaseChannel must be defined');
+  const { releaseChannel } = ctx.job;
+  if (!releaseChannel) {
+    throw Error('releaseChannel must be defined');
+  }
+  const escapedReleaseChannel = XML.escapeAndroidString(releaseChannel);
 
   const manifestPath = await AndroidConfig.Paths.getAndroidManifestAsync(
     ctx.reactNativeProjectDirectory
@@ -53,12 +57,30 @@ export async function androidSetClassicReleaseChannelNativelyAsync(
     throw new Error(`Couldn't find Android manifest at ${manifestPath}`);
   }
 
+  // Store the release channel in a string resource to ensure it is interpreted as a string
+  const stringResourcePath = await AndroidConfig.Strings.getProjectStringsXMLPathAsync(
+    ctx.reactNativeProjectDirectory
+  );
+  const stringResourceObject = await AndroidConfig.Resources.readResourcesXMLAsync({
+    path: stringResourcePath,
+  });
+  const resourceName = 'release_channel';
+  const releaseChannelResourceItem = AndroidConfig.Resources.buildResourceItem({
+    name: resourceName,
+    value: escapedReleaseChannel,
+  });
+  const newStringResourceObject = AndroidConfig.Strings.setStringItem(
+    [releaseChannelResourceItem],
+    stringResourceObject
+  );
+  await XML.writeXMLAsync({ path: stringResourcePath, xml: newStringResourceObject });
+
   const androidManifest = await AndroidConfig.Manifest.readAndroidManifestAsync(manifestPath);
   const mainApp = AndroidConfig.Manifest.getMainApplicationOrThrow(androidManifest);
   AndroidConfig.Manifest.addMetaDataItemToMainApplication(
     mainApp,
     AndroidMetadataName.RELEASE_CHANNEL,
-    ctx.job.releaseChannel,
+    `@string/${resourceName}`,
     'value'
   );
   await AndroidConfig.Manifest.writeAndroidManifestAsync(manifestPath, androidManifest);


### PR DESCRIPTION
# Why

Android makes a best guess cast when interpreting metadata values. This can lead to discordance between the releaseChannel stored by the build and the releaseChannel of a published update. 

The motivating example/bug is when a user had `1.0` as a releaseChannel.

# How

Store the releaseChannel as a string resource to ensure Android interprets it as a string.

# Test Plan

1. set releaseChannel to `1.0` in eas.json
2. build locally, install into an emulator.
3. publish to `1.0`
4. confirm app downloads and loads update.