### PR TITLE
[ENG-6599][local-build-plugin] Remove requirement to install yarn

### DIFF
--- a/packages/local-build-plugin/src/checkRuntime.ts
+++ b/packages/local-build-plugin/src/checkRuntime.ts
@@ -53,17 +53,20 @@ const validators: Validator[] = [
   },
   {
     async checkAsync(job: Job) {
-      try {
-        const version = (await spawnAsync('yarn', ['--version'], { stdio: 'pipe' })).stdout.trim();
-        const versionFromJob = job.builderEnvironment?.yarn;
-        if (versionFromJob && versionFromJob !== version) {
-          warn(
-            'Yarn version in your eas.json does not match the yarn currently installed in your system'
-          );
+      const versionFromJob = job.builderEnvironment?.yarn;
+      if (versionFromJob) {
+        try {
+          const version = (
+            await spawnAsync('yarn', ['--version'], { stdio: 'pipe' })
+          ).stdout.trim();
+          if (versionFromJob !== version) {
+            warn(
+              'Yarn version in your eas.json does not match the yarn currently installed in your system'
+            );
+          }
+        } catch (err) {
+          warn("Yarn is not available, make sure it's installed and in your PATH");
         }
-      } catch (err) {
-        error("Yarn is not available, make sure it's installed and in your PATH");
-        throw err;
       }
     },
   },

--- a/packages/local-build-plugin/src/checkRuntime.ts
+++ b/packages/local-build-plugin/src/checkRuntime.ts
@@ -54,19 +54,18 @@ const validators: Validator[] = [
   {
     async checkAsync(job: Job) {
       const versionFromJob = job.builderEnvironment?.yarn;
-      if (versionFromJob) {
-        try {
-          const version = (
-            await spawnAsync('yarn', ['--version'], { stdio: 'pipe' })
-          ).stdout.trim();
-          if (versionFromJob !== version) {
-            warn(
-              'Yarn version in your eas.json does not match the yarn currently installed in your system'
-            );
-          }
-        } catch (err) {
-          warn("Yarn is not available, make sure it's installed and in your PATH");
+      if (!versionFromJob) {
+        return;
+      }
+      try {
+        const version = (await spawnAsync('yarn', ['--version'], { stdio: 'pipe' })).stdout.trim();
+        if (versionFromJob !== version) {
+          warn(
+            'Yarn version in your eas.json does not match the yarn currently installed in your system'
+          );
         }
+      } catch (err) {
+        warn("Yarn is not available, make sure it's installed and in your PATH");
       }
     },
   },


### PR DESCRIPTION
# Why

We shouldn't require yarn for all local builds.

# How

- Check yarn version only if it's specified in eas.json.
- Do not throw error if yarn is not installed.

# Test Plan

