### PR TITLE
[ENG-5893][eas-build-job] add runFromCI and runWithNoWaitFlag to metadata

### DIFF
--- a/packages/eas-build-job/src/__tests__/metadata.test.ts
+++ b/packages/eas-build-job/src/__tests__/metadata.test.ts
@@ -18,6 +18,8 @@ describe('MetadataSchema', () => {
       username: 'notdominik',
       iosEnterpriseProvisioning: 'adhoc',
       message: 'fix foo, bar, and baz',
+      runFromCI: true,
+      runWithNoWaitFlag: true,
     };
     const { value, error } = MetadataSchema.validate(metadata, {
       stripUnknown: true,
@@ -43,6 +45,8 @@ describe('MetadataSchema', () => {
       workflow: 'generic',
       username: 'notdominik',
       message: 'a'.repeat(1025),
+      runFromCI: true,
+      runWithNoWaitFlag: true,
     };
     const { error } = MetadataSchema.validate(metadata, {
       stripUnknown: true,

--- a/packages/eas-build-job/src/metadata.ts
+++ b/packages/eas-build-job/src/metadata.ts
@@ -124,6 +124,16 @@ export type Metadata = {
    * Message attached to the build.
    */
   message?: string;
+
+  /**
+   * Indicates whether the build was run from CI.
+   */
+  runFromCI?: boolean;
+
+  /**
+   * Indicates whether the build was run with --no-wait flag.
+   */
+  runWithNoWaitFlag?: boolean;
 };
 
 export const MetadataSchema = Joi.object({
@@ -150,6 +160,8 @@ export const MetadataSchema = Joi.object({
   username: Joi.string(),
   iosEnterpriseProvisioning: Joi.string().valid('adhoc', 'universal'),
   message: Joi.string().max(1024),
+  runFromCI: Joi.boolean(),
+  runWithNoWaitFlag: Joi.boolean(),
 });
 
 export function sanitizeMetadata(metadata: object): Metadata {


### PR DESCRIPTION
Adds `runFromCI` and `runWithNoWaitFlag` to metadata.