### PR TITLE
[build-tools] don't pass --non-interactive flag to prebuild (local CLI)

### DIFF
--- a/packages/build-tools/src/utils/__tests__/project.test.ts
+++ b/packages/build-tools/src/utils/__tests__/project.test.ts
@@ -77,6 +77,29 @@ describe(runExpoCliCommand, () => {
       expect(ctx.runGlobalExpoCliCommand).toHaveBeenCalledWith('doctor', expect.any(Object));
       expect(spawn).not.toHaveBeenCalled();
     });
+
+    it('does not append extraArgsForGlobalExpoCli to command args for the local Expo CLI call', () => {
+      const mockExpoConfig = mock<ExpoConfig>();
+      when(mockExpoConfig.sdkVersion).thenReturn('46.0.0');
+      const expoConfig = instance(mockExpoConfig);
+
+      const mockCtx = mock<BuildContext<Android.Job>>();
+      when(mockCtx.packageManager).thenReturn(PackageManager.PNPM);
+      when(mockCtx.appConfig).thenReturn(expoConfig);
+      when(mockCtx.runGlobalExpoCliCommand).thenReturn(jest.fn());
+      const ctx = instance(mockCtx);
+
+      void runExpoCliCommand(
+        ctx,
+        ['prebuild'],
+        {},
+        {
+          extraArgsForGlobalExpoCli: ['--non-interactive'],
+        }
+      );
+      expect(ctx.runGlobalExpoCliCommand).not.toHaveBeenCalled();
+      expect(spawn).toHaveBeenCalledWith('pnpm', ['dlx', 'expo', 'prebuild'], expect.any(Object));
+    });
   });
 
   describe('EXPO_USE_LOCAL_CLI = 0', () => {
@@ -112,6 +135,32 @@ describe(runExpoCliCommand, () => {
 
       void runExpoCliCommand(ctx, ['doctor'], {});
       expect(ctx.runGlobalExpoCliCommand).toHaveBeenCalledWith('doctor', expect.any(Object));
+      expect(spawn).not.toHaveBeenCalled();
+    });
+
+    it('appends extraArgsForGlobalExpoCli to command args for the global Expo CLI call', () => {
+      const mockExpoConfig = mock<ExpoConfig>();
+      when(mockExpoConfig.sdkVersion).thenReturn('45.0.0');
+      const expoConfig = instance(mockExpoConfig);
+
+      const mockCtx = mock<BuildContext<Android.Job>>();
+      when(mockCtx.packageManager).thenReturn(PackageManager.PNPM);
+      when(mockCtx.appConfig).thenReturn(expoConfig);
+      when(mockCtx.runGlobalExpoCliCommand).thenReturn(jest.fn());
+      const ctx = instance(mockCtx);
+
+      void runExpoCliCommand(
+        ctx,
+        ['prebuild'],
+        {},
+        {
+          extraArgsForGlobalExpoCli: ['--non-interactive'],
+        }
+      );
+      expect(ctx.runGlobalExpoCliCommand).toHaveBeenCalledWith(
+        'prebuild --non-interactive',
+        expect.any(Object)
+      );
       expect(spawn).not.toHaveBeenCalled();
     });
   });

--- a/packages/build-tools/src/utils/__tests__/project.test.ts
+++ b/packages/build-tools/src/utils/__tests__/project.test.ts
@@ -77,29 +77,6 @@ describe(runExpoCliCommand, () => {
       expect(ctx.runGlobalExpoCliCommand).toHaveBeenCalledWith('doctor', expect.any(Object));
       expect(spawn).not.toHaveBeenCalled();
     });
-
-    it('does not append extraArgsForGlobalExpoCli to command args for the local Expo CLI call', () => {
-      const mockExpoConfig = mock<ExpoConfig>();
-      when(mockExpoConfig.sdkVersion).thenReturn('46.0.0');
-      const expoConfig = instance(mockExpoConfig);
-
-      const mockCtx = mock<BuildContext<Android.Job>>();
-      when(mockCtx.packageManager).thenReturn(PackageManager.PNPM);
-      when(mockCtx.appConfig).thenReturn(expoConfig);
-      when(mockCtx.runGlobalExpoCliCommand).thenReturn(jest.fn());
-      const ctx = instance(mockCtx);
-
-      void runExpoCliCommand(
-        ctx,
-        ['prebuild'],
-        {},
-        {
-          extraArgsForGlobalExpoCli: ['--non-interactive'],
-        }
-      );
-      expect(ctx.runGlobalExpoCliCommand).not.toHaveBeenCalled();
-      expect(spawn).toHaveBeenCalledWith('pnpm', ['dlx', 'expo', 'prebuild'], expect.any(Object));
-    });
   });
 
   describe('EXPO_USE_LOCAL_CLI = 0', () => {
@@ -135,32 +112,6 @@ describe(runExpoCliCommand, () => {
 
       void runExpoCliCommand(ctx, ['doctor'], {});
       expect(ctx.runGlobalExpoCliCommand).toHaveBeenCalledWith('doctor', expect.any(Object));
-      expect(spawn).not.toHaveBeenCalled();
-    });
-
-    it('appends extraArgsForGlobalExpoCli to command args for the global Expo CLI call', () => {
-      const mockExpoConfig = mock<ExpoConfig>();
-      when(mockExpoConfig.sdkVersion).thenReturn('45.0.0');
-      const expoConfig = instance(mockExpoConfig);
-
-      const mockCtx = mock<BuildContext<Android.Job>>();
-      when(mockCtx.packageManager).thenReturn(PackageManager.PNPM);
-      when(mockCtx.appConfig).thenReturn(expoConfig);
-      when(mockCtx.runGlobalExpoCliCommand).thenReturn(jest.fn());
-      const ctx = instance(mockCtx);
-
-      void runExpoCliCommand(
-        ctx,
-        ['prebuild'],
-        {},
-        {
-          extraArgsForGlobalExpoCli: ['--non-interactive'],
-        }
-      );
-      expect(ctx.runGlobalExpoCliCommand).toHaveBeenCalledWith(
-        'prebuild --non-interactive',
-        expect.any(Object)
-      );
       expect(spawn).not.toHaveBeenCalled();
     });
   });

--- a/packages/build-tools/src/utils/prebuild.ts
+++ b/packages/build-tools/src/utils/prebuild.ts
@@ -29,19 +29,17 @@ export async function prebuildAsync<TJob extends Job>(
   };
 
   const prebuildCommandArgs = getPrebuildCommandArgs(ctx.job);
-  await runExpoCliCommand(ctx, prebuildCommandArgs, spawnOptions);
+  await runExpoCliCommand(ctx, prebuildCommandArgs, spawnOptions, {
+    extraArgsForGlobalExpoCli: ['--non-interactive'],
+  });
   await installDependencies(ctx);
 }
 
 function getPrebuildCommandArgs(job: Job): string[] {
   let prebuildCommand =
-    job.experimental?.prebuildCommand ??
-    `prebuild --non-interactive --no-install --platform ${job.platform}`;
+    job.experimental?.prebuildCommand ?? `prebuild --no-install --platform ${job.platform}`;
   if (!prebuildCommand.match(/(?:--platform| -p)/)) {
     prebuildCommand = `${prebuildCommand} --platform ${job.platform}`;
-  }
-  if (!prebuildCommand.match(/--non-interactive/)) {
-    prebuildCommand = `${prebuildCommand} --non-interactive`;
   }
   const npxCommandPrefix = 'npx ';
   const expoCommandPrefix = 'expo ';

--- a/packages/build-tools/src/utils/prebuild.ts
+++ b/packages/build-tools/src/utils/prebuild.ts
@@ -4,7 +4,7 @@ import semver from 'semver';
 
 import { BuildContext } from '../context';
 
-import { installDependencies, runExpoCliCommand } from './project';
+import { installDependencies, runExpoCliCommand, shouldUseGlobalExpoCli } from './project';
 
 export interface PrebuildOptions {
   extraEnvs?: Record<string, string>;
@@ -28,18 +28,17 @@ export async function prebuildAsync<TJob extends Job>(
     },
   };
 
-  const prebuildCommandArgs = getPrebuildCommandArgs(ctx.job);
-  await runExpoCliCommand(ctx, prebuildCommandArgs, spawnOptions, {
-    extraArgsForGlobalExpoCli: ['--non-interactive'],
-  });
+  const prebuildCommandArgs = getPrebuildCommandArgs(ctx);
+  await runExpoCliCommand(ctx, prebuildCommandArgs, spawnOptions);
   await installDependencies(ctx);
 }
 
-function getPrebuildCommandArgs(job: Job): string[] {
+function getPrebuildCommandArgs<TJob extends Job>(ctx: BuildContext<TJob>): string[] {
   let prebuildCommand =
-    job.experimental?.prebuildCommand ?? `prebuild --no-install --platform ${job.platform}`;
+    ctx.job.experimental?.prebuildCommand ??
+    `prebuild --non-interactive --no-install --platform ${ctx.job.platform}`;
   if (!prebuildCommand.match(/(?:--platform| -p)/)) {
-    prebuildCommand = `${prebuildCommand} --platform ${job.platform}`;
+    prebuildCommand = `${prebuildCommand} --platform ${ctx.job.platform}`;
   }
   const npxCommandPrefix = 'npx ';
   const expoCommandPrefix = 'expo ';
@@ -52,6 +51,9 @@ function getPrebuildCommandArgs(job: Job): string[] {
   }
   if (prebuildCommand.startsWith(expoCliCommandPrefix)) {
     prebuildCommand = prebuildCommand.substring(expoCliCommandPrefix.length).trim();
+  }
+  if (!shouldUseGlobalExpoCli(ctx)) {
+    prebuildCommand = prebuildCommand.replace(' --non-interactive', '');
   }
   return prebuildCommand.split(' ');
 }

--- a/packages/build-tools/src/utils/project.ts
+++ b/packages/build-tools/src/utils/project.ts
@@ -141,19 +141,10 @@ export function runExpoCliCommand<TJob extends Job>(
   ctx: BuildContext<TJob>,
   args: string[],
   options: SpawnOptions,
-  {
-    forceUseGlobalExpoCli = false,
-    extraArgsForGlobalExpoCli = [],
-  }: { forceUseGlobalExpoCli?: boolean; extraArgsForGlobalExpoCli?: string[] } = {}
+  { forceUseGlobalExpoCli = false } = {}
 ): SpawnPromise<SpawnResult> {
-  if (
-    forceUseGlobalExpoCli ||
-    ctx.env.EXPO_USE_LOCAL_CLI === '0' ||
-    !ctx.appConfig.sdkVersion ||
-    semver.satisfies(ctx.appConfig.sdkVersion, '<46')
-  ) {
-    const updatedArgs = [...args, ...extraArgsForGlobalExpoCli];
-    return ctx.runGlobalExpoCliCommand(updatedArgs.join(' '), options);
+  if (shouldUseGlobalExpoCli(ctx, forceUseGlobalExpoCli)) {
+    return ctx.runGlobalExpoCliCommand(args.join(' '), options);
   } else {
     const argsWithExpo = ['expo', ...args];
     if (ctx.packageManager === PackageManager.NPM) {
@@ -166,6 +157,18 @@ export function runExpoCliCommand<TJob extends Job>(
       throw new Error(`Unsupported package manager: ${ctx.packageManager}`);
     }
   }
+}
+
+export function shouldUseGlobalExpoCli<TJob extends Job>(
+  ctx: BuildContext<TJob>,
+  forceUseGlobalExpoCli = false
+): boolean {
+  return (
+    forceUseGlobalExpoCli ||
+    ctx.env.EXPO_USE_LOCAL_CLI === '0' ||
+    !ctx.appConfig.sdkVersion ||
+    semver.satisfies(ctx.appConfig.sdkVersion, '<46')
+  );
 }
 
 async function runExpoDoctor<TJob extends Job>(ctx: BuildContext<TJob>): Promise<SpawnResult> {

--- a/packages/build-tools/src/utils/project.ts
+++ b/packages/build-tools/src/utils/project.ts
@@ -141,7 +141,10 @@ export function runExpoCliCommand<TJob extends Job>(
   ctx: BuildContext<TJob>,
   args: string[],
   options: SpawnOptions,
-  { forceUseGlobalExpoCli = false } = {}
+  {
+    forceUseGlobalExpoCli = false,
+    extraArgsForGlobalExpoCli = [],
+  }: { forceUseGlobalExpoCli?: boolean; extraArgsForGlobalExpoCli?: string[] } = {}
 ): SpawnPromise<SpawnResult> {
   if (
     forceUseGlobalExpoCli ||
@@ -149,7 +152,8 @@ export function runExpoCliCommand<TJob extends Job>(
     !ctx.appConfig.sdkVersion ||
     semver.satisfies(ctx.appConfig.sdkVersion, '<46')
   ) {
-    return ctx.runGlobalExpoCliCommand(args.join(' '), options);
+    const updatedArgs = [...args, ...extraArgsForGlobalExpoCli];
+    return ctx.runGlobalExpoCliCommand(updatedArgs.join(' '), options);
   } else {
     const argsWithExpo = ['expo', ...args];
     if (ctx.packageManager === PackageManager.NPM) {


### PR DESCRIPTION
# Why

Local Expo CLI doesn't support `--non-interactive` flag for `prebuild`.

# How

Pass `--non-interactive` flag only for global Expo CLI execution.

# Test Plan

Test.