### PR TITLE
[build-tools][ENG-4933] use cocoapods proxy

### DIFF
--- a/packages/build-tools/src/ios/pod.ts
+++ b/packages/build-tools/src/ios/pod.ts
@@ -36,5 +36,15 @@ export async function installPods<TJob extends Ios.Job>(ctx: BuildContext<TJob>)
     cwd: iosDir,
     logger: ctx.logger,
     env: { ...ctx.env, LANG: 'en_US.UTF-8' },
+    lineTransformer: (line?: string) => {
+      if (
+        !line ||
+        /\[!\] '[a-zA-Z1-9-]+' uses the unencrypted 'http' protocol to transfer the Pod./.exec(line)
+      ) {
+        return null;
+      } else {
+        return line;
+      }
+    },
   });
 }

--- a/packages/build-tools/src/ios/pod.ts
+++ b/packages/build-tools/src/ios/pod.ts
@@ -10,11 +10,10 @@ export async function installPods<TJob extends Ios.Job>(ctx: BuildContext<TJob>)
   const iosDir = path.join(ctx.reactNativeProjectDirectory, 'ios');
 
   if (ctx.env.EAS_BUILD_COCOAPODS_CACHE_URL) {
-    ctx.logger.info('Running using experimental CocoaPods cache proxy...');
     const podfilePath = path.join(iosDir, 'Podfile');
     const originalPodfileContents = await fs.readFile(podfilePath, 'utf-8');
 
-    const cocoaPodsCdnSourceRegex = /source( )+('|")https:\/\/cdn.cocoapods.org(\/)*('|")/;
+    const cocoaPodsCdnSourceRegex = /\bsource\s*\(?['"]https:\/\/cdn\.cocoapods\.org\/?['"]\)?/g;
 
     if (originalPodfileContents.search(cocoaPodsCdnSourceRegex) !== -1) {
       await fs.writeFile(
@@ -39,7 +38,7 @@ export async function installPods<TJob extends Ios.Job>(ctx: BuildContext<TJob>)
     lineTransformer: (line?: string) => {
       if (
         !line ||
-        /\[!\] '[a-zA-Z1-9-]+' uses the unencrypted 'http' protocol to transfer the Pod./.exec(line)
+        /\[!\] '[\w-]+' uses the unencrypted 'http' protocol to transfer the Pod\./.exec(line)
       ) {
         return null;
       } else {

--- a/packages/build-tools/src/ios/pod.ts
+++ b/packages/build-tools/src/ios/pod.ts
@@ -1,5 +1,6 @@
 import path from 'path';
 
+import fs from 'fs-extra';
 import { Ios } from '@expo/eas-build-job';
 import spawn from '@expo/turtle-spawn';
 
@@ -7,6 +8,13 @@ import { BuildContext } from '../context';
 
 export async function installPods<TJob extends Ios.Job>(ctx: BuildContext<TJob>): Promise<void> {
   const iosDir = path.join(ctx.reactNativeProjectDirectory, 'ios');
+
+  if (ctx.env.EAS_BUILD_COCOAPODS_CACHE_URL && Math.random() < 0.33) {
+    ctx.logger.info('Running using experimental Cocoapods cache proxy...');
+    const podFile = path.join(iosDir, 'Podfile');
+    await fs.appendFile(podFile, `\nsource "${ctx.env.EAS_BUILD_COCOAPODS_CACHE_URL}"`);
+  }
+
   ctx.logger.info('Installing pods');
   await spawn('pod', ['install'], {
     cwd: iosDir,


### PR DESCRIPTION
# Why

[ENG-4933](https://linear.app/expo/issue/ENG-4933/investigate-cocoapods-cachemirror)

# How

Uses newly created Cocoapods proxy as a source for pods.

This is an experimental feature so we want to use it for 1/3 of builds on our platform to reduce the impact of a potential outage.

# Test Plan

Run build locally using MacStadium network and see how it goes.

