### PR TITLE
detect and report corupted packages

### DIFF
--- a/packages/build-tools/src/context.ts
+++ b/packages/build-tools/src/context.ts
@@ -96,7 +96,15 @@ export class BuildContext<TJob extends Job> {
   public async runBuildPhase<T>(
     buildPhase: BuildPhase,
     phase: () => Promise<T>,
-    { doNotMarkStart = false, doNotMarkEnd = false } = {}
+    {
+      doNotMarkStart = false,
+      doNotMarkEnd = false,
+      onError,
+    }: {
+      doNotMarkStart?: boolean;
+      doNotMarkEnd?: boolean;
+      onError?: (err: Error) => void;
+    } = {}
   ): Promise<T> {
     try {
       this.setBuildPhase(buildPhase, { doNotMarkStart });
@@ -125,6 +133,9 @@ export class BuildContext<TJob extends Job> {
       } else {
         // leaving message empty, website will display err.stack which already includes err.message
         this.logger.error({ err }, '');
+      }
+      if (onError) {
+        onError(userError ?? err);
       }
       this.endCurrentBuildPhase({ result: BuildPhaseResult.FAIL });
       throw userError ?? err;

--- a/packages/build-tools/src/utils/detectUserError.ts
+++ b/packages/build-tools/src/utils/detectUserError.ts
@@ -112,6 +112,18 @@ const errorHandlers: ErrorHandler[] = [
     },
   },
   {
+    phase: BuildPhase.INSTALL_DEPENDENCIES,
+    // example log:
+    // [stderr] WARN tarball tarball data for @typescript-eslint/typescript-estree@5.26.0 (sha512-cozo/GbwixVR0sgfHItz3t1yXu521yn71Wj6PlYCFA3WPhy51CUPkifFKfBis91bDclGmAY45hhaAXVjdn4new==) seems to be corrupted. Trying again.
+    regexp: /tarball tarball data for ([^ ]*) .* seems to be corrupted. Trying again/,
+    createError: (matchResult: RegExpMatchArray) => {
+      if (matchResult.length >= 2) {
+        return new errors.NpmCorruptedPackageError(matchResult[1]);
+      }
+      return undefined;
+    },
+  },
+  {
     platform: Platform.ANDROID,
     phase: BuildPhase.RUN_GRADLEW,
     regexp: /.*/,

--- a/packages/eas-build-job/src/errors.ts
+++ b/packages/eas-build-job/src/errors.ts
@@ -12,6 +12,7 @@ export enum ErrorCode {
   INCOMPATIBLE_PODS_MANAGED_WORKFLOW_ERROR = 'EAS_BUILD_INCOMPATIBLE_PODS_MANAGED_WORKFLOW_ERROR',
   INCOMPATIBLE_PODS_GENERIC_WORKFLOW_ERROR = 'EAS_BUILD_INCOMPATIBLE_PODS_GENERIC_WORKFLOW_ERROR',
   YARN_LOCK_CHECKSUM_ERROR = 'EAS_BUILD_YARN_LOCK_CHECKSUM_ERROR',
+  NPM_PACKAGE_CORRUPTED_ERROR = 'NPM_PACKAGE_CORRUPTED_ERROR',
   UNKNOWN_FASTLANE_ERROR = 'EAS_BUILD_UNKNOWN_FASTLANE_ERROR',
   UNKNOWN_GRADLE_ERROR = 'EAS_BUILD_UNKNOWN_GRADLE_ERROR',
   BUILD_TIMEOUT_ERROR = 'EAS_BUILD_TIMEOUT_ERROR',
@@ -124,8 +125,8 @@ export class IncompatiblePodsManagedWorkflowError extends UserError {
 You are seeing this error because either:
   - Versions in the Podfile.lock cached by EAS do not match required values for some of the libraries, it can be triggered when upgrading Expo SDK or any other library with native code. To fix that ${
     usingDefaultCacheConfig
-      ? 'add the "cache.key" field (it can be set to any value) in eas.json to invalidate the cache.'
-      : 'update value of the "cache.key" field in eas.json to invalidate the cache.'
+      ? 'add the "cache.key" field (it can be set to any value) in the build profile in eas.json to invalidate the cache.'
+      : 'update value of the "cache.key" field in the build profile in eas.json to invalidate the cache.'
   }
   - Some of your npm packages have native code that depend on different versions of the same pod. Please see logs for more info.
 `;
@@ -141,8 +142,8 @@ export class IncompatiblePodsGenericWorkflowError extends UserError {
 You are seeing this error because either:
   - Versions in the Podfile.lock cached by EAS do not match required values in Podspecs of some of the libraries. To fix that ${
     usingDefaultCacheConfig
-      ? 'add the "cache.key" field (it can be set to any value) in eas.json to invalidate the cache.'
-      : 'update value of the "cache.key" field in eas.json to invalidate the cache.'
+      ? 'add the "cache.key" field (it can be set to any value) in the build profile in eas.json to invalidate the cache.'
+      : 'update value of the "cache.key" field in the build profile in eas.json to invalidate the cache.'
   }
   - Some of the pods used in your project depend on different versions of the same pod. Please see logs for more info.
 `;
@@ -158,6 +159,15 @@ export class YarnLockChecksumError extends UserError {
 - run "yarn cache clean"
 - remove yarn.lock (or only the section for that package)
 - run "yarn install --force"`;
+  }
+}
+
+export class NpmCorruptedPackageError extends UserError {
+  errorCode = ErrorCode.NPM_PACKAGE_CORRUPTED_ERROR;
+
+  constructor(packageName: string) {
+    super();
+    this.message = `Package ${packageName} is corrupted, try switching to public npm registry by adding ("eas-build-pre-install": "npm config set registry https://registry.npmjs.org/") in the "scripts" section in package.json. If this resolves the issue please report it as a bug.`;
   }
 }
 


### PR DESCRIPTION
# Why

Occasionally I have seen reports where the error suggests that there is a problem with corrupted packages in npm caches. One recent issue I was able to reproduce, in that case file returned by verdaccio was correct, but the checksum reported by verdacio API was not.

I'm adding this monitoring to help with monitoring the issues, and as way to provide quick workaround for users that hit those issues 

# How

- detect error based on logs and throw custom error
- add onError callback to runBuildPhase
- report erro to sentry

# Test Plan

will test on turtle
