### PR TITLE
mark build phases with warnings

### DIFF
--- a/packages/build-tools/src/builders/ios.ts
+++ b/packages/build-tools/src/builders/ios.ts
@@ -129,6 +129,7 @@ async function readEntitlementsAsync(
     return plist.parse(entitlementsRaw);
   } catch (err) {
     ctx.logger.warn({ err }, 'Failed to read entitlements');
+    ctx.markBuildPhaseHasWarnings();
     return null;
   }
 }

--- a/packages/build-tools/src/utils/expoUpdates.ts
+++ b/packages/build-tools/src/utils/expoUpdates.ts
@@ -132,6 +132,7 @@ export const configureExpoUpdatesIfInstalledAsync = async (
 
   const appConfigRuntimeVersion = getRuntimeVersionNullable(ctx.appConfig, ctx.job.platform);
   if (ctx.metadata?.runtimeVersion && ctx.metadata?.runtimeVersion !== appConfigRuntimeVersion) {
+    ctx.markBuildPhaseHasWarnings();
     ctx.logger.warn(
       `Runtime version from the app config evaluated on your local machine (${ctx.metadata.runtimeVersion}) does not match the one resolved here (${appConfigRuntimeVersion}).`
     );

--- a/packages/build-tools/src/utils/hooks.ts
+++ b/packages/build-tools/src/utils/hooks.ts
@@ -26,6 +26,7 @@ export async function runHookIfPresent<TJob extends Job>(
     packageJson = await readPackageJson(projectDir);
   } catch (err: any) {
     ctx.logger.warn(`Failed to parse or read package.json: ${err.message}`);
+    ctx.markBuildPhaseHasWarnings();
     return;
   }
   if (packageJson.scripts?.[hook]) {


### PR DESCRIPTION
# Why

There are few places were we are not failing the build, but user could use some visual warning

