### PR TITLE
detect when multiple yarn installs interfere with each other

### DIFF
--- a/packages/build-tools/src/utils/detectUserError.ts
+++ b/packages/build-tools/src/utils/detectUserError.ts
@@ -114,6 +114,23 @@ const errorHandlers: ErrorHandler[] = [
   {
     phase: BuildPhase.INSTALL_DEPENDENCIES,
     // example log:
+    // yarn install v1.22.17
+    // [1/4] Resolving packages...
+    // [2/4] Fetching packages...
+    // [1/4] Resolving packages...
+    // [2/4] Fetching packages...
+    // [stderr] error https://registry.yarnpkg.com/jest-util/-/jest-util-26.6.2.tgz: Extracting tar content of undefined failed, the file appears to be corrupt: "ENOENT: no such file or directory, chmod '/Users/expo/Library/Caches/Yarn/v6/npm-jest-util-26.6.2-907535dbe4d5a6cb4c47ac9b926f6af29576cbc1-integrity/node_modules/jest-util/build/pluralize.d.ts'"
+    regexp: /\[1\/4\] Resolving packages...\s*\[2\/4\] Fetching packages...\s*\[1\/4\] Resolving packages...\s*\[2\/4\] Fetching packages.../,
+    createError: (matchResult: RegExpMatchArray) => {
+      if (matchResult) {
+        return new errors.YarnMultipleInstancesError();
+      }
+      return undefined;
+    },
+  },
+  {
+    phase: BuildPhase.INSTALL_DEPENDENCIES,
+    // example log:
     // [stderr] WARN tarball tarball data for @typescript-eslint/typescript-estree@5.26.0 (sha512-cozo/GbwixVR0sgfHItz3t1yXu521yn71Wj6PlYCFA3WPhy51CUPkifFKfBis91bDclGmAY45hhaAXVjdn4new==) seems to be corrupted. Trying again.
     regexp: /tarball tarball data for ([^ ]*) .* seems to be corrupted. Trying again/,
     createError: (matchResult: RegExpMatchArray) => {

--- a/packages/eas-build-job/src/errors.ts
+++ b/packages/eas-build-job/src/errors.ts
@@ -12,7 +12,8 @@ export enum ErrorCode {
   INCOMPATIBLE_PODS_MANAGED_WORKFLOW_ERROR = 'EAS_BUILD_INCOMPATIBLE_PODS_MANAGED_WORKFLOW_ERROR',
   INCOMPATIBLE_PODS_GENERIC_WORKFLOW_ERROR = 'EAS_BUILD_INCOMPATIBLE_PODS_GENERIC_WORKFLOW_ERROR',
   YARN_LOCK_CHECKSUM_ERROR = 'EAS_BUILD_YARN_LOCK_CHECKSUM_ERROR',
-  NPM_PACKAGE_CORRUPTED_ERROR = 'NPM_PACKAGE_CORRUPTED_ERROR',
+  YARN_MULTIPLE_INSTANCES_ERROR = 'EAS_BUILD_YARN_MULTIPLE_INSTANCES_ERROR',
+  NPM_PACKAGE_CORRUPTED_ERROR = 'EAS_BUILD_NPM_PACKAGE_CORRUPTED_ERROR',
   UNKNOWN_FASTLANE_ERROR = 'EAS_BUILD_UNKNOWN_FASTLANE_ERROR',
   UNKNOWN_GRADLE_ERROR = 'EAS_BUILD_UNKNOWN_GRADLE_ERROR',
   BUILD_TIMEOUT_ERROR = 'EAS_BUILD_TIMEOUT_ERROR',
@@ -147,6 +148,15 @@ You are seeing this error because either:
   }
   - Some of the pods used in your project depend on different versions of the same pod. Please see logs for more info.
 `;
+  }
+}
+
+export class YarnMultipleInstancesError extends UserError {
+  errorCode = ErrorCode.YARN_MULTIPLE_INSTANCES_ERROR;
+
+  constructor() {
+    super();
+    this.message = `One of project dependencies is starting new install process while the main one is still in progress, which might result in corrupted packages. Most likely the reason for error is "prepare" script in git-referenced dependency of your project. Learn more: https://github.com/yarnpkg/yarn/issues/7212#issuecomment-493720324`;
   }
 }
 


### PR DESCRIPTION
# Why

Misconfigured git dependencies might cause hard to debug issues when yarn is triggered twice during install
https://github.com/yarnpkg/yarn/issues/7212#issuecomment-493720324

# How



# Test Plan

tested regexp in console on example output
