### PR TITLE
[build-tools] improve cocoapods cache error handling

### DIFF
--- a/packages/build-tools/src/buildErrors/buildErrorHandlers.ts
+++ b/packages/build-tools/src/buildErrors/buildErrorHandlers.ts
@@ -162,6 +162,28 @@ export const buildErrorHandlers: ErrorHandler<TrackedBuildError>[] = [
     platform: Platform.IOS,
     phase: BuildPhase.INSTALL_PODS,
     regexp: ({ env }: ErrorContext) =>
+      env.EAS_BUILD_COCOAPODS_CACHE_URL ? /Error installing/ : undefined,
+    createError: () =>
+      new TrackedBuildError(
+        'COCOAPODS_CACHE_INSTALLING_POD_ERROR',
+        `cocoapods: error installing a pod using internal cache instance`
+      ),
+  },
+  {
+    platform: Platform.IOS,
+    phase: BuildPhase.INSTALL_PODS,
+    regexp: ({ env }: ErrorContext) =>
+      env.EAS_BUILD_COCOAPODS_CACHE_URL ? /No podspec exists at path/ : undefined,
+    createError: () =>
+      new TrackedBuildError(
+        'COCOAPODS_CACHE_NO_PODSPEC_EXISTS_AT_PATH_ERROR',
+        `cocoapods: error fetching a podspec through internal cache instance`
+      ),
+  },
+  {
+    platform: Platform.IOS,
+    phase: BuildPhase.INSTALL_PODS,
+    regexp: ({ env }: ErrorContext) =>
       env.EAS_BUILD_COCOAPODS_CACHE_URL
         ? new RegExp(escapeRegExp(env.EAS_BUILD_COCOAPODS_CACHE_URL))
         : undefined,


### PR DESCRIPTION
# Why

In almost all cases if CocoaPods cache fails due to an issue with Nexus3 internal problems we can see in the logs that it either failed with `Error installing ...` or `No podspec found ...` error.

Creating two separate error handlers for these errors can help us monitor issues with the nexus cache more effectively. Generic errors (mostly containing user errors) should still be available under the generic `COCOAPODS_CACHE_ERROR` error in Sentry.

# How

Add two more error handlers for the CocoaPods cache.

# Test Plan

Test on staging
