### PR TITLE
[eas-build-job] Remove xcode 12.5  from default images

### DIFF
--- a/packages/eas-build-job/src/ios.ts
+++ b/packages/eas-build-job/src/ios.ts
@@ -50,9 +50,7 @@ export const builderBaseImages = [
 ] as const;
 
 export const sdkVersionToDefaultBuilderImage: Record<string, typeof builderBaseImages[number]> = {
-  '<=42': 'macos-big-sur-11.4-xcode-12.5',
-  '43': 'macos-big-sur-11.4-xcode-13.0',
-  '44': 'macos-big-sur-11.4-xcode-13.0',
+  '<=44': 'macos-big-sur-11.4-xcode-13.0',
   '45': 'macos-monterey-12.3-xcode-13.3',
 };
 


### PR DESCRIPTION
# Why

builds with xcode 12.5 are no longer accepted into appstore
