### PR TITLE
[build-tools] fix missing signingConfigs error

### DIFF
--- a/packages/build-tools/templates/eas-build.gradle
+++ b/packages/build-tools/templates/eas-build.gradle
@@ -21,6 +21,10 @@ android {
 }
 
 tasks.whenTaskAdded {
+  // when using com.android.tools.build:gradle:7.0.4 signingConfigs is not defined while task :app:lintAnalyzeDebug is executed
+  if (android.hasProperty('signingConfigs') == null) {
+    return
+  }
   android.signingConfigs.release {
     def credentialsJson = rootProject.file("../credentials.json");
     def credentials = new groovy.json.JsonSlurper().parse(credentialsJson)

--- a/packages/build-tools/templates/eas-build.gradle
+++ b/packages/build-tools/templates/eas-build.gradle
@@ -5,51 +5,32 @@ import java.nio.file.Paths
 android {
   signingConfigs {
     release {
-      // This is necessary to avoid needing the user to define a release signing config manually
-      // If no release config is defined, and this is not present, build for assembleRelease will crash
+      def credentialsJson = rootProject.file("../credentials.json");
+      def credentials = new groovy.json.JsonSlurper().parse(credentialsJson)
+      def keystorePath = Paths.get(credentials.android.keystore.keystorePath);
+      def storeFilePath = keystorePath.isAbsolute()
+        ? keystorePath
+        : rootProject.file("..").toPath().resolve(keystorePath);
+
+      storeFile storeFilePath.toFile()
+      storePassword credentials.android.keystore.keystorePassword
+      keyAlias credentials.android.keystore.keyAlias
+      if (credentials.android.keystore.containsKey("keyPassword")) {
+        keyPassword credentials.android.keystore.keyPassword
+      } else {
+        // key password is required by Gradle, but PKCS keystores don't have one
+        // using the keystore password seems to satisfy the requirement
+        keyPassword credentials.android.keystore.keystorePassword
+      }
     }
   }
 
   buildTypes {
     release {
-      // This is necessary to avoid needing the user to define a release build type manually
+      signingConfig android.signingConfigs.release
     }
     debug {
-      // This is necessary to avoid needing the user to define a debug build type manually
+      signingConfig android.signingConfigs.release
     }
-  }
-}
-
-tasks.whenTaskAdded {
-  // when using com.android.tools.build:gradle:7.0.4 signingConfigs is not defined while task :app:lintAnalyzeDebug is executed
-  if (android.hasProperty('signingConfigs') == null) {
-    return
-  }
-  android.signingConfigs.release {
-    def credentialsJson = rootProject.file("../credentials.json");
-    def credentials = new groovy.json.JsonSlurper().parse(credentialsJson)
-    def keystorePath = Paths.get(credentials.android.keystore.keystorePath);
-    def storeFilePath = keystorePath.isAbsolute()
-      ? keystorePath
-      : rootProject.file("..").toPath().resolve(keystorePath);
-
-    storeFile storeFilePath.toFile()
-    storePassword credentials.android.keystore.keystorePassword
-    keyAlias credentials.android.keystore.keyAlias
-    if (credentials.android.keystore.containsKey("keyPassword")) {
-      keyPassword credentials.android.keystore.keyPassword
-    } else {
-      // key password is required by Gradle, but PKCS keystores don't have one
-      // using the keystore password seems to satisfy the requirement
-      keyPassword credentials.android.keystore.keystorePassword
-    }
-  }
-
-  android.buildTypes.release {
-    signingConfig android.signingConfigs.release
-  }
-
-  android.buildTypes.debug {
-    signingConfig android.signingConfigs.release
   }
 }


### PR DESCRIPTION
# Why

https://github.com/expo/eas-cli/issues/1040 gradle tools 7.1.2 (does not allow to override keystore after project is evaluated)
https://github.com/expo/eas-cli/issues/1037 gradle tools 7.0.4(does not allow to override keystore after some specific task)

# How

this is potentially breaking change for older version of gradle tools if someone has code that is overriding keystore config as part of a gradle task

Context, why `whenTaskAdded` was used https://github.com/expo/expo-cli/pull/2833/files

# Test Plan

run build with `expo init` and `react-native init` projects using gradle tools 7.1.2, 7.0.4, and 4.1.0
