### PR TITLE
[eas-build] Remove release channel is "default" log

### DIFF
--- a/packages/build-tools/src/utils/expoUpdates.ts
+++ b/packages/build-tools/src/utils/expoUpdates.ts
@@ -114,19 +114,12 @@ export async function configureClassicExpoUpdatesAsync(ctx: BuildContext<Job>): 
   if (ctx.job.releaseChannel) {
     await setClassicReleaseChannelNativelyAsync(ctx);
   } else {
-    /**
-     * If releaseChannel is not defined:
-     *  1. Try to infer it from the native value.
-     *  2. If it is not set, fallback to 'default'.
-     */
     const releaseChannel = await getNativelyDefinedClassicReleaseChannelAsync(ctx);
     if (releaseChannel) {
       ctx.logger.info(
         `Using the release channel pre-configured in native project (${releaseChannel})`
       );
       ctx.logger.warn('Please add the "releaseChannel" field to your build profile (eas.json)');
-    } else {
-      ctx.logger.info(`Using default release channel for 'expo-updates' (default)`);
     }
   }
 }


### PR DESCRIPTION
# Why

> This is just an idea right now. There may be a better way to approach this.

This removes a log that would no longer be true if we merge and publish https://github.com/expo/expo/pull/19321

