### PR TITLE
[cocoapods-nexus-plugin] blacklist few more Mapbox pods

### DIFF
--- a/packages/cocoapods-nexus-plugin/lib/cocoapods-nexus-plugin/gem_version.rb
+++ b/packages/cocoapods-nexus-plugin/lib/cocoapods-nexus-plugin/gem_version.rb
@@ -1,3 +1,3 @@
 module CocoapodsNexusPlugin
-  VERSION = "0.0.11"
+  VERSION = "0.0.12"
 end

--- a/packages/cocoapods-nexus-plugin/lib/cocoapods_plugin.rb
+++ b/packages/cocoapods-nexus-plugin/lib/cocoapods_plugin.rb
@@ -10,7 +10,11 @@ POD_BLACKLIST = [
   "MapboxCoreMaps",
   "CFSDK",
   "MapboxMobileEvents",
-  "Mapbox-iOS-SDK"
+  "Mapbox-iOS-SDK",
+  "MapboxNavigationNative",
+  "MapboxNavigation",
+  "MapboxCoreNavigation",
+  "MapboxSpeech"
 ]
 
 NEXUS_COCOAPODS_REPO_URL = ENV['NEXUS_COCOAPODS_REPO_URL']


### PR DESCRIPTION
# Why

https://sentry.io/organizations/expoio/issues/3612014624/events/26a839144f6145b58c7bb7e957681bf5/?project=1837720

Seems like yet another Mapbox pod requires a token to download it. It causes the CocoaPods cache to fail.

# How

Blacklist the` MapboxNavigation` pod with all dependencies.
