### PR TITLE
[ENG-3865][build-tools] add support for running multiple tasks with gradlew

### DIFF
--- a/packages/build-tools/src/android/gradle.ts
+++ b/packages/build-tools/src/android/gradle.ts
@@ -23,7 +23,7 @@ export async function runGradleCommand(
 ): Promise<void> {
   const androidDir = path.join(ctx.reactNativeProjectDirectory, 'android');
   ctx.logger.info(`Running './gradlew ${gradleCommand}' in ${androidDir}`);
-  await spawn('sh', ['gradlew', gradleCommand], {
+  await spawn('bash', ['-c', `./gradlew ${gradleCommand}`], {
     cwd: androidDir,
     logger: ctx.logger,
     lineTransformer: (line?: string) => {


### PR DESCRIPTION
# Why

Part of https://linear.app/expo/issue/ENG-3865/testing-on-eas-build-documentation
For Detox tests I need to run the following gradlew command:
`assembleRelease assembleAndroidTest -DtestBuildType=release`

# How

Use `bash -c` to run gradle.

# Test Plan

Tested with local build plugin.
