### PR TITLE
[ENG-3865][local-build-plugin] set more env variables

### DIFF
--- a/packages/local-build-plugin/src/main.ts
+++ b/packages/local-build-plugin/src/main.ts
@@ -9,9 +9,9 @@ listenForInterrupts();
 
 async function main(): Promise<void> {
   try {
-    const { job } = await parseInputAsync();
+    const { job, metadata } = await parseInputAsync();
     await checkRuntimeAsync(job);
-    await buildAsync(job);
+    await buildAsync(job, metadata);
   } catch (err: any) {
     if (!shouldExit()) {
       console.error(chalk.red(err.message));

--- a/packages/local-build-plugin/src/parseInput.ts
+++ b/packages/local-build-plugin/src/parseInput.ts
@@ -1,4 +1,10 @@
-import { Job, sanitizeJob, ArchiveSourceType } from '@expo/eas-build-job';
+import {
+  Job,
+  sanitizeJob,
+  ArchiveSourceType,
+  Metadata,
+  sanitizeMetadata,
+} from '@expo/eas-build-job';
 import Joi from 'joi';
 import chalk from 'chalk';
 import fs from 'fs-extra';
@@ -9,10 +15,12 @@ const packageJson = require('../package.json');
 
 interface Params {
   job: Job;
+  metadata: Metadata;
 }
 
 const ParamsSchema = Joi.object<Params>({
   job: Joi.object().unknown(),
+  metadata: Joi.object().unknown(),
 });
 
 export async function parseInputAsync(): Promise<Params> {
@@ -53,7 +61,8 @@ function validateParams(params: object): Params {
   }
   try {
     const job = sanitizeJob(value.job);
-    return { ...value, job };
+    const metadata = sanitizeMetadata(value.metadata);
+    return { ...value, job, metadata };
   } catch (err) {
     console.log(`Currently using ${packageJson.name}@${packageJson.version}.`);
     console.error(


### PR DESCRIPTION
# Why

Part of https://linear.app/expo/issue/ENG-3865/testing-on-eas-build-documentation
An env variable with platform would be really useful for running detox tests.

# How

Set `EAS_BUILD_PLATFORM` and a few other env vars that are set when running builds in cloud.

# Test Plan

Tested with https://github.com/expo/eas-cli/pull/1256