### PR TITLE
[eas-build-job] build timeout should be server error

### DIFF
--- a/packages/eas-build-job/src/errors.ts
+++ b/packages/eas-build-job/src/errors.ts
@@ -48,6 +48,15 @@ export class ServerError extends UserError {
     'Internal Server Error.\nPlease try again later. If the problem persists, please report the issue.';
 }
 
+export class BuildTimeout extends ServerError {
+  constructor(maxBuildTimeMs: number) {
+    super();
+    this.message = `Your build has exceeded the maximum build time of ${
+      maxBuildTimeMs / (60 * 1000)
+    } minutes.`;
+  }
+}
+
 export class CredentialsDistCertMismatchError extends UserError {
   errorCode = ErrorCode.CREDENTIALS_DIST_CERT_MISMATCH;
   message = "Provisioning profile and distribution certificate don't match.";
@@ -155,15 +164,4 @@ export class YarnLockChecksumError extends UserError {
 export class UnknownGradleError extends UserError {
   errorCode = ErrorCode.UNKNOWN_GRADLE_ERROR;
   message = 'Gradle build failed with unknown error. Please see logs for the "Run gradlew" phase.';
-}
-
-export class BuildTimeout extends UserError {
-  errorCode = ErrorCode.BUILD_TIMEOUT_ERROR;
-
-  constructor(maxBuildTimeMs: number) {
-    super();
-    this.message = `Your build has exceeded the maximum build time of ${
-      maxBuildTimeMs / (60 * 1000)
-    } minutes.`;
-  }
 }


### PR DESCRIPTION
# Why

https://github.com/expo/turtle-v2/blob/main/src/services/launcher/src/jobService.ts#L105

launcher duplicates all error messages(worker already prints that), I want to add conditions there, but to avoid checking for bunch of status codes  I want everything thrown in launcher to extend server error

# How


# Test Plan
