### PR TITLE
[cocoapods-nexus-plugin] blacklist Mapbox-iOS-SDK pod

### DIFF
--- a/packages/cocoapods-nexus-plugin/lib/cocoapods-nexus-plugin/gem_version.rb
+++ b/packages/cocoapods-nexus-plugin/lib/cocoapods-nexus-plugin/gem_version.rb
@@ -1,3 +1,3 @@
 module CocoapodsNexusPlugin
-  VERSION = "0.0.10"
+  VERSION = "0.0.11"
 end

--- a/packages/cocoapods-nexus-plugin/lib/cocoapods_plugin.rb
+++ b/packages/cocoapods-nexus-plugin/lib/cocoapods_plugin.rb
@@ -9,7 +9,8 @@ POD_BLACKLIST = [
   "MapboxCommon",
   "MapboxCoreMaps",
   "CFSDK",
-  "MapboxMobileEvents"
+  "MapboxMobileEvents",
+  "Mapbox-iOS-SDK"
 ]
 
 NEXUS_COCOAPODS_REPO_URL = ENV['NEXUS_COCOAPODS_REPO_URL']


### PR DESCRIPTION
# Why

https://sentry.io/organizations/expoio/issues/3612014624/events/12b9e78b9d7b429fa28ac86085eaca7a/?project=1837720
A similar issue we've already seen with some other Mapbox pods.

# How

Blacklist `Mapbox-iOS-SDK` pod

# Test Plan

Test locally and on staging
