### PR TITLE
[ENG-5059][build-tools] add skipped prebuild phase for bare projects

### DIFF
--- a/packages/build-tools/src/context.ts
+++ b/packages/build-tools/src/context.ts
@@ -76,6 +76,7 @@ export class BuildContext<TJob extends Job> {
 
   private readonly defaultLogger: bunyan;
   private buildPhase?: BuildPhase;
+  private buildPhaseSkipped = false;
   private buildPhaseHasWarnings = false;
   private _appConfig?: ExpoConfig;
 
@@ -129,7 +130,9 @@ export class BuildContext<TJob extends Job> {
     try {
       this.setBuildPhase(buildPhase, { doNotMarkStart });
       const result = await phase();
-      const buildPhaseResult: BuildPhaseResult = this.buildPhaseHasWarnings
+      const buildPhaseResult: BuildPhaseResult = this.buildPhaseSkipped
+        ? BuildPhaseResult.SKIPPED
+        : this.buildPhaseHasWarnings
         ? BuildPhaseResult.WARNING
         : BuildPhaseResult.SUCCESS;
       this.endCurrentBuildPhase({ result: buildPhaseResult, doNotMarkEnd });
@@ -160,6 +163,10 @@ export class BuildContext<TJob extends Job> {
       this.endCurrentBuildPhase({ result: BuildPhaseResult.FAIL });
       throw userError ?? err;
     }
+  }
+
+  public markBuildPhaseSkipped(): void {
+    this.buildPhaseSkipped = true;
   }
 
   public markBuildPhaseHasWarnings(): void {
@@ -200,6 +207,7 @@ export class BuildContext<TJob extends Job> {
     }
     this.logger = this.defaultLogger;
     this.buildPhase = undefined;
+    this.buildPhaseSkipped = false;
     this.buildPhaseHasWarnings = false;
   }
 }

--- a/packages/eas-build-job/src/logs.ts
+++ b/packages/eas-build-job/src/logs.ts
@@ -44,6 +44,7 @@ export enum BuildPhaseResult {
   SUCCESS = 'success',
   FAIL = 'failed',
   WARNING = 'warning',
+  SKIPPED = 'skipped',
   UNKNOWN = 'unknown',
 }
 


### PR DESCRIPTION
# Why

https://linear.app/expo/issue/ENG-5059/add-skipped-prebuild-phase-to-bare-builds

# How

- Add a prebuild step for bare projects and indicate that it was skipped.
- Add a new build phase result type - SKIPPED - so we can mark it with another icon on the website.

# Test Plan

Tested with local plugin.