### PR TITLE
[build-tools] Try detect bundler errors in logs

### DIFF
--- a/packages/build-tools/package.json
+++ b/packages/build-tools/package.json
@@ -28,7 +28,7 @@
     "@expo/plist": "^0.0.11",
     "@expo/template-file": "0.1.21",
     "@expo/turtle-spawn": "0.0.23",
-    "@expo/xcpretty": "^4.1.1",
+    "@expo/xcpretty": "4.1.3",
     "fast-glob": "^3.2.5",
     "fs-extra": "^10.0.1",
     "node-forge": "^1.2.1",

--- a/packages/build-tools/src/ios/xcpretty.ts
+++ b/packages/build-tools/src/ios/xcpretty.ts
@@ -1,6 +1,7 @@
 import assert from 'assert';
 import path from 'path';
 
+import fs from 'fs-extra';
 import { bunyan } from '@expo/logger';
 import { ExpoRunFormatter } from '@expo/xcpretty';
 import spawnAsync, { SpawnPromise, SpawnResult } from '@expo/spawn-async';
@@ -12,6 +13,7 @@ export class XcodeBuildLogger {
   private loggerError?: Error;
   private flushing: boolean = false;
   private logReaderPromise?: SpawnPromise<SpawnResult>;
+  private logsPath?: string;
 
   constructor(private readonly logger: bunyan, private readonly projectRoot: string) {}
 
@@ -19,7 +21,8 @@ export class XcodeBuildLogger {
     while (!this.flushing) {
       const logsFilename = await this.getBuildLogFilename(logsDirectory);
       if (logsFilename) {
-        void this.startBuildLogger(path.join(logsDirectory, logsFilename));
+        this.logsPath = path.join(logsDirectory, logsFilename);
+        void this.startBuildLogger(this.logsPath);
         return;
       }
       await new Promise((res) => setTimeout(res, CHECK_FILE_INTERVAL_MS));
@@ -36,6 +39,9 @@ export class XcodeBuildLogger {
       try {
         await this.logReaderPromise;
       } catch {}
+    }
+    if (this.logsPath) {
+      await this.findBundlerErrors(this.logsPath);
     }
   }
   private async getBuildLogFilename(logsDirectory: string): Promise<string | undefined> {
@@ -64,6 +70,20 @@ export class XcodeBuildLogger {
       if (!this.flushing) {
         this.loggerError = err;
       }
+    }
+  }
+
+  private async findBundlerErrors(logsPath: string): Promise<void> {
+    try {
+      const logFile = await fs.readFile(logsPath, 'utf-8');
+      const match = logFile.match(
+        /Welcome to Metro!\s* Fast - Scalable - Integrated\s*([\s\S]*)Run CLI with --verbose flag for more details.\nCommand PhaseScriptExecution failed with a nonzero exit code/
+      );
+      if (match) {
+        this.logger.info(match[1]);
+      }
+    } catch (err) {
+      this.logger.error({ err }, 'Failed to read xcode logs');
     }
   }
 }

--- a/packages/build-tools/src/ios/xcpretty.ts
+++ b/packages/build-tools/src/ios/xcpretty.ts
@@ -83,7 +83,7 @@ export class XcodeBuildLogger {
         this.logger.info(match[1]);
       }
     } catch (err) {
-      this.logger.error({ err }, 'Failed to read xcode logs');
+      this.logger.error({ err }, 'Failed to read Xcode logs');
     }
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -945,20 +945,20 @@
     webpack-dev-server "3.11.0"
     webpack-manifest-plugin "~2.2.0"
 
-"@expo/xcpretty@^4.1.0":
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/@expo/xcpretty/-/xcpretty-4.1.0.tgz#63a1b54635f1e67250bfe74d58f25d2b52c5818a"
-  integrity sha512-Q2FCVFpMEeWk2oxEx3nFg2AAwyzPdSAOVWa25f734+qCL9szL7sj20a53q4QH1T52BaGvdLoBaq/cNNCA5SzRg==
+"@expo/xcpretty@4.1.3":
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/@expo/xcpretty/-/xcpretty-4.1.3.tgz#cbe04f654571c0ee733dbe729d5593b3bcfbf487"
+  integrity sha512-testj0jpEe1IwRfnmQ3shizTXOY6IGcuMJg1vtmXy2bC9sPTLK1wjliRJp2xCJGcp1ZbEA1/eptzX+6MDnYjrA==
   dependencies:
     "@babel/code-frame" "7.10.4"
     chalk "^4.1.0"
     find-up "^5.0.0"
     js-yaml "^4.1.0"
 
-"@expo/xcpretty@^4.1.1":
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/@expo/xcpretty/-/xcpretty-4.1.1.tgz#9a15e015169bb4247a74c0d45dbcee60dd418d3f"
-  integrity sha512-2ssiyKGjgRUn61MSdSQyptV5lq1BtaT1DX80OjnCLvg+tXxIp2MVLZASSNqYqo8gQotghv35EpVrWBmOxMFuoQ==
+"@expo/xcpretty@^4.1.0":
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/@expo/xcpretty/-/xcpretty-4.1.0.tgz#63a1b54635f1e67250bfe74d58f25d2b52c5818a"
+  integrity sha512-Q2FCVFpMEeWk2oxEx3nFg2AAwyzPdSAOVWa25f734+qCL9szL7sj20a53q4QH1T52BaGvdLoBaq/cNNCA5SzRg==
   dependencies:
     "@babel/code-frame" "7.10.4"
     chalk "^4.1.0"


### PR DESCRIPTION
# Why

Often users do not know how to find js errors in xcode logs

# How

after build check for section starting with
```
                    Welcome to Metro!
              Fast - Scalable - Integrated
```
and ending with 
```
info Run CLI with --verbose flag for more details.
Command PhaseScriptExecution failed with a nonzero exit code
```

# Test Plan

tested with local build

![20220527_14h17m54s_grim](https://user-images.githubusercontent.com/9753141/170697946-92c541b9-e4b2-4e94-b5bf-6fcf11855ef0.png)
