### PR TITLE
[build-tools] disable sharp on expo-cli >= 5.4.4

### DIFF
--- a/packages/build-tools/package.json
+++ b/packages/build-tools/package.json
@@ -33,7 +33,8 @@
     "fs-extra": "^10.0.1",
     "node-forge": "^1.2.1",
     "nullthrows": "^1.1.1",
-    "plist": "^3.0.1"
+    "plist": "^3.0.1",
+    "semver": "^7.3.7"
   },
   "devDependencies": {
     "@types/fs-extra": "^9.0.13",
@@ -41,6 +42,7 @@
     "@types/node": "^16.11.26",
     "@types/node-forge": "^1.0.1",
     "@types/plist": "^3.0.2",
+    "@types/semver": "^7.3.9",
     "@types/uuid": "^3.4.5",
     "@types/xml2js": "^0.4.5",
     "jest": "^27.5.1",

--- a/packages/build-tools/src/utils/prebuild.ts
+++ b/packages/build-tools/src/utils/prebuild.ts
@@ -1,5 +1,6 @@
 import { Job } from '@expo/eas-build-job';
 import { SpawnOptions } from '@expo/turtle-spawn';
+import semver from 'semver';
 
 import { BuildContext } from '../context';
 
@@ -13,10 +14,15 @@ export async function prebuildAsync<TJob extends Job>(
   ctx: BuildContext<TJob>,
   options?: PrebuildOptions
 ): Promise<void> {
+  const customExpoCliVersion = ctx.job.builderEnvironment?.expoCli;
+  const shouldDisableSharp =
+    !customExpoCliVersion || semver.satisfies(customExpoCliVersion, '>=5.4.4');
+
   const spawnOptions: SpawnOptions = {
     cwd: ctx.reactNativeProjectDirectory,
     logger: ctx.logger,
     env: {
+      ...(shouldDisableSharp ? { EXPO_IMAGE_UTILS_NO_SHARP: '1' } : {}),
       ...options?.extraEnvs,
       ...ctx.env,
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2388,6 +2388,11 @@
   resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.3.4.tgz#43d7168fec6fa0988bb1a513a697b29296721afb"
   integrity sha512-+nVsLKlcUCeMzD2ufHEYuJ9a2ovstb6Dp52A5VsoKxDXgvE051XgHI/33I1EymwkRGQkwnA0LkhnUzituGs4EQ==
 
+"@types/semver@^7.3.9":
+  version "7.3.9"
+  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.3.9.tgz#152c6c20a7688c30b967ec1841d31ace569863fc"
+  integrity sha512-L/TMpyURfBkf+o/526Zb6kd/tchUP3iBDEPjqjb+U2MAJhVRxxrmr2fwpe08E7QsV7YLcpq0tUaQ9O9x97ZIxQ==
+
 "@types/source-list-map@*":
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/@types/source-list-map/-/source-list-map-0.1.2.tgz#0078836063ffaf17412349bba364087e0ac02ec9"
@@ -12296,6 +12301,13 @@ semver@^6.0.0, semver@^6.1.0, semver@^6.1.1, semver@^6.2.0, semver@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
+
+semver@^7.3.7:
+  version "7.3.7"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.7.tgz#12c5b649afdbf9049707796e22a4028814ce523f"
+  integrity sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==
+  dependencies:
+    lru-cache "^6.0.0"
 
 send@0.16.2:
   version "0.16.2"


### PR DESCRIPTION
# Why

https://linear.app/expo/issue/ENG-4967/update-to-expo-cli-544-and-disable-sharp-on-ios-xcode-133-image

# How

If the custom value is not specified or specified value is higher than 5.4.4 disable sharp
- for cloud builds default version will be higher than 5.4.4 so we can disable it
- for cloud builds with a custom expo-cli version we know the version based on job field
- for local build with the default version we are bundling that version with local build plugin (so version will be at least 5.4.4)
- custom values in eas.json are ignored when building locally (so version will be at least 5.4.4)
- we are not handling the case where users run local build and specifies path to expo-cli via env

# Test Plan

