### PR TITLE
[ENG-4643][build-tools] detect warnings in expo doctor phase

### DIFF
--- a/packages/eas-build-job/src/logs.ts
+++ b/packages/eas-build-job/src/logs.ts
@@ -37,6 +37,13 @@ export enum BuildPhase {
   PRE_UPLOAD_ARTIFACTS_HOOK = 'PRE_UPLOAD_ARTIFACTS_HOOK',
 }
 
+export enum BuildPhaseResult {
+  SUCCESS = 'success',
+  FAIL = 'failed',
+  WARNING = 'warning',
+  UNKNOWN = 'unknown',
+}
+
 export enum LogMarker {
   START_PHASE = 'START_PHASE',
   END_PHASE = 'END_PHASE',


### PR DESCRIPTION
# Why

https://linear.app/expo/issue/ENG-4643/improve-error-reporting-for-expo-doctor-phase

We don't fail builds for which the expo doctor phase has warnings. On the website, we don't have a way of showing the user that a build phase has warnings. 

This PR introduces a mechanism so that we can mark that a build phase has warnings. This can be used on the website to use e.g. a different icon of the build phase.

# How

- Introduce `.markBuildPhaseHasWarnings()` method to the build context class.
- Introduce `BuildPhaseResult` enum with new value - `warning`.
- Check if there is `Didn't find any issues with the project` in the `expo doctor` output. Call `markBuildPhaseHasWarnings` if it's missing. It's not the best way to detect this, I'll follow up on this in the `expo-cli` repo as this is currently the best we can do.
# Test Plan

I ran 2 builds using the `eas build --local` feature:
- one that had errors for `expo doctor`
- another without errors in `expo doctor`

Both times, a correct build phase result was set.