### PR TITLE
[build-tools] pass all eas envs to the install process

### DIFF
--- a/packages/build-tools/src/utils/hooks.ts
+++ b/packages/build-tools/src/utils/hooks.ts
@@ -1,12 +1,10 @@
-import path from 'path';
-
 import { Job } from '@expo/eas-build-job';
 import spawn from '@expo/turtle-spawn';
-import fs from 'fs-extra';
 
 import { BuildContext } from '../context';
 
-import { PackageManager, findPackagerRootDir, readPackageJson } from './packageManager';
+import { PackageManager, readPackageJson } from './packageManager';
+import { isUsingYarn2 } from './project';
 
 export enum Hook {
   PRE_INSTALL = 'eas-build-pre-install',
@@ -44,13 +42,4 @@ export async function runHookIfPresent<TJob extends Job>(
       env: ctx.env,
     });
   }
-}
-
-/**
- * check if .yarnrc.yml exists in the project dir or in the workspace root dir
- */
-async function isUsingYarn2(projectDir: string): Promise<boolean> {
-  const yarnrcPath = path.join(projectDir, '.yarnrc.yml');
-  const yarnrcRootPath = path.join(findPackagerRootDir(projectDir), '.yarnrc.yml');
-  return (await fs.pathExists(yarnrcPath)) || (await fs.pathExists(yarnrcRootPath));
 }


### PR DESCRIPTION
# Why

 pnpm and yarn2 do enforce immutable lockfiles by default if CI env is present, it looks like some users relied on that value
 https://linear.app/expo/issue/ENG-5009/missing-env-vars-in-install-dependencies-step
 
# How

- Pass all envs we use in EAS_BUILD on install process
- allow mutable install using command line args
- print args that we are passing to command

# Test Plan

tested with yarn2  via local build 
verified pnpm behavior by running with option `--no-frozen-lockfile` and `CI` env set
