### PR TITLE
[cocoapods-nexus-plugin] blacklist `razorpay-pod`

### DIFF
--- a/packages/cocoapods-nexus-plugin/lib/cocoapods-nexus-plugin/gem_version.rb
+++ b/packages/cocoapods-nexus-plugin/lib/cocoapods-nexus-plugin/gem_version.rb
@@ -1,3 +1,3 @@
 module CocoapodsNexusPlugin
-  VERSION = "0.0.2"
+  VERSION = "0.0.3"
 end

--- a/packages/cocoapods-nexus-plugin/lib/cocoapods_plugin.rb
+++ b/packages/cocoapods-nexus-plugin/lib/cocoapods_plugin.rb
@@ -3,7 +3,7 @@ require 'fileutils'
 
 CDN_URL = "https://cdn.cocoapods.org"
 
-POD_BLACKLIST = ["libwebp", "Braintree"]
+POD_BLACKLIST = ["libwebp", "Braintree", "razorpay-pod"]
 
 NEXUS_COCOAPODS_REPO_URL = ENV['NEXUS_COCOAPODS_REPO_URL']
 


### PR DESCRIPTION
# Why

https://sentry.io/organizations/expoio/issues/3612014624/events/8b2cb187a8ca454da95b12ef1d906fa0/?project=1837720

Our proxy fails to install `razorpay-pod`. I tested it locally and adding it to the blacklist resolves the issue.

# How

Add `razorpay-pod` to the blacklist

# Test Plan

Test locally and on staging
