### PR TITLE
[eas-build-job] scope android images per sdk

### DIFF
--- a/packages/eas-build-job/src/__tests__/job.test.ts
+++ b/packages/eas-build-job/src/__tests__/job.test.ts
@@ -1,0 +1,42 @@
+import { Workflow } from '../common';
+import { setAndroidBuilderImage, setIosBuilderImageForManagedJob } from '../job';
+
+function testAndroidImage(
+  sdkVersion?: string,
+  reactNativeVersion?: string,
+  expectedImage?: string
+): void {
+  const job: any = { builderEnvironment: {} };
+  setAndroidBuilderImage(job, sdkVersion, reactNativeVersion);
+  expect(job?.builderEnvironment?.image).toBe(expectedImage);
+}
+
+describe(setAndroidBuilderImage, () => {
+  test('selecting image', () => {
+    testAndroidImage('45.0.0', '0.69.0', 'ubuntu-18.04-jdk-11-ndk-r19c');
+    testAndroidImage('45.0.0', '0.67.0', 'ubuntu-18.04-jdk-8-ndk-r19c');
+    testAndroidImage('46.0.0', '0.69.0', 'ubuntu-20.04-jdk-11-ndk-r21e');
+    testAndroidImage(undefined, '0.69.0', undefined);
+    testAndroidImage('46.0.0', undefined, undefined);
+  });
+});
+
+function testIosImage(
+  sdkVersion: string | undefined,
+  workflow: Workflow,
+  expectedImage: string | undefined
+): void {
+  const job: any = { builderEnvironment: {}, type: workflow };
+  setIosBuilderImageForManagedJob(job, sdkVersion);
+  expect(job?.builderEnvironment?.image).toBe(expectedImage);
+}
+
+describe(setIosBuilderImageForManagedJob, () => {
+  test('selecting image', () => {
+    testIosImage('44.0.0', Workflow.MANAGED, 'macos-big-sur-11.4-xcode-13.0');
+    testIosImage('45.0.0', Workflow.MANAGED, 'macos-monterey-12.3-xcode-13.3');
+    testIosImage('46.0.0', Workflow.MANAGED, 'macos-monterey-12.3-xcode-13.3');
+    testIosImage('46.0.0', Workflow.GENERIC, undefined);
+    testIosImage(undefined, Workflow.MANAGED, undefined);
+  });
+});

--- a/packages/eas-build-job/src/__tests__/job.test.ts
+++ b/packages/eas-build-job/src/__tests__/job.test.ts
@@ -1,42 +1,36 @@
 import { Workflow } from '../common';
 import { setAndroidBuilderImage, setIosBuilderImageForManagedJob } from '../job';
 
-function testAndroidImage(
-  sdkVersion?: string,
-  reactNativeVersion?: string,
-  expectedImage?: string
-): void {
-  const job: any = { builderEnvironment: {} };
-  setAndroidBuilderImage(job, sdkVersion, reactNativeVersion);
-  expect(job?.builderEnvironment?.image).toBe(expectedImage);
-}
-
 describe(setAndroidBuilderImage, () => {
-  test('selecting image', () => {
-    testAndroidImage('45.0.0', '0.69.0', 'ubuntu-18.04-jdk-11-ndk-r19c');
-    testAndroidImage('45.0.0', '0.67.0', 'ubuntu-18.04-jdk-8-ndk-r19c');
-    testAndroidImage('46.0.0', '0.69.0', 'ubuntu-20.04-jdk-11-ndk-r21e');
-    testAndroidImage(undefined, '0.69.0', undefined);
-    testAndroidImage('46.0.0', undefined, undefined);
-  });
+  test.each([
+    ['45.0.0', '0.69.0', 'ubuntu-18.04-jdk-11-ndk-r19c'],
+    ['45.0.0', '0.67.0', 'ubuntu-18.04-jdk-8-ndk-r19c'],
+    ['46.0.0', '0.69.0', 'ubuntu-20.04-jdk-11-ndk-r21e'],
+    [undefined, '0.69.0', undefined],
+    ['46.0.0', undefined, undefined],
+  ])(
+    'selecting image for sdkVersion %s and React Native %s',
+    (sdkVersion?: string, reactNativeVersion?: string, expectedImage?: string) => {
+      const job: any = { builderEnvironment: {} };
+      setAndroidBuilderImage(job, sdkVersion, reactNativeVersion);
+      expect(job?.builderEnvironment?.image).toBe(expectedImage);
+    }
+  );
 });
 
-function testIosImage(
-  sdkVersion: string | undefined,
-  workflow: Workflow,
-  expectedImage: string | undefined
-): void {
-  const job: any = { builderEnvironment: {}, type: workflow };
-  setIosBuilderImageForManagedJob(job, sdkVersion);
-  expect(job?.builderEnvironment?.image).toBe(expectedImage);
-}
-
 describe(setIosBuilderImageForManagedJob, () => {
-  test('selecting image', () => {
-    testIosImage('44.0.0', Workflow.MANAGED, 'macos-big-sur-11.4-xcode-13.0');
-    testIosImage('45.0.0', Workflow.MANAGED, 'macos-monterey-12.3-xcode-13.3');
-    testIosImage('46.0.0', Workflow.MANAGED, 'macos-monterey-12.3-xcode-13.3');
-    testIosImage('46.0.0', Workflow.GENERIC, undefined);
-    testIosImage(undefined, Workflow.MANAGED, undefined);
-  });
+  test.each([
+    ['44.0.0', Workflow.MANAGED, 'macos-big-sur-11.4-xcode-13.0'],
+    ['45.0.0', Workflow.MANAGED, 'macos-monterey-12.3-xcode-13.3'],
+    ['46.0.0', Workflow.MANAGED, 'macos-monterey-12.3-xcode-13.3'],
+    ['46.0.0', Workflow.GENERIC, undefined],
+    [undefined, Workflow.MANAGED, undefined],
+  ])(
+    'selecting image for sdkVersion %s and React Native %s',
+    (sdkVersion: string | undefined, workflow: Workflow, expectedImage: string | undefined) => {
+      const job: any = { builderEnvironment: {}, type: workflow };
+      setIosBuilderImageForManagedJob(job, sdkVersion);
+      expect(job?.builderEnvironment?.image).toBe(expectedImage);
+    }
+  );
 });

--- a/packages/eas-build-job/src/android.ts
+++ b/packages/eas-build-job/src/android.ts
@@ -44,13 +44,34 @@ export const builderBaseImages = [
   'ubuntu-22.04-jdk-11-ndk-r21e',
 ] as const;
 
-export const reactNativeVersionToDefaultBuilderImage: Record<
-  string,
-  typeof builderBaseImages[number]
-> = {
-  '>=0.68.0': 'ubuntu-18.04-jdk-11-ndk-r19c',
-  '<0.68.0': 'ubuntu-18.04-jdk-8-ndk-r19c',
-};
+interface ImageMatchRule {
+  image: typeof builderBaseImages[number];
+  reactNativeSemverRange: string;
+  sdkSemverRange: string;
+}
+
+export const reactNativeImageMatchRules: ImageMatchRule[] = [
+  {
+    image: 'ubuntu-18.04-jdk-11-ndk-r19c',
+    reactNativeSemverRange: '>=0.68.0',
+    sdkSemverRange: '<46',
+  },
+  {
+    image: 'ubuntu-18.04-jdk-8-ndk-r19c',
+    reactNativeSemverRange: '<0.68.0',
+    sdkSemverRange: '<46',
+  },
+  {
+    image: 'ubuntu-20.04-jdk-11-ndk-r21e',
+    reactNativeSemverRange: '>=0.68.0',
+    sdkSemverRange: '>=46',
+  },
+  {
+    image: 'ubuntu-20.04-jdk-8-ndk-r21e',
+    reactNativeSemverRange: '<0.68.0',
+    sdkSemverRange: '>=46',
+  },
+];
 
 export interface BuilderEnvironment {
   image?: typeof builderBaseImages[number];

--- a/packages/eas-build-job/src/ios.ts
+++ b/packages/eas-build-job/src/ios.ts
@@ -52,7 +52,7 @@ export const builderBaseImages = [
 
 export const sdkVersionToDefaultBuilderImage: Record<string, typeof builderBaseImages[number]> = {
   '<=44': 'macos-big-sur-11.4-xcode-13.0',
-  '45': 'macos-monterey-12.3-xcode-13.3',
+  '>=45': 'macos-monterey-12.3-xcode-13.3',
 };
 
 export interface BuilderEnvironment {


### PR DESCRIPTION
# Why

Detect default android image per SDK, e.g. for SDK 46 we should use an image with ndk 21 already installed otherwise build times are significantly increasing

# How


# Test Plan

Added tests