### PR TITLE
[ENG-4730] add support for environment secret files

### DIFF
--- a/packages/build-tools/src/context.ts
+++ b/packages/build-tools/src/context.ts
@@ -106,19 +106,8 @@ export class BuildContext<TJob extends Job> {
     this.reportError = options.reportError;
     this.metadata = options.metadata;
     this.skipNativeBuild = options.skipNativeBuild;
-    const environmentSecrets: Record<string, string> = {};
-    if (Array.isArray(job?.secrets?.environmentSecrets)) {
-      for (const { name, type, value } of job.secrets.environmentSecrets) {
-        if (type === EnvironmentSecretType.STRING) {
-          environmentSecrets[name] = value;
-        } else {
-          environmentSecrets[name] = createTemporaryEnvironmentSecretFile(
-            this.environmentSecrectsDirectory,
-            value
-          );
-        }
-      }
-    }
+
+    const environmentSecrets = this.getEnvironmentSecrets(job);
     this.env = {
       ...options.env,
       ...job?.builderEnvironment?.env,
@@ -246,5 +235,26 @@ export class BuildContext<TJob extends Job> {
     this.buildPhase = undefined;
     this.buildPhaseSkipped = false;
     this.buildPhaseHasWarnings = false;
+  }
+
+  private getEnvironmentSecrets(job: TJob): Record<string, string> {
+    if (Array.isArray(job?.secrets?.environmentSecrets)) {
+      const environmentSecrets: Record<string, string> = {};
+      for (const { name, type, value } of job.secrets.environmentSecrets) {
+        if (type === EnvironmentSecretType.STRING) {
+          environmentSecrets[name] = value;
+        } else {
+          environmentSecrets[name] = createTemporaryEnvironmentSecretFile(
+            this.environmentSecrectsDirectory,
+            value
+          );
+        }
+      }
+      return environmentSecrets;
+    } else if (job?.secrets?.environmentSecrets) {
+      return { ...job.secrets.environmentSecrets };
+    } else {
+      return {};
+    }
   }
 }

--- a/packages/build-tools/src/context.ts
+++ b/packages/build-tools/src/context.ts
@@ -8,6 +8,7 @@ import {
   Env,
   errors,
   Metadata,
+  EnvironmentSecretType,
 } from '@expo/eas-build-job';
 import { ExpoConfig } from '@expo/config';
 import { bunyan } from '@expo/logger';
@@ -16,6 +17,7 @@ import { SpawnPromise, SpawnOptions, SpawnResult } from '@expo/turtle-spawn';
 import { PackageManager, resolvePackageManager } from './utils/packageManager';
 import { resolveBuildPhaseError } from './buildErrors/detectError';
 import { readAppConfig } from './utils/appConfig';
+import { createTemporaryEnvironmentSecretFile } from './utils/environmentSecrets';
 
 export enum ArtifactType {
   APPLICATION_ARCHIVE = 'APPLICATION_ARCHIVE',
@@ -104,10 +106,23 @@ export class BuildContext<TJob extends Job> {
     this.reportError = options.reportError;
     this.metadata = options.metadata;
     this.skipNativeBuild = options.skipNativeBuild;
+    const environmentSecrets: Record<string, string> = {};
+    if (Array.isArray(job?.secrets?.environmentSecrets)) {
+      for (const { name, type, value } of job.secrets.environmentSecrets) {
+        if (type === EnvironmentSecretType.STRING) {
+          environmentSecrets[name] = value;
+        } else {
+          environmentSecrets[name] = createTemporaryEnvironmentSecretFile(
+            this.environmentSecrectsDirectory,
+            value
+          );
+        }
+      }
+    }
     this.env = {
       ...options.env,
       ...job?.builderEnvironment?.env,
-      ...job?.secrets?.environmentSecrets,
+      ...environmentSecrets,
     };
   }
 
@@ -116,6 +131,9 @@ export class BuildContext<TJob extends Job> {
   }
   public get buildLogsDirectory(): string {
     return path.join(this.workingdir, 'logs');
+  }
+  public get environmentSecrectsDirectory(): string {
+    return path.join(this.workingdir, 'environment-secrets');
   }
   public get reactNativeProjectDirectory(): string {
     return path.join(this.buildDirectory, this.job.projectRootDirectory);

--- a/packages/build-tools/src/utils/environmentSecrets.ts
+++ b/packages/build-tools/src/utils/environmentSecrets.ts
@@ -1,0 +1,10 @@
+import fs from 'fs';
+import path from 'path';
+
+import { v4 as uuid } from 'uuid';
+
+export function createTemporaryEnvironmentSecretFile(secretsDir: string, value: string): string {
+  const randomFilePath = path.join(secretsDir, uuid());
+  fs.writeFileSync(randomFilePath, Buffer.from(value, 'base64'));
+  return randomFilePath;
+}

--- a/packages/eas-build-job/src/android.ts
+++ b/packages/eas-build-job/src/android.ts
@@ -9,6 +9,8 @@ import {
   Workflow,
   Cache,
   CacheSchema,
+  EnvironmentSecretsSchema,
+  EnvironmentSecret,
 } from './common';
 
 export interface Keystore {
@@ -104,7 +106,7 @@ export interface Job {
     buildCredentials?: {
       keystore: Keystore;
     };
-    environmentSecrets?: Env;
+    environmentSecrets?: EnvironmentSecret[] | Env;
   };
   builderEnvironment?: BuilderEnvironment;
   cache: Cache;
@@ -146,7 +148,7 @@ export const JobSchema = Joi.object({
   }),
   secrets: Joi.object({
     buildCredentials: Joi.object({ keystore: KeystoreSchema.required() }),
-    environmentSecrets: EnvSchema,
+    environmentSecrets: Joi.alternatives().try(EnvironmentSecretsSchema, EnvSchema),
   }).required(),
   builderEnvironment: BuilderEnvironmentSchema,
   cache: CacheSchema.default(),

--- a/packages/eas-build-job/src/common.ts
+++ b/packages/eas-build-job/src/common.ts
@@ -46,8 +46,26 @@ export const ArchiveSourceSchema = Joi.object<ArchiveSource>({
   });
 
 export type Env = Record<string, string>;
-
 export const EnvSchema = Joi.object().pattern(Joi.string(), Joi.string());
+
+export type EnvironmentSecret = {
+  name: string;
+  type: EnvironmentSecretType;
+  value: string;
+};
+export enum EnvironmentSecretType {
+  STRING = 'string',
+  FILE = 'file',
+}
+export const EnvironmentSecretsSchema = Joi.array().items(
+  Joi.object({
+    name: Joi.string().required(),
+    value: Joi.string().required(),
+    type: Joi.string()
+      .valid(...Object.values(EnvironmentSecretType))
+      .required(),
+  })
+);
 
 export interface Cache {
   disabled: boolean;

--- a/packages/eas-build-job/src/index.ts
+++ b/packages/eas-build-job/src/index.ts
@@ -1,6 +1,15 @@
 export * as Android from './android';
 export * as Ios from './ios';
-export { ArchiveSourceType, ArchiveSource, Env, Workflow, Platform, Cache } from './common';
+export {
+  ArchiveSourceType,
+  ArchiveSource,
+  Env,
+  EnvironmentSecret,
+  EnvironmentSecretType,
+  Workflow,
+  Platform,
+  Cache,
+} from './common';
 export { Job, sanitizeJob } from './job';
 export { Metadata, sanitizeMetadata } from './metadata';
 export * from './logs';

--- a/packages/eas-build-job/src/ios.ts
+++ b/packages/eas-build-job/src/ios.ts
@@ -9,6 +9,8 @@ import {
   Workflow,
   Cache,
   CacheSchema,
+  EnvironmentSecretsSchema,
+  EnvironmentSecret,
 } from './common';
 
 export type DistributionType = 'store' | 'internal' | 'simulator';
@@ -88,7 +90,7 @@ export interface Job {
   };
   secrets: {
     buildCredentials?: BuildCredentials;
-    environmentSecrets?: Env;
+    environmentSecrets?: EnvironmentSecret[] | Env;
   };
   builderEnvironment?: BuilderEnvironment;
   cache: Cache;
@@ -131,7 +133,7 @@ export const JobSchema = Joi.object({
   }),
   secrets: Joi.object({
     buildCredentials: BuildCredentialsSchema,
-    environmentSecrets: EnvSchema,
+    environmentSecrets: Joi.alternatives().try(EnvironmentSecretsSchema, EnvSchema),
   }).required(),
   builderEnvironment: BuilderEnvironmentSchema,
   cache: CacheSchema.default(),


### PR DESCRIPTION
# Why

We want to support uploading files to EAS Secrets.
This PR changes the format of environment secrets passed to Turtle. Now they have the `type` field which can be either `string` or `file`. For `file` env secrets, we save the value to an ephemeral file and set the env variable to file path.

# How

- Support the new job format (typed secrets).
- Creating files for `file` secret values.

# Test Plan

Tested manually.