### PR TITLE
Support Apple TV simulator builds

### DIFF
--- a/packages/build-tools/src/builders/ios.ts
+++ b/packages/build-tools/src/builders/ios.ts
@@ -165,10 +165,7 @@ function resolveArtifactPath(ctx: BuildContext<Ios.Job>): string {
   if (ctx.job.artifactPath) {
     return ctx.job.artifactPath;
   } else if (ctx.job.simulator) {
-    if (isTVOS(ctx, ctx.job.buildConfiguration)) {
-      return 'ios/build/Build/Products/*-appletvsimulator/*.app';
-    }
-    return 'ios/build/Build/Products/*-iphonesimulator/*.app';
+    return 'ios/build/Build/Products/*simulator/*.app';
   } else {
     return 'ios/build/*.ipa';
   }

--- a/packages/build-tools/src/builders/ios.ts
+++ b/packages/build-tools/src/builders/ios.ts
@@ -1,5 +1,3 @@
-import assert from 'assert';
-
 import plist from '@expo/plist';
 import { IOSConfig } from '@expo/config-plugins';
 import { BuildPhase, Ios, Workflow } from '@expo/eas-build-job';
@@ -16,6 +14,7 @@ import CredentialsManager from '../ios/credentials/manager';
 import { runFastlaneGym } from '../ios/fastlane';
 import { installPods } from '../ios/pod';
 import { prebuildAsync } from '../utils/prebuild';
+import { resolveArtifactPath, resolveBuildConfiguration, resolveScheme } from '../ios/resolve';
 
 export default async function iosBuilder(ctx: BuildContext<Ios.Job>): Promise<string> {
   let buildSuccess = true;
@@ -123,15 +122,6 @@ async function buildAsync(ctx: BuildContext<Ios.Job>): Promise<string> {
   });
 }
 
-function resolveScheme(ctx: BuildContext<Ios.Job>): string {
-  if (ctx.job.scheme) {
-    return ctx.job.scheme;
-  }
-  const schemes = IOSConfig.BuildScheme.getSchemesFromXcodeproj(ctx.reactNativeProjectDirectory);
-  assert(schemes.length === 1, 'Ejected project should have exactly one scheme');
-  return schemes[0];
-}
-
 async function readEntitlementsAsync(
   ctx: BuildContext<Ios.Job>,
   { scheme, buildConfiguration }: { scheme: string; buildConfiguration: string }
@@ -157,25 +147,5 @@ async function readEntitlementsAsync(
     ctx.logger.warn({ err }, 'Failed to read entitlements');
     ctx.markBuildPhaseHasWarnings();
     return null;
-  }
-}
-
-function resolveArtifactPath(ctx: BuildContext<Ios.Job>): string {
-  if (ctx.job.artifactPath) {
-    return ctx.job.artifactPath;
-  } else if (ctx.job.simulator) {
-    return 'ios/build/Build/Products/*simulator/*.app';
-  } else {
-    return 'ios/build/*.ipa';
-  }
-}
-
-function resolveBuildConfiguration(ctx: BuildContext<Ios.Job>): string {
-  if (ctx.job.buildConfiguration) {
-    return ctx.job.buildConfiguration;
-  } else if (ctx.job.developmentClient) {
-    return 'Debug';
-  } else {
-    return 'Release';
   }
 }

--- a/packages/build-tools/src/builders/ios.ts
+++ b/packages/build-tools/src/builders/ios.ts
@@ -16,6 +16,7 @@ import CredentialsManager from '../ios/credentials/manager';
 import { runFastlaneGym } from '../ios/fastlane';
 import { installPods } from '../ios/pod';
 import { prebuildAsync } from '../utils/prebuild';
+import { isTVOS } from '../ios/tvos';
 
 export default async function iosBuilder(ctx: BuildContext<Ios.Job>): Promise<string> {
   let buildSuccess = true;
@@ -164,6 +165,9 @@ function resolveArtifactPath(ctx: BuildContext<Ios.Job>): string {
   if (ctx.job.artifactPath) {
     return ctx.job.artifactPath;
   } else if (ctx.job.simulator) {
+    if (isTVOS(ctx, ctx.job.buildConfiguration)) {
+      return 'ios/build/Build/Products/*-appletvsimulator/*.app';
+    }
     return 'ios/build/Build/Products/*-iphonesimulator/*.app';
   } else {
     return 'ios/build/*.ipa';

--- a/packages/build-tools/src/builders/ios.ts
+++ b/packages/build-tools/src/builders/ios.ts
@@ -16,7 +16,6 @@ import CredentialsManager from '../ios/credentials/manager';
 import { runFastlaneGym } from '../ios/fastlane';
 import { installPods } from '../ios/pod';
 import { prebuildAsync } from '../utils/prebuild';
-import { isTVOS } from '../ios/tvos';
 
 export default async function iosBuilder(ctx: BuildContext<Ios.Job>): Promise<string> {
   let buildSuccess = true;

--- a/packages/build-tools/src/ios/fastlane.ts
+++ b/packages/build-tools/src/ios/fastlane.ts
@@ -11,6 +11,7 @@ import { BuildContext, SkipNativeBuildError } from '../context';
 import { createGymfileForArchiveBuild, createGymfileForSimulatorBuild } from './gymfile';
 import { Credentials } from './credentials/manager';
 import { XcodeBuildLogger } from './xcpretty';
+import { isTVOS } from './tvos';
 
 export async function runFastlaneGym<TJob extends Ios.Job>(
   ctx: BuildContext<TJob>,
@@ -102,6 +103,10 @@ async function ensureGymfileExists<TJob extends Ios.Job>(
 
   ctx.logger.info('Creating Gymfile');
   if (ctx.job.simulator) {
+    const simulatorDestination = isTVOS(ctx, buildConfiguration)
+      ? 'generic/platform=tvOS Simulator'
+      : 'generic/platform=iOS Simulator';
+
     await createGymfileForSimulatorBuild({
       outputFile: gymfilePath,
       scheme,
@@ -109,6 +114,7 @@ async function ensureGymfileExists<TJob extends Ios.Job>(
       derivedDataPath: './build',
       clean: false,
       logsDirectory,
+      simulatorDestination,
     });
   } else {
     await createGymfileForArchiveBuild({

--- a/packages/build-tools/src/ios/fastlane.ts
+++ b/packages/build-tools/src/ios/fastlane.ts
@@ -103,9 +103,8 @@ async function ensureGymfileExists<TJob extends Ios.Job>(
 
   ctx.logger.info('Creating Gymfile');
   if (ctx.job.simulator) {
-    const simulatorDestination = isTVOS(ctx, buildConfiguration)
-      ? 'generic/platform=tvOS Simulator'
-      : 'generic/platform=iOS Simulator';
+    const isTV = await isTVOS(ctx);
+    const simulatorDestination = `generic/platform=${isTV ? 'tvOS' : 'iOS'} Simulator`;
 
     await createGymfileForSimulatorBuild({
       outputFile: gymfilePath,
@@ -128,5 +127,6 @@ async function ensureGymfileExists<TJob extends Ios.Job>(
       entitlements: entitlements ?? undefined,
     });
   }
+
   ctx.logger.info('Gymfile created');
 }

--- a/packages/build-tools/src/ios/gymfile.ts
+++ b/packages/build-tools/src/ios/gymfile.ts
@@ -29,6 +29,7 @@ interface SimulatorBuildOptions {
   derivedDataPath: string;
   clean: boolean;
   logsDirectory: string;
+  simulatorDestination: string;
 }
 
 export async function createGymfileForArchiveBuild({
@@ -81,6 +82,7 @@ export async function createGymfileForSimulatorBuild({
   buildConfiguration,
   derivedDataPath,
   logsDirectory,
+  simulatorDestination,
 }: SimulatorBuildOptions): Promise<void> {
   await fs.mkdirp(logsDirectory);
   await createGymfile({
@@ -89,6 +91,7 @@ export async function createGymfileForSimulatorBuild({
     vars: {
       SCHEME: scheme,
       SCHEME_BUILD_CONFIGURATION: buildConfiguration,
+      SCHEME_SIMULATOR_DESTINATION: simulatorDestination,
       DERIVED_DATA_PATH: derivedDataPath,
       CLEAN: String(clean),
       LOGS_DIRECTORY: logsDirectory,

--- a/packages/build-tools/src/ios/resolve.ts
+++ b/packages/build-tools/src/ios/resolve.ts
@@ -1,0 +1,35 @@
+import assert from 'assert';
+
+import { Ios } from '@expo/eas-build-job';
+import { IOSConfig } from '@expo/config-plugins';
+
+import { BuildContext } from '../context';
+
+export function resolveScheme(ctx: BuildContext<Ios.Job>): string {
+  if (ctx.job.scheme) {
+    return ctx.job.scheme;
+  }
+  const schemes = IOSConfig.BuildScheme.getSchemesFromXcodeproj(ctx.reactNativeProjectDirectory);
+  assert(schemes.length === 1, 'Ejected project should have exactly one scheme');
+  return schemes[0];
+}
+
+export function resolveArtifactPath(ctx: BuildContext<Ios.Job>): string {
+  if (ctx.job.artifactPath) {
+    return ctx.job.artifactPath;
+  } else if (ctx.job.simulator) {
+    return 'ios/build/Build/Products/*simulator/*.app';
+  } else {
+    return 'ios/build/*.ipa';
+  }
+}
+
+export function resolveBuildConfiguration(ctx: BuildContext<Ios.Job>): string {
+  if (ctx.job.buildConfiguration) {
+    return ctx.job.buildConfiguration;
+  } else if (ctx.job.developmentClient) {
+    return 'Debug';
+  } else {
+    return 'Release';
+  }
+}

--- a/packages/build-tools/src/ios/tvos.ts
+++ b/packages/build-tools/src/ios/tvos.ts
@@ -1,0 +1,30 @@
+import { Ios } from '@expo/eas-build-job';
+import { IOSConfig } from '@expo/config-plugins';
+
+import { BuildContext } from '../context';
+
+// Functions specific to Apple TV support should be added here
+
+/**
+ * Use XcodeUtils to check if a build configuration is for Apple TV and not iOS
+ *
+ * @param ctx The build context
+ * @param buildConfiguration The build configuration selected (usually "Release")
+ * @returns true if this is an Apple TV configuration, false otherwise
+ */
+export function isTVOS(
+  ctx: BuildContext<Ios.Job>,
+  buildConfiguration: string | undefined
+): boolean {
+  if (ctx.job.scheme) {
+    const project = IOSConfig.XcodeUtils.getPbxproj(ctx.reactNativeProjectDirectory);
+
+    const xcBuildConfiguration = IOSConfig.Target.getXCBuildConfigurationFromPbxproj(project, {
+      targetName: ctx.job.scheme,
+      buildConfiguration,
+    });
+    return xcBuildConfiguration?.buildSettings?.SDKROOT?.includes('appletv');
+  } else {
+    return false;
+  }
+}

--- a/packages/build-tools/src/ios/tvos.ts
+++ b/packages/build-tools/src/ios/tvos.ts
@@ -9,22 +9,22 @@ import { BuildContext } from '../context';
  * Use XcodeUtils to check if a build configuration is for Apple TV and not iOS
  *
  * @param ctx The build context
- * @param buildConfiguration The build configuration selected (usually "Release")
  * @returns true if this is an Apple TV configuration, false otherwise
  */
-export function isTVOS(
-  ctx: BuildContext<Ios.Job>,
-  buildConfiguration: string
-): boolean {
+export async function isTVOS(ctx: BuildContext<Ios.Job>): Promise<boolean> {
   if (!ctx.job.scheme) {
     return false;
   }
-  
   const project = IOSConfig.XcodeUtils.getPbxproj(ctx.reactNativeProjectDirectory);
 
+  const targetName = await IOSConfig.BuildScheme.getApplicationTargetNameForSchemeAsync(
+    ctx.reactNativeProjectDirectory,
+    ctx.job.scheme || ''
+  );
+
   const xcBuildConfiguration = IOSConfig.Target.getXCBuildConfigurationFromPbxproj(project, {
-    targetName: ctx.job.scheme,
-    buildConfiguration,
+    targetName,
+    buildConfiguration: ctx.job.buildConfiguration,
   });
   return xcBuildConfiguration?.buildSettings?.SDKROOT?.includes('appletv');
 }

--- a/packages/build-tools/src/ios/tvos.ts
+++ b/packages/build-tools/src/ios/tvos.ts
@@ -14,7 +14,7 @@ import { BuildContext } from '../context';
  */
 export function isTVOS(
   ctx: BuildContext<Ios.Job>,
-  buildConfiguration: string | undefined
+  buildConfiguration: string
 ): boolean {
   if (ctx.job.scheme) {
     const project = IOSConfig.XcodeUtils.getPbxproj(ctx.reactNativeProjectDirectory);

--- a/packages/build-tools/src/ios/tvos.ts
+++ b/packages/build-tools/src/ios/tvos.ts
@@ -16,15 +16,15 @@ export function isTVOS(
   ctx: BuildContext<Ios.Job>,
   buildConfiguration: string
 ): boolean {
-  if (ctx.job.scheme) {
-    const project = IOSConfig.XcodeUtils.getPbxproj(ctx.reactNativeProjectDirectory);
-
-    const xcBuildConfiguration = IOSConfig.Target.getXCBuildConfigurationFromPbxproj(project, {
-      targetName: ctx.job.scheme,
-      buildConfiguration,
-    });
-    return xcBuildConfiguration?.buildSettings?.SDKROOT?.includes('appletv');
-  } else {
+  if (!ctx.job.scheme) {
     return false;
   }
+  
+  const project = IOSConfig.XcodeUtils.getPbxproj(ctx.reactNativeProjectDirectory);
+
+  const xcBuildConfiguration = IOSConfig.Target.getXCBuildConfigurationFromPbxproj(project, {
+    targetName: ctx.job.scheme,
+    buildConfiguration,
+  });
+  return xcBuildConfiguration?.buildSettings?.SDKROOT?.includes('appletv');
 }

--- a/packages/build-tools/src/ios/tvos.ts
+++ b/packages/build-tools/src/ios/tvos.ts
@@ -3,6 +3,8 @@ import { IOSConfig } from '@expo/config-plugins';
 
 import { BuildContext } from '../context';
 
+import { resolveBuildConfiguration, resolveScheme } from './resolve';
+
 // Functions specific to Apple TV support should be added here
 
 /**
@@ -12,19 +14,20 @@ import { BuildContext } from '../context';
  * @returns true if this is an Apple TV configuration, false otherwise
  */
 export async function isTVOS(ctx: BuildContext<Ios.Job>): Promise<boolean> {
-  if (!ctx.job.scheme) {
-    return false;
-  }
+  const scheme = resolveScheme(ctx);
+
   const project = IOSConfig.XcodeUtils.getPbxproj(ctx.reactNativeProjectDirectory);
 
   const targetName = await IOSConfig.BuildScheme.getApplicationTargetNameForSchemeAsync(
     ctx.reactNativeProjectDirectory,
-    ctx.job.scheme || ''
+    scheme
   );
+
+  const buildConfiguration = resolveBuildConfiguration(ctx);
 
   const xcBuildConfiguration = IOSConfig.Target.getXCBuildConfigurationFromPbxproj(project, {
     targetName,
-    buildConfiguration: ctx.job.buildConfiguration,
+    buildConfiguration,
   });
   return xcBuildConfiguration?.buildSettings?.SDKROOT?.includes('appletv');
 }

--- a/packages/build-tools/templates/Gymfile.simulator.template
+++ b/packages/build-tools/templates/Gymfile.simulator.template
@@ -9,7 +9,7 @@ configuration("<%- SCHEME_BUILD_CONFIGURATION %>")
 derived_data_path("<%- DERIVED_DATA_PATH %>")
 skip_package_ipa(true)
 skip_archive(true)
-destination("generic/platform=iOS Simulator")
+destination("<%- SCHEME_SIMULATOR_DESTINATION %>")
 
 disable_xcpretty(true)
 buildlog_path("<%- LOGS_DIRECTORY %>")


### PR DESCRIPTION
# Why

This is the first step in adding EAS support for Apple TV. See https://www.notion.so/expo/EAS-for-Apple-TV-99e62720e71f423ca5ae2c146cf2923e for details.

This does not add support for device builds, only for simulator builds.

# How

Added new module `tvos.ts` for Apple TV specific functions, with one new function to check if a build job is for tvOS and not iOS.

Made modifications to Gymfile simulator template and to `gymfile.ts` and `fastlane.ts` to select the correct simulator destination instead of using the hardcoded iOS simulator, and in `ios.ts` to select the correct build artifacts path.

# Test Plan

- Create a new React Native TV project with `react-native init ExpoTVTest --template=react-native-tvos`
- Execute `eas build:configure` to create the EAS JSON file
- Add a `preview` profile to `eas.json` to build for simulator as in the example below.
- Execute `eas build -p ios --profile=preview`

EAS will ask you to select from either the `ExpoTVTest` or `ExpoTVTest-tvOS` scheme, which will start a build for iOS and tvOS, respectively.

Example `eas.json`:

```json
{
  "cli": {
    "version": ">= 0.56.0"
  },
  "build": {
    "development": {
      "distribution": "internal",
      "android": {
        "gradleCommand": ":app:assembleDebug"
      },
      "ios": {
        "buildConfiguration": "Debug"
      }
    },
    "preview": {
      "android": {
        "buildType": "apk"
      },
      "ios": {
        "simulator": true
      },
      "distribution": "internal"
    },
    "production": {}
  },
  "submit": {
    "production": {}
  }
}
```
