### PR TITLE
[cocapods-nexus-plugin] blacklist MapboxMobileEvents pod

### DIFF
--- a/packages/cocoapods-nexus-plugin/lib/cocoapods-nexus-plugin/gem_version.rb
+++ b/packages/cocoapods-nexus-plugin/lib/cocoapods-nexus-plugin/gem_version.rb
@@ -1,3 +1,3 @@
 module CocoapodsNexusPlugin
-  VERSION = "0.0.8"
+  VERSION = "0.0.9"
 end

--- a/packages/cocoapods-nexus-plugin/lib/cocoapods_plugin.rb
+++ b/packages/cocoapods-nexus-plugin/lib/cocoapods_plugin.rb
@@ -3,7 +3,16 @@ require 'fileutils'
 
 CDN_URL = "https://cdn.cocoapods.org"
 
-POD_BLACKLIST = ["libwebp", "Braintree", "razorpay-pod", "TrezorCrypto", "MapboxCommon", "MapboxCoreMaps", "CFSDK"]
+POD_BLACKLIST = [
+  "libwebp",
+  "Braintree",
+  "razorpay-pod",
+  "TrezorCrypto",
+  "MapboxCommon",
+  "MapboxCoreMaps",
+  "CFSDK",
+  "MapboxMobileEvents"
+]
 
 NEXUS_COCOAPODS_REPO_URL = ENV['NEXUS_COCOAPODS_REPO_URL']
 


### PR DESCRIPTION
# Why

Blacklist MapboxMobileEvents pod

I think that all pods which were the dependencies of https://cocoapods.org/pods/MapboxMaps required an authentication token when downloading the pod which caused the proxy to fail

Hopefully, this PR changes it and we will no longer see the issues about Mapbox on our end

# How

Blacklist MapboxMobileEvents pod

# Test Plan

Test locally and on staging
