### PR TITLE
Use absolute path for credentials

### DIFF
--- a/packages/build-tools/src/android/credentials.ts
+++ b/packages/build-tools/src/android/credentials.ts
@@ -13,12 +13,8 @@ async function restoreCredentials(ctx: BuildContext<Android.Job>): Promise<void>
     throw new Error('secrets are missing in the job object');
   }
   ctx.logger.info("Writing secrets to the project's directory");
-  const projectDir = ctx.reactNativeProjectDirectory;
-  const keystorePath = `keystore-${uuidv4()}`;
-  await fs.writeFile(
-    path.join(projectDir, keystorePath),
-    Buffer.from(buildCredentials.keystore.dataBase64, 'base64')
-  );
+  const keystorePath = path.join(ctx.buildDirectory, `keystore-${uuidv4()}`);
+  await fs.writeFile(keystorePath, Buffer.from(buildCredentials.keystore.dataBase64, 'base64'));
   const credentialsJson = {
     android: {
       keystore: {
@@ -29,7 +25,10 @@ async function restoreCredentials(ctx: BuildContext<Android.Job>): Promise<void>
       },
     },
   };
-  await fs.writeFile(path.join(projectDir, 'credentials.json'), JSON.stringify(credentialsJson));
+  await fs.writeFile(
+    path.join(ctx.buildDirectory, 'credentials.json'),
+    JSON.stringify(credentialsJson)
+  );
 }
 
 export { restoreCredentials };

--- a/packages/build-tools/templates/eas-build.gradle
+++ b/packages/build-tools/templates/eas-build.gradle
@@ -26,14 +26,11 @@ android {
   }
   signingConfigs {
     release {
-      def credentialsJson = rootProject.file("../credentials.json");
+      def credentialsJson = Paths.get(System.getenv("EAS_BUILD_WORKINGDIR")).resolve("credentials.json").toFile();
       def credentials = new groovy.json.JsonSlurper().parse(credentialsJson)
       def keystorePath = Paths.get(credentials.android.keystore.keystorePath);
-      def storeFilePath = keystorePath.isAbsolute()
-        ? keystorePath
-        : rootProject.file("..").toPath().resolve(keystorePath);
 
-      storeFile storeFilePath.toFile()
+      storeFile keystorePath.toFile()
       storePassword credentials.android.keystore.keystorePassword
       keyAlias credentials.android.keystore.keyAlias
       if (credentials.android.keystore.containsKey("keyPassword")) {

--- a/packages/local-build-plugin/src/build.ts
+++ b/packages/local-build-plugin/src/build.ts
@@ -1,3 +1,5 @@
+import path from 'path';
+
 import { Job, Platform, ArchiveSourceType } from '@expo/eas-build-job';
 import pickBy from 'lodash/pickBy';
 import fs from 'fs-extra';
@@ -17,6 +19,7 @@ export async function buildAsync(job: Job): Promise<void> {
       ...pickBy(process.env, (val?: string): val is string => !!val),
       ...job.builderEnvironment?.env,
       EAS_BUILD: '1',
+      EAS_BUILD_WORKINGDIR: path.join(workingdir, 'build'),
     };
     let artifactPath: string | undefined;
     switch (job.platform) {


### PR DESCRIPTION
# Why

If an android directory is a symlink to a different location, resolving credentials.json might not work

# How

- use absolute paths
- define env that specifies the root of user repo( and place credentials.json and keystore there(in old behavior it was placed in a directory with eas.json)

# Test Plan

run local build
