### PR TITLE
unescape string when reading xml

### DIFF
--- a/packages/build-tools/src/android/expoUpdates.ts
+++ b/packages/build-tools/src/android/expoUpdates.ts
@@ -62,6 +62,17 @@ export async function androidSetClassicReleaseChannelNativelyAsync(
   const stringResourceObject = await AndroidConfig.Resources.readResourcesXMLAsync({
     path: stringResourcePath,
   });
+
+  // TODO move this to expo-cli
+  if (Array.isArray(stringResourceObject?.resources?.string)) {
+    for (const string of stringResourceObject?.resources?.string) {
+      if (string.$.translatable === 'false') {
+        continue;
+      }
+      string._ = unescapeAndroidString(string._);
+    }
+  }
+
   const resourceName = 'release_channel';
   const releaseChannelResourceItem = AndroidConfig.Resources.buildResourceItem({
     name: resourceName,
@@ -116,4 +127,9 @@ export async function androidGetNativelyDefinedRuntimeVersionAsync(
     androidManifest,
     AndroidMetadataName.RUNTIME_VERSION
   );
+}
+
+// TODO move this to expo-cli
+export function unescapeAndroidString(value: string): string {
+  return value.replace(/\\(.)/g, '$1');
 }


### PR DESCRIPTION
# Why

when we read and write XML values, string values are escaped twice

# How

unescape values on read

# Test Plan

tested with local build and pap that had `'` in name
