### PR TITLE
[1/1] Support resource-flag in eas-build-job

### DIFF
--- a/packages/build-tools/src/ios/credentials/__tests__/manager.test.ios.ts
+++ b/packages/build-tools/src/ios/credentials/__tests__/manager.test.ios.ts
@@ -1,7 +1,13 @@
 import assert from 'assert';
 
 import { createLogger } from '@expo/logger';
-import { Ios, Workflow, ArchiveSourceType, Platform } from '@expo/eas-build-job';
+import {
+  Ios,
+  Workflow,
+  ArchiveSourceType,
+  Platform,
+  BuildResourceClass,
+} from '@expo/eas-build-job';
 
 import { BuildContext } from '../../../context';
 import { distributionCertificate, provisioningProfile } from '../__tests__/fixtures';
@@ -28,6 +34,7 @@ function createTestIosJob({
 } = {}): Ios.Job {
   return {
     platform: Platform.IOS,
+    buildResourceClass: BuildResourceClass.IOS_LARGE,
     type: Workflow.GENERIC,
     projectArchive: {
       type: ArchiveSourceType.URL,

--- a/packages/eas-build-job/src/__tests__/android.test.ts
+++ b/packages/eas-build-job/src/__tests__/android.test.ts
@@ -1,7 +1,7 @@
 import Joi from 'joi';
 
 import * as Android from '../android';
-import { ArchiveSourceType, Platform, Workflow } from '../common';
+import { ArchiveSourceType, Platform, Workflow, BuildResourceClass } from '../common';
 
 const joiOptions: Joi.ValidationOptions = {
   stripUnknown: true,
@@ -25,6 +25,7 @@ describe('Android.JobSchema', () => {
     const genericJob = {
       secrets,
       platform: Platform.ANDROID,
+      buildResourceClass: BuildResourceClass.ANDROID_LARGE,
       type: Workflow.GENERIC,
       projectArchive: {
         type: ArchiveSourceType.URL,
@@ -54,6 +55,7 @@ describe('Android.JobSchema', () => {
     const genericJob = {
       secrets,
       platform: Platform.ANDROID,
+      buildResourceClass: BuildResourceClass.ANDROID_LARGE,
       type: Workflow.GENERIC,
       projectArchive: {
         type: ArchiveSourceType.URL,
@@ -77,6 +79,7 @@ describe('Android.JobSchema', () => {
     const managedJob = {
       secrets,
       platform: Platform.ANDROID,
+      buildResourceClass: BuildResourceClass.ANDROID_LARGE,
       type: Workflow.MANAGED,
       buildType: Android.BuildType.APP_BUNDLE,
       username: 'turtle-tutorial',
@@ -106,6 +109,7 @@ describe('Android.JobSchema', () => {
     const managedJob = {
       secrets,
       platform: Platform.ANDROID,
+      buildResourceClass: BuildResourceClass.ANDROID_LARGE,
       type: Workflow.MANAGED,
       buildType: Android.BuildType.APP_BUNDLE,
       username: 3,
@@ -136,6 +140,7 @@ describe('Android.JobSchema', () => {
         url: 'http://localhost:3000',
       },
       projectRootDirectory: '.',
+      buildResourceClass: BuildResourceClass.ANDROID_LARGE,
     };
 
     const { value, error } = Android.JobSchema.validate(managedJob, joiOptions);
@@ -156,6 +161,7 @@ describe('Android.JobSchema', () => {
         url: 'http://localhost:3000',
       },
       projectRootDirectory: '.',
+      buildResourceClass: BuildResourceClass.ANDROID_LARGE,
     };
 
     const { error } = Android.JobSchema.validate(managedJob, joiOptions);

--- a/packages/eas-build-job/src/__tests__/ios.test.ts
+++ b/packages/eas-build-job/src/__tests__/ios.test.ts
@@ -1,7 +1,7 @@
 import Joi from 'joi';
 
 import * as Ios from '../ios';
-import { ArchiveSourceType, Platform, Workflow } from '../common';
+import { ArchiveSourceType, IosResourceClass, Platform, Workflow } from '../common';
 
 const joiOptions: Joi.ValidationOptions = {
   stripUnknown: true,
@@ -25,6 +25,7 @@ describe('Ios.JobSchema', () => {
       secrets: {
         buildCredentials,
       },
+      buildResourceClass: IosResourceClass.IOS_DEFAULT,
       type: Workflow.GENERIC,
       platform: Platform.IOS,
       projectArchive: {
@@ -66,6 +67,7 @@ describe('Ios.JobSchema', () => {
       },
       projectRootDirectory: '.',
       uknownField: 'field',
+      buildResourceClass: IosResourceClass.IOS_DEFAULT,
     };
 
     const { value, error } = Ios.JobSchema.validate(genericJob, joiOptions);
@@ -97,6 +99,7 @@ describe('Ios.JobSchema', () => {
           ENV_VAR: '123',
         },
       },
+      buildResourceClass: IosResourceClass.IOS_DEFAULT,
     };
 
     const { value, error } = Ios.JobSchema.validate(managedJob, joiOptions);
@@ -117,6 +120,7 @@ describe('Ios.JobSchema', () => {
       },
       projectRootDirectory: 312,
       uknownField: 'field',
+      buildResourceClass: IosResourceClass.IOS_DEFAULT,
     };
 
     const { value, error } = Ios.JobSchema.validate(managedJob, joiOptions);
@@ -140,6 +144,7 @@ describe('Ios.JobSchema', () => {
         url: 'http://localhost:3000',
       },
       projectRootDirectory: '.',
+      buildResourceClass: IosResourceClass.IOS_DEFAULT,
     };
 
     const { value, error } = Ios.JobSchema.validate(managedJob, joiOptions);
@@ -161,6 +166,7 @@ describe('Ios.JobSchema', () => {
         type: ArchiveSourceType.URL,
         url: 'http://localhost:3000',
       },
+      buildResourceClass: IosResourceClass.IOS_DEFAULT,
       projectRootDirectory: '.',
     };
 

--- a/packages/eas-build-job/src/android.ts
+++ b/packages/eas-build-job/src/android.ts
@@ -9,6 +9,7 @@ import {
   Workflow,
   Cache,
   CacheSchema,
+  AndroidResourceClass,
 } from './common';
 
 export interface Keystore {
@@ -84,6 +85,7 @@ export interface Job {
     environmentSecrets?: Env;
   };
   builderEnvironment?: BuilderEnvironment;
+  buildResourceClass: AndroidResourceClass;
   cache: Cache;
   developmentClient?: boolean;
 
@@ -116,6 +118,10 @@ export const JobSchema = Joi.object({
     environmentSecrets: EnvSchema,
   }).required(),
   builderEnvironment: BuilderEnvironmentSchema,
+  buildResourceClass: Joi.string()
+    .valid(...Object.values(AndroidResourceClass))
+    .default(AndroidResourceClass.ANDROID_DEFAULT)
+    .required(),
   cache: CacheSchema.default(),
   developmentClient: Joi.boolean(),
 

--- a/packages/eas-build-job/src/common.ts
+++ b/packages/eas-build-job/src/common.ts
@@ -16,6 +16,19 @@ export enum ArchiveSourceType {
   PATH = 'PATH',
 }
 
+export enum AndroidResourceClass {
+  ANDROID_DEFAULT = 'ANDROID_DEFAULT',
+  ANDROID_LARGE = 'ANDROID_LARGE',
+}
+
+export enum IosResourceClass {
+  IOS_DEFAULT = 'IOS_DEFAULT',
+  IOS_LARGE = 'IOS_LARGE',
+  IOS_M1 = 'IOS_M1',
+}
+
+export const BuildResourceClass = { ...AndroidResourceClass, ...IosResourceClass };
+
 export type ArchiveSource =
   | { type: ArchiveSourceType.S3; bucketKey: string }
   | { type: ArchiveSourceType.URL; url: string }

--- a/packages/eas-build-job/src/index.ts
+++ b/packages/eas-build-job/src/index.ts
@@ -1,6 +1,14 @@
 export * as Android from './android';
 export * as Ios from './ios';
-export { ArchiveSourceType, ArchiveSource, Env, Workflow, Platform, Cache } from './common';
+export {
+  ArchiveSourceType,
+  ArchiveSource,
+  Env,
+  Workflow,
+  Platform,
+  Cache,
+  BuildResourceClass,
+} from './common';
 export { Job, sanitizeJob } from './job';
 export { Metadata, sanitizeMetadata } from './metadata';
 export * from './logs';

--- a/packages/eas-build-job/src/ios.ts
+++ b/packages/eas-build-job/src/ios.ts
@@ -9,6 +9,7 @@ import {
   Workflow,
   Cache,
   CacheSchema,
+  IosResourceClass,
 } from './common';
 
 export type DistributionType = 'store' | 'internal' | 'simulator';
@@ -80,6 +81,7 @@ const BuilderEnvironmentSchema = Joi.object({
 export interface Job {
   type: Workflow;
   projectArchive: ArchiveSource;
+  buildResourceClass: IosResourceClass;
   platform: Platform.IOS;
   projectRootDirectory: string;
   releaseChannel?: string;
@@ -122,6 +124,10 @@ export const JobSchema = Joi.object({
     environmentSecrets: EnvSchema,
   }).required(),
   builderEnvironment: BuilderEnvironmentSchema,
+  buildResourceClass: Joi.string()
+    .valid(...Object.values(IosResourceClass))
+    .required()
+    .default(IosResourceClass.IOS_DEFAULT),
   cache: CacheSchema.default(),
   developmentClient: Joi.boolean(),
   simulator: Joi.boolean(),


### PR DESCRIPTION
# Why
In order to support resource flags on EAS Build commands, we need to
make some modifications to the eas-build-job package.

# How
Add a new enum for BuildResourceClass that matches the enum created
for GraphQL in universe/server/www. Then use that enum to specify new
buildResourceClass attributes on JobSchema objects for both Android and
iOS.

# Test Plan
```
yarn test
```
See test plan on this PR for more thorough e2e testing summary: https://github.com/expo/universe/pull/9800