### PR TITLE
[ENG-5836][eas-build-job] add message to metadata

### DIFF
--- a/packages/eas-build-job/src/__tests__/metadata.test.ts
+++ b/packages/eas-build-job/src/__tests__/metadata.test.ts
@@ -16,6 +16,7 @@ describe('MetadataSchema', () => {
       workflow: 'generic',
       username: 'notdominik',
       iosEnterpriseProvisioning: 'adhoc',
+      message: 'fix foo, bar, and baz',
     };
     const { value, error } = MetadataSchema.validate(metadata, {
       stripUnknown: true,
@@ -39,6 +40,7 @@ describe('MetadataSchema', () => {
       trackingContext: {},
       workflow: 'generic',
       username: 'notdominik',
+      message: 'a'.repeat(1025),
     };
     const { error } = MetadataSchema.validate(metadata, {
       stripUnknown: true,
@@ -46,7 +48,7 @@ describe('MetadataSchema', () => {
       abortEarly: false,
     });
     expect(error?.message).toEqual(
-      '"credentialsSource" must be one of [local, remote]. "gitCommitHash" length must be 40 characters long. "gitCommitHash" must only contain hexadecimal characters'
+      '"credentialsSource" must be one of [local, remote]. "gitCommitHash" length must be 40 characters long. "gitCommitHash" must only contain hexadecimal characters. "message" length must be less than or equal to 1024 characters long'
     );
   });
 });

--- a/packages/eas-build-job/src/metadata.ts
+++ b/packages/eas-build-job/src/metadata.ts
@@ -114,6 +114,11 @@ export type Metadata = {
    * It's either adhoc or universal
    */
   iosEnterpriseProvisioning?: 'adhoc' | 'universal';
+
+  /**
+   * Message attached to the build.
+   */
+  message?: string;
 };
 
 export const MetadataSchema = Joi.object({
@@ -138,6 +143,7 @@ export const MetadataSchema = Joi.object({
   isGitWorkingTreeDirty: Joi.boolean(),
   username: Joi.string(),
   iosEnterpriseProvisioning: Joi.string().valid('adhoc', 'universal'),
+  message: Joi.string().max(1024),
 });
 
 export function sanitizeMetadata(metadata: object): Metadata {


### PR DESCRIPTION
# Why

We want to allow users to attach messages to builds.

# How

Add `message` to build's metadata.

# Test Plan

Tests
