### PR TITLE
[build-tools] add `--no-install` to prebuild command

### DIFF
--- a/packages/build-tools/src/utils/prebuild.ts
+++ b/packages/build-tools/src/utils/prebuild.ts
@@ -26,7 +26,8 @@ export async function prebuildAsync<TJob extends Job>(
 
 function getPrebuildCommand(job: Job): string {
   let prebuildCommand =
-    job.experimental?.prebuildCommand ?? `prebuild --non-interactive --platform ${job.platform}`;
+    job.experimental?.prebuildCommand ??
+    `prebuild --non-interactive --no-install --platform ${job.platform}`;
   if (!prebuildCommand.match(/(?:--platform| -p)/)) {
     prebuildCommand = `${prebuildCommand} --platform ${job.platform}`;
   }


### PR DESCRIPTION
# Why

When refactoring eject provider I missed `--no-install` option

# How

add `--no-install` options

# Test Plan

not tested
