### PR TITLE
[cocoapods-nexus-plugin] blacklist TrezorCrypto pod

### DIFF
--- a/packages/cocoapods-nexus-plugin/lib/cocoapods-nexus-plugin/gem_version.rb
+++ b/packages/cocoapods-nexus-plugin/lib/cocoapods-nexus-plugin/gem_version.rb
@@ -1,3 +1,3 @@
 module CocoapodsNexusPlugin
-  VERSION = "0.0.3"
+  VERSION = "0.0.4"
 end

--- a/packages/cocoapods-nexus-plugin/lib/cocoapods_plugin.rb
+++ b/packages/cocoapods-nexus-plugin/lib/cocoapods_plugin.rb
@@ -3,7 +3,7 @@ require 'fileutils'
 
 CDN_URL = "https://cdn.cocoapods.org"
 
-POD_BLACKLIST = ["libwebp", "Braintree", "razorpay-pod"]
+POD_BLACKLIST = ["libwebp", "Braintree", "razorpay-pod", "TrezorCrypto"]
 
 NEXUS_COCOAPODS_REPO_URL = ENV['NEXUS_COCOAPODS_REPO_URL']
 


### PR DESCRIPTION
# Why

TrezorCrypto pod doesn't work with our proxy and I've seen some errors about it in Sentry.

# How

Blacklist TrezorCrypto pod

# Test Plan

Tested locally
