### PR TITLE
[build-tools] EXPO_USE_GLOBAL_CLI -> EXPO_USE_LOCAL_CLI

### DIFF
--- a/packages/build-tools/src/utils/__tests__/project.test.ts
+++ b/packages/build-tools/src/utils/__tests__/project.test.ts
@@ -79,14 +79,14 @@ describe(runExpoCliCommand, () => {
     });
   });
 
-  describe('EXPO_USE_GLOBAL_CLI = 1', () => {
+  describe('EXPO_USE_LOCAL_CLI = 0', () => {
     it('calls ctx.runGlobalExpoCliCommand', () => {
       const mockExpoConfig = mock<ExpoConfig>();
       when(mockExpoConfig.sdkVersion).thenReturn('46.0.0');
       const expoConfig = instance(mockExpoConfig);
 
       const mockCtx = mock<BuildContext<Android.Job>>();
-      when(mockCtx.env).thenReturn({ EXPO_USE_GLOBAL_CLI: '1' });
+      when(mockCtx.env).thenReturn({ EXPO_USE_LOCAL_CLI: '0' });
       when(mockCtx.packageManager).thenReturn(PackageManager.PNPM);
       when(mockCtx.appConfig).thenReturn(expoConfig);
       when(mockCtx.runGlobalExpoCliCommand).thenReturn(jest.fn());

--- a/packages/build-tools/src/utils/project.ts
+++ b/packages/build-tools/src/utils/project.ts
@@ -145,7 +145,7 @@ export function runExpoCliCommand<TJob extends Job>(
 ): SpawnPromise<SpawnResult> {
   if (
     forceUseGlobalExpoCli ||
-    ctx.env.EXPO_USE_GLOBAL_CLI === '1' ||
+    ctx.env.EXPO_USE_LOCAL_CLI === '0' ||
     !ctx.appConfig.sdkVersion ||
     semver.satisfies(ctx.appConfig.sdkVersion, '<46')
   ) {


### PR DESCRIPTION
`EXPO_USE_LOCAL_CLI` was already announced in https://blog.expo.dev/expo-sdk-46-beta-is-now-available-9dfee4040aa7 + is used in the `expo` package - https://github.com/expo/expo/blob/main/packages/expo/bin/cli.js