### PR TITLE
[cocoapods-nexus-plugin] fix problem with multiple sources setup

### DIFF
--- a/packages/cocoapods-nexus-plugin/lib/cocoapods-nexus-plugin/gem_version.rb
+++ b/packages/cocoapods-nexus-plugin/lib/cocoapods-nexus-plugin/gem_version.rb
@@ -1,3 +1,3 @@
 module CocoapodsNexusPlugin
-  VERSION = "0.0.9"
+  VERSION = "0.0.10"
 end


### PR DESCRIPTION
# Why

https://forums.expo.dev/t/eas-build-ios-install-pods-error-undefined-method-search-for-https-cdn-cocoapods-org-string/66771
It seems like our proxy had a bug and wasn't able to handle multiple sources set in `Podfile`

# How

In `Pod::Installer::Analyzer` `sources` method make sure that all the sources are converted to `Pod::Source` class instances vs being just the string URLs (what caused the bug for the user). Reuse code from CocoaPods core repo to auto convert URL to the `Pod::Source` class instance using sources manager. This should handle inline sources as well, specified for a given pod.

# Test Plan

Test locally and on staging
