### PR TITLE
[ENG-5837][build-tools][local-plugin] use local CLI for prebuild in SDK 46+

### DIFF
--- a/packages/build-tools/src/context.ts
+++ b/packages/build-tools/src/context.ts
@@ -13,7 +13,6 @@ import { ExpoConfig } from '@expo/config';
 import { bunyan } from '@expo/logger';
 import { SpawnPromise, SpawnOptions, SpawnResult } from '@expo/turtle-spawn';
 
-import { readPackageJson } from './utils/project';
 import { PackageManager, resolvePackageManager } from './utils/packageManager';
 import { detectUserError } from './utils/detectUserError';
 import { readAppConfig } from './utils/appConfig';
@@ -74,7 +73,6 @@ export class BuildContext<TJob extends Job> {
   private buildPhase?: BuildPhase;
   private buildPhaseHasWarnings = false;
   private _appConfig?: ExpoConfig;
-  private _packageJson?: any = undefined;
 
   constructor(public readonly job: TJob, options: BuildContextOptions) {
     this.workingdir = options.workingdir;
@@ -107,12 +105,6 @@ export class BuildContext<TJob extends Job> {
       this._appConfig = readAppConfig(this.reactNativeProjectDirectory, this.env, this.logger).exp;
     }
     return this._appConfig;
-  }
-  public get packageJson(): any {
-    if (this._packageJson === undefined) {
-      this._packageJson = readPackageJson(this.reactNativeProjectDirectory);
-    }
-    return this._packageJson;
   }
 
   public async runBuildPhase<T>(

--- a/packages/build-tools/src/context.ts
+++ b/packages/build-tools/src/context.ts
@@ -13,6 +13,7 @@ import { ExpoConfig } from '@expo/config';
 import { bunyan } from '@expo/logger';
 import { SpawnPromise, SpawnOptions, SpawnResult } from '@expo/turtle-spawn';
 
+import { readPackageJson } from './utils/project';
 import { PackageManager, resolvePackageManager } from './utils/packageManager';
 import { detectUserError } from './utils/detectUserError';
 import { readAppConfig } from './utils/appConfig';
@@ -73,6 +74,7 @@ export class BuildContext<TJob extends Job> {
   private buildPhase?: BuildPhase;
   private buildPhaseHasWarnings = false;
   private _appConfig?: ExpoConfig;
+  private _packageJson?: any = undefined;
 
   constructor(public readonly job: TJob, options: BuildContextOptions) {
     this.workingdir = options.workingdir;
@@ -105,6 +107,12 @@ export class BuildContext<TJob extends Job> {
       this._appConfig = readAppConfig(this.reactNativeProjectDirectory, this.env, this.logger).exp;
     }
     return this._appConfig;
+  }
+  public get packageJson(): any {
+    if (this._packageJson === undefined) {
+      this._packageJson = readPackageJson(this.reactNativeProjectDirectory);
+    }
+    return this._packageJson;
   }
 
   public async runBuildPhase<T>(

--- a/packages/build-tools/src/context.ts
+++ b/packages/build-tools/src/context.ts
@@ -33,7 +33,10 @@ export interface BuildContextOptions {
   logBuffer: LogBuffer;
   env: Env;
   cacheManager?: CacheManager;
-  runExpoCliCommand: (args: string, options: SpawnOptions) => SpawnPromise<SpawnResult>;
+  /**
+   * @deprecated
+   */
+  runGlobalExpoCliCommand: (args: string, options: SpawnOptions) => SpawnPromise<SpawnResult>;
   reportError?: (
     msg: string,
     err?: Error,
@@ -51,7 +54,10 @@ export class BuildContext<TJob extends Job> {
   public readonly logBuffer: LogBuffer;
   public readonly env: Env;
   public readonly cacheManager?: CacheManager;
-  public readonly runExpoCliCommand: (
+  /**
+   * @deprecated
+   */
+  public readonly runGlobalExpoCliCommand: (
     args: string,
     options: SpawnOptions
   ) => SpawnPromise<SpawnResult>;
@@ -74,7 +80,7 @@ export class BuildContext<TJob extends Job> {
     this.logger = this.defaultLogger;
     this.logBuffer = options.logBuffer;
     this.cacheManager = options.cacheManager;
-    this.runExpoCliCommand = options.runExpoCliCommand;
+    this.runGlobalExpoCliCommand = options.runGlobalExpoCliCommand;
     this.reportError = options.reportError;
     this.metadata = options.metadata;
     this.skipNativeBuild = options.skipNativeBuild;

--- a/packages/build-tools/src/ios/credentials/__tests__/keychain.test.ios.ts
+++ b/packages/build-tools/src/ios/credentials/__tests__/keychain.test.ios.ts
@@ -38,7 +38,7 @@ describe('Keychain class', () => {
         logBuffer: { getLogs: () => [], getPhaseLogs: () => [] },
         logger: mockLogger,
         env: {},
-        runExpoCliCommand: jest.fn(),
+        runGlobalExpoCliCommand: jest.fn(),
       });
       keychain = new Keychain(ctx);
       await keychain.create();

--- a/packages/build-tools/src/ios/credentials/__tests__/manager.test.ios.ts
+++ b/packages/build-tools/src/ios/credentials/__tests__/manager.test.ios.ts
@@ -66,7 +66,7 @@ describe(IosCredentialsManager, () => {
         logBuffer: { getLogs: () => [], getPhaseLogs: () => [] },
         logger: mockLogger,
         env: {},
-        runExpoCliCommand: jest.fn(),
+        runGlobalExpoCliCommand: jest.fn(),
       });
       const manager = new IosCredentialsManager(ctx);
       const credentials = await manager.prepare();

--- a/packages/build-tools/src/ios/credentials/__tests__/provisioningProfile.test.ios.ts
+++ b/packages/build-tools/src/ios/credentials/__tests__/provisioningProfile.test.ios.ts
@@ -22,7 +22,7 @@ describe('ProvisioningProfile class', () => {
         logBuffer: { getLogs: () => [], getPhaseLogs: () => [] },
         logger: mockLogger,
         env: {},
-        runExpoCliCommand: jest.fn(),
+        runGlobalExpoCliCommand: jest.fn(),
       });
       keychain = new Keychain(ctx);
       await keychain.create();

--- a/packages/build-tools/src/utils/__tests__/hooks.test.ts
+++ b/packages/build-tools/src/utils/__tests__/hooks.test.ts
@@ -31,7 +31,7 @@ describe(runHookIfPresent, () => {
       logBuffer: { getLogs: () => [], getPhaseLogs: () => [] },
       logger: loggerMock as any,
       env: {},
-      runExpoCliCommand: jest.fn(),
+      runGlobalExpoCliCommand: jest.fn(),
     });
   });
 

--- a/packages/build-tools/src/utils/__tests__/project.test.ts
+++ b/packages/build-tools/src/utils/__tests__/project.test.ts
@@ -63,6 +63,25 @@ describe(runExpoCliCommand, () => {
     });
   });
 
+  describe('EXPO_USE_LOCAL_CLI = 0', () => {
+    it('calls ctx.runGlobalExpoCliCommand', () => {
+      const mockExpoConfig = mock<ExpoConfig>();
+      when(mockExpoConfig.sdkVersion).thenReturn('46.0.0');
+      const expoConfig = instance(mockExpoConfig);
+
+      const mockCtx = mock<BuildContext<Android.Job>>();
+      when(mockCtx.env).thenReturn({ EXPO_USE_LOCAL_CLI: '0' });
+      when(mockCtx.packageManager).thenReturn(PackageManager.PNPM);
+      when(mockCtx.appConfig).thenReturn(expoConfig);
+      when(mockCtx.runGlobalExpoCliCommand).thenReturn(jest.fn());
+      const ctx = instance(mockCtx);
+
+      void runExpoCliCommand(ctx, ['doctor'], {});
+      expect(ctx.runGlobalExpoCliCommand).toHaveBeenCalledWith('doctor', expect.any(Object));
+      expect(spawn).not.toHaveBeenCalled();
+    });
+  });
+
   describe('Expo SDK < 46', () => {
     it('calls ctx.runGlobalExpoCliCommand', () => {
       const mockExpoConfig = mock<ExpoConfig>();

--- a/packages/build-tools/src/utils/__tests__/project.test.ts
+++ b/packages/build-tools/src/utils/__tests__/project.test.ts
@@ -61,6 +61,22 @@ describe(runExpoCliCommand, () => {
       expect(ctx.runGlobalExpoCliCommand).not.toHaveBeenCalled();
       expect(spawn).toHaveBeenCalledWith('pnpm', ['dlx', 'expo', 'doctor'], expect.any(Object));
     });
+
+    it('calls ctx.runGlobalExpoCliCommand if forceUseGlobalExpoCli = true', () => {
+      const mockExpoConfig = mock<ExpoConfig>();
+      when(mockExpoConfig.sdkVersion).thenReturn('46.0.0');
+      const expoConfig = instance(mockExpoConfig);
+
+      const mockCtx = mock<BuildContext<Android.Job>>();
+      when(mockCtx.packageManager).thenReturn(PackageManager.PNPM);
+      when(mockCtx.appConfig).thenReturn(expoConfig);
+      when(mockCtx.runGlobalExpoCliCommand).thenReturn(jest.fn());
+      const ctx = instance(mockCtx);
+
+      void runExpoCliCommand(ctx, ['doctor'], {}, { forceUseGlobalExpoCli: true });
+      expect(ctx.runGlobalExpoCliCommand).toHaveBeenCalledWith('doctor', expect.any(Object));
+      expect(spawn).not.toHaveBeenCalled();
+    });
   });
 
   describe('EXPO_USE_LOCAL_CLI = 0', () => {

--- a/packages/build-tools/src/utils/__tests__/project.test.ts
+++ b/packages/build-tools/src/utils/__tests__/project.test.ts
@@ -1,0 +1,83 @@
+import { ExpoConfig } from '@expo/config';
+import { Android } from '@expo/eas-build-job';
+import spawn from '@expo/turtle-spawn';
+import { instance, mock, when } from 'ts-mockito';
+
+import { BuildContext } from '../../context';
+import { PackageManager } from '../packageManager';
+import { runExpoCliCommand } from '../project';
+
+jest.mock('@expo/turtle-spawn', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+describe(runExpoCliCommand, () => {
+  describe('Expo SDK >= 46', () => {
+    it('spawns expo via "npx" when package manager is npm', () => {
+      const mockExpoConfig = mock<ExpoConfig>();
+      when(mockExpoConfig.sdkVersion).thenReturn('46.0.0');
+      const expoConfig = instance(mockExpoConfig);
+
+      const mockCtx = mock<BuildContext<Android.Job>>();
+      when(mockCtx.packageManager).thenReturn(PackageManager.NPM);
+      when(mockCtx.appConfig).thenReturn(expoConfig);
+      when(mockCtx.runGlobalExpoCliCommand).thenReturn(jest.fn());
+      const ctx = instance(mockCtx);
+
+      void runExpoCliCommand(ctx, ['doctor'], {});
+      expect(ctx.runGlobalExpoCliCommand).not.toHaveBeenCalled();
+      expect(spawn).toHaveBeenCalledWith('npx', ['expo', 'doctor'], expect.any(Object));
+    });
+
+    it('spawns expo via "yarn" when package manager is yarn', () => {
+      const mockExpoConfig = mock<ExpoConfig>();
+      when(mockExpoConfig.sdkVersion).thenReturn('46.0.0');
+      const expoConfig = instance(mockExpoConfig);
+
+      const mockCtx = mock<BuildContext<Android.Job>>();
+      when(mockCtx.packageManager).thenReturn(PackageManager.NPM);
+      when(mockCtx.appConfig).thenReturn(expoConfig);
+      when(mockCtx.runGlobalExpoCliCommand).thenReturn(jest.fn());
+      const ctx = instance(mockCtx);
+
+      void runExpoCliCommand(ctx, ['doctor'], {});
+      expect(ctx.runGlobalExpoCliCommand).not.toHaveBeenCalled();
+      expect(spawn).toHaveBeenCalledWith('npx', ['expo', 'doctor'], expect.any(Object));
+    });
+
+    it('spawns expo via "pnpm dlx" when package manager is pnpm', () => {
+      const mockExpoConfig = mock<ExpoConfig>();
+      when(mockExpoConfig.sdkVersion).thenReturn('46.0.0');
+      const expoConfig = instance(mockExpoConfig);
+
+      const mockCtx = mock<BuildContext<Android.Job>>();
+      when(mockCtx.packageManager).thenReturn(PackageManager.PNPM);
+      when(mockCtx.appConfig).thenReturn(expoConfig);
+      when(mockCtx.runGlobalExpoCliCommand).thenReturn(jest.fn());
+      const ctx = instance(mockCtx);
+
+      void runExpoCliCommand(ctx, ['doctor'], {});
+      expect(ctx.runGlobalExpoCliCommand).not.toHaveBeenCalled();
+      expect(spawn).toHaveBeenCalledWith('pnpm', ['dlx', 'expo', 'doctor'], expect.any(Object));
+    });
+  });
+
+  describe('Expo SDK < 46', () => {
+    it('calls ctx.runGlobalExpoCliCommand', () => {
+      const mockExpoConfig = mock<ExpoConfig>();
+      when(mockExpoConfig.sdkVersion).thenReturn('45.0.0');
+      const expoConfig = instance(mockExpoConfig);
+
+      const mockCtx = mock<BuildContext<Android.Job>>();
+      when(mockCtx.packageManager).thenReturn(PackageManager.PNPM);
+      when(mockCtx.appConfig).thenReturn(expoConfig);
+      when(mockCtx.runGlobalExpoCliCommand).thenReturn(jest.fn());
+      const ctx = instance(mockCtx);
+
+      void runExpoCliCommand(ctx, ['doctor'], {});
+      expect(ctx.runGlobalExpoCliCommand).toHaveBeenCalledWith('doctor', expect.any(Object));
+      expect(spawn).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/build-tools/src/utils/__tests__/project.test.ts
+++ b/packages/build-tools/src/utils/__tests__/project.test.ts
@@ -79,14 +79,14 @@ describe(runExpoCliCommand, () => {
     });
   });
 
-  describe('EXPO_USE_LOCAL_CLI = 0', () => {
+  describe('EXPO_USE_GLOBAL_CLI = 1', () => {
     it('calls ctx.runGlobalExpoCliCommand', () => {
       const mockExpoConfig = mock<ExpoConfig>();
       when(mockExpoConfig.sdkVersion).thenReturn('46.0.0');
       const expoConfig = instance(mockExpoConfig);
 
       const mockCtx = mock<BuildContext<Android.Job>>();
-      when(mockCtx.env).thenReturn({ EXPO_USE_LOCAL_CLI: '0' });
+      when(mockCtx.env).thenReturn({ EXPO_USE_GLOBAL_CLI: '1' });
       when(mockCtx.packageManager).thenReturn(PackageManager.PNPM);
       when(mockCtx.appConfig).thenReturn(expoConfig);
       when(mockCtx.runGlobalExpoCliCommand).thenReturn(jest.fn());

--- a/packages/build-tools/src/utils/hooks.ts
+++ b/packages/build-tools/src/utils/hooks.ts
@@ -4,7 +4,7 @@ import spawn from '@expo/turtle-spawn';
 import { BuildContext } from '../context';
 
 import { PackageManager } from './packageManager';
-import { isUsingYarn2 } from './project';
+import { isUsingYarn2, readPackageJson } from './project';
 
 export enum Hook {
   PRE_INSTALL = 'eas-build-pre-install',
@@ -17,7 +17,8 @@ export async function runHookIfPresent<TJob extends Job>(
   hook: Hook
 ): Promise<void> {
   const projectDir = ctx.reactNativeProjectDirectory;
-  if (ctx.packageJson.scripts?.[hook]) {
+  const packageJson = readPackageJson(projectDir);
+  if (packageJson.scripts?.[hook]) {
     ctx.logger.info(`Script '${hook}' is present in package.json, running it...`);
     // when using yarn 2, it's not possible to run any scripts before running 'yarn install'
     // use 'npm' in that case

--- a/packages/build-tools/src/utils/hooks.ts
+++ b/packages/build-tools/src/utils/hooks.ts
@@ -3,7 +3,7 @@ import spawn from '@expo/turtle-spawn';
 
 import { BuildContext } from '../context';
 
-import { PackageManager, readPackageJson } from './packageManager';
+import { PackageManager } from './packageManager';
 import { isUsingYarn2 } from './project';
 
 export enum Hook {
@@ -12,24 +12,12 @@ export enum Hook {
   PRE_UPLOAD_ARTIFACTS = 'eas-build-pre-upload-artifacts',
 }
 
-interface PackageJson {
-  scripts?: Record<string, string>;
-}
-
 export async function runHookIfPresent<TJob extends Job>(
   ctx: BuildContext<TJob>,
   hook: Hook
 ): Promise<void> {
   const projectDir = ctx.reactNativeProjectDirectory;
-  let packageJson: PackageJson;
-  try {
-    packageJson = await readPackageJson(projectDir);
-  } catch (err: any) {
-    ctx.logger.warn(`Failed to parse or read package.json: ${err.message}`);
-    ctx.markBuildPhaseHasWarnings();
-    return;
-  }
-  if (packageJson.scripts?.[hook]) {
+  if (ctx.packageJson.scripts?.[hook]) {
     ctx.logger.info(`Script '${hook}' is present in package.json, running it...`);
     // when using yarn 2, it's not possible to run any scripts before running 'yarn install'
     // use 'npm' in that case

--- a/packages/build-tools/src/utils/packageManager.ts
+++ b/packages/build-tools/src/utils/packageManager.ts
@@ -1,7 +1,4 @@
-import path from 'path';
-
 import * as PackageManagerUtils from '@expo/package-manager';
-import fs from 'fs-extra';
 
 export enum PackageManager {
   YARN = 'yarn',
@@ -26,13 +23,4 @@ export function resolvePackageManager(directory: string): PackageManager {
 
 export function findPackagerRootDir(currentDir: string): string {
   return PackageManagerUtils.findWorkspaceRoot(currentDir) ?? currentDir;
-}
-
-export async function readPackageJson(projectDir: string): Promise<any> {
-  const packageJsonPath = path.join(projectDir, 'package.json');
-  if (!(await fs.pathExists(packageJsonPath))) {
-    throw new Error(`package.json does not exist in ${projectDir}`);
-  }
-  const contents = await fs.readFile(packageJsonPath, 'utf-8');
-  return JSON.parse(contents);
 }

--- a/packages/build-tools/src/utils/prebuild.ts
+++ b/packages/build-tools/src/utils/prebuild.ts
@@ -28,7 +28,8 @@ export async function prebuildAsync<TJob extends Job>(
     },
   };
 
-  await ctx.runExpoCliCommand(getPrebuildCommand(ctx.job), spawnOptions);
+  const prebuildCommand = getPrebuildCommand(ctx.job);
+  await ctx.runGlobalExpoCliCommand(prebuildCommand, spawnOptions);
   await installDependencies(ctx);
 }
 
@@ -46,13 +47,13 @@ function getPrebuildCommand(job: Job): string {
   const expoCommandPrefix = 'expo ';
   const expoCliCommandPrefix = 'expo-cli ';
   if (prebuildCommand.startsWith(npxCommandPrefix)) {
-    prebuildCommand = prebuildCommand.substr(npxCommandPrefix.length).trim();
+    prebuildCommand = prebuildCommand.substring(npxCommandPrefix.length).trim();
   }
   if (prebuildCommand.startsWith(expoCommandPrefix)) {
-    prebuildCommand = prebuildCommand.substr(expoCommandPrefix.length).trim();
+    prebuildCommand = prebuildCommand.substring(expoCommandPrefix.length).trim();
   }
   if (prebuildCommand.startsWith(expoCliCommandPrefix)) {
-    prebuildCommand = prebuildCommand.substr(expoCliCommandPrefix.length).trim();
+    prebuildCommand = prebuildCommand.substring(expoCliCommandPrefix.length).trim();
   }
   return prebuildCommand;
 }

--- a/packages/build-tools/src/utils/prebuild.ts
+++ b/packages/build-tools/src/utils/prebuild.ts
@@ -4,7 +4,7 @@ import semver from 'semver';
 
 import { BuildContext } from '../context';
 
-import { installDependencies } from './project';
+import { installDependencies, runExpoCliCommand } from './project';
 
 export interface PrebuildOptions {
   extraEnvs?: Record<string, string>;
@@ -28,12 +28,12 @@ export async function prebuildAsync<TJob extends Job>(
     },
   };
 
-  const prebuildCommand = getPrebuildCommand(ctx.job);
-  await ctx.runGlobalExpoCliCommand(prebuildCommand, spawnOptions);
+  const prebuildCommandArgs = getPrebuildCommandArgs(ctx.job);
+  await runExpoCliCommand(ctx, prebuildCommandArgs, spawnOptions);
   await installDependencies(ctx);
 }
 
-function getPrebuildCommand(job: Job): string {
+function getPrebuildCommandArgs(job: Job): string[] {
   let prebuildCommand =
     job.experimental?.prebuildCommand ??
     `prebuild --non-interactive --no-install --platform ${job.platform}`;
@@ -55,5 +55,5 @@ function getPrebuildCommand(job: Job): string {
   if (prebuildCommand.startsWith(expoCliCommandPrefix)) {
     prebuildCommand = prebuildCommand.substring(expoCliCommandPrefix.length).trim();
   }
-  return prebuildCommand;
+  return prebuildCommand.split(' ');
 }

--- a/packages/build-tools/src/utils/project.ts
+++ b/packages/build-tools/src/utils/project.ts
@@ -141,7 +141,7 @@ async function runExpoDoctor<TJob extends Job>(ctx: BuildContext<TJob>): Promise
   ctx.logger.info('Running "expo doctor"');
   let timeout: NodeJS.Timeout | undefined;
   try {
-    const promise = ctx.runExpoCliCommand('doctor', {
+    const promise = ctx.runGlobalExpoCliCommand('doctor', {
       cwd: ctx.reactNativeProjectDirectory,
       logger: ctx.logger,
       env: ctx.env,

--- a/packages/build-tools/src/utils/project.ts
+++ b/packages/build-tools/src/utils/project.ts
@@ -140,7 +140,11 @@ export function runExpoCliCommand<TJob extends Job>(
   args: string[],
   options: SpawnOptions
 ): SpawnPromise<SpawnResult> {
-  if (ctx.appConfig.sdkVersion && semver.satisfies(ctx.appConfig.sdkVersion, '>=46')) {
+  if (
+    ctx.env.EXPO_USE_LOCAL_CLI !== '0' &&
+    ctx.appConfig.sdkVersion &&
+    semver.satisfies(ctx.appConfig.sdkVersion, '>=46')
+  ) {
     const argsWithExpo = ['expo', ...args];
     if (ctx.packageManager === PackageManager.NPM) {
       return spawn('npx', argsWithExpo, options);

--- a/packages/local-build-plugin/src/android.ts
+++ b/packages/local-build-plugin/src/android.ts
@@ -6,7 +6,7 @@ import logger, { logBuffer } from './logger';
 import { BuildParams } from './types';
 import { prepareBuildArtifact } from './buildArtifact';
 import config from './config';
-import { runExpoCliCommandAsync } from './expoCli';
+import { runGlobalExpoCliCommandAsync } from './expoCli';
 
 export async function buildAndroidAsync(
   job: Android.Job,
@@ -23,7 +23,7 @@ export async function buildAndroidAsync(
     workingdir,
     logger,
     logBuffer,
-    runExpoCliCommand: runExpoCliCommandAsync,
+    runGlobalExpoCliCommand: runGlobalExpoCliCommandAsync,
     env,
     skipNativeBuild: config.skipNativeBuild,
   });

--- a/packages/local-build-plugin/src/expoCli.ts
+++ b/packages/local-build-plugin/src/expoCli.ts
@@ -4,7 +4,7 @@ import spawnAsync, { SpawnOptions, SpawnPromise, SpawnResult } from '@expo/turtl
 
 const expoCliPackage = require.resolve('expo-cli');
 
-export function runExpoCliCommandAsync(
+export function runGlobalExpoCliCommandAsync(
   command: string,
   options: SpawnOptions
 ): SpawnPromise<SpawnResult> {

--- a/packages/local-build-plugin/src/ios.ts
+++ b/packages/local-build-plugin/src/ios.ts
@@ -2,7 +2,7 @@ import { Ios, BuildPhase, Env } from '@expo/eas-build-job';
 import { Builders, BuildContext } from '@expo/build-tools';
 import omit from 'lodash/omit';
 
-import { runExpoCliCommandAsync } from './expoCli';
+import { runGlobalExpoCliCommandAsync } from './expoCli';
 import logger, { logBuffer } from './logger';
 import { BuildParams } from './types';
 import { prepareBuildArtifact } from './buildArtifact';
@@ -23,7 +23,7 @@ export async function buildIosAsync(
     workingdir,
     logger,
     logBuffer,
-    runExpoCliCommand: runExpoCliCommandAsync,
+    runGlobalExpoCliCommand: runGlobalExpoCliCommandAsync,
     env,
     skipNativeBuild: config.skipNativeBuild,
   });


### PR DESCRIPTION
https://linear.app/expo/issue/ENG-5837/use-local-cli-for-prebuild-in-sdk-46

> The default prebuild command should be npx expo prebuild when the project uses npm or yarn expo prebuild when the project uses yarn.
>
> This is because we are moving away from using a global Expo CLI installation. In the future, this means we will be able to move away from installing Expo CLI on EAS Build workers entirely — everything needed to prebuild the project will be packaged inside of @expo/cli in the expo package. For now, we should leave expo-cli installed on workers even when building SDK 46+ projects because they may run into an issue with the new CLI and want to opt out by using a custom prebuildCommand or setting EXPO_USE_LOCAL_CLI=0 .

I made one change to the behavior from the description. The only way to opt out from using local CLI is by setting `EXPO_USE_LOCAL_CLI=0`.

--- 

I tested the changes using https://github.com/byCedric/expo-monorepo-benchmark Thanks, Cedric!