### PR TITLE
[build-tools] move the install dependencies phase after printing package.json

### DIFF
--- a/packages/build-tools/src/utils/project.ts
+++ b/packages/build-tools/src/utils/project.ts
@@ -32,13 +32,13 @@ export async function setup<TJob extends Job>(ctx: BuildContext<TJob>): Promise<
     await runHookIfPresent(ctx, Hook.PRE_INSTALL);
   });
 
-  await ctx.runBuildPhase(BuildPhase.INSTALL_DEPENDENCIES, async () => {
-    await installDependencies(ctx);
-  });
-
   await ctx.runBuildPhase(BuildPhase.READ_PACKAGE_JSON, async () => {
     ctx.logger.info('Using package.json:');
     ctx.logger.info(JSON.stringify(packageJson, null, 2));
+  });
+
+  await ctx.runBuildPhase(BuildPhase.INSTALL_DEPENDENCIES, async () => {
+    await installDependencies(ctx);
   });
 
   await ctx.runBuildPhase(BuildPhase.READ_APP_CONFIG, async () => {


### PR DESCRIPTION
If installing dependencies fails, we don't know what was in package.json.