### PR TITLE
[ENG-6777][build-tools] measure build phase durations and report to worker

### DIFF
--- a/packages/build-tools/src/context.ts
+++ b/packages/build-tools/src/context.ts
@@ -3,6 +3,7 @@ import path from 'path';
 import {
   BuildPhase,
   BuildPhaseResult,
+  BuildPhaseStats,
   Job,
   LogMarker,
   Env,
@@ -56,10 +57,7 @@ export interface BuildContextOptions {
     err?: Error,
     options?: { tags?: Record<string, string>; extras?: Record<string, string> }
   ) => void;
-  reportBuildPhaseStats?: (
-    buildPhase: BuildPhase,
-    stats: { result: BuildPhaseResult; durationMs: number }
-  ) => void;
+  reportBuildPhaseStats?: (stats: BuildPhaseStats) => void;
   skipNativeBuild?: boolean;
   metadata?: Metadata;
 }
@@ -98,10 +96,7 @@ export class BuildContext<TJob extends Job> {
   private buildPhaseSkipped = false;
   private buildPhaseHasWarnings = false;
   private _appConfig?: ExpoConfig;
-  private readonly reportBuildPhaseStats?: (
-    buildPhase: BuildPhase,
-    stats: { result: BuildPhaseResult; durationMs: number }
-  ) => void;
+  private readonly reportBuildPhaseStats?: (stats: BuildPhaseStats) => void;
 
   constructor(public readonly job: TJob, options: BuildContextOptions) {
     this.workingdir = options.workingdir;
@@ -252,7 +247,7 @@ export class BuildContext<TJob extends Job> {
       return;
     }
 
-    this.reportBuildPhaseStats?.(this.buildPhase, { result, durationMs });
+    this.reportBuildPhaseStats?.({ buildPhase: this.buildPhase, result, durationMs });
 
     if (!doNotMarkEnd) {
       this.logger.info(

--- a/packages/build-tools/src/context.ts
+++ b/packages/build-tools/src/context.ts
@@ -56,6 +56,10 @@ export interface BuildContextOptions {
     err?: Error,
     options?: { tags?: Record<string, string>; extras?: Record<string, string> }
   ) => void;
+  reportBuildPhaseStats?: (
+    buildPhase: BuildPhase,
+    stats: { result: BuildPhaseResult; durationMs: number }
+  ) => void;
   skipNativeBuild?: boolean;
   metadata?: Metadata;
 }
@@ -94,6 +98,10 @@ export class BuildContext<TJob extends Job> {
   private buildPhaseSkipped = false;
   private buildPhaseHasWarnings = false;
   private _appConfig?: ExpoConfig;
+  private readonly reportBuildPhaseStats?: (
+    buildPhase: BuildPhase,
+    stats: { result: BuildPhaseResult; durationMs: number }
+  ) => void;
 
   constructor(public readonly job: TJob, options: BuildContextOptions) {
     this.workingdir = options.workingdir;
@@ -106,6 +114,7 @@ export class BuildContext<TJob extends Job> {
     this.reportError = options.reportError;
     this.metadata = options.metadata;
     this.skipNativeBuild = options.skipNativeBuild;
+    this.reportBuildPhaseStats = options.reportBuildPhaseStats;
 
     const environmentSecrets = this.getEnvironmentSecrets(job);
     this.env = {
@@ -148,19 +157,23 @@ export class BuildContext<TJob extends Job> {
       doNotMarkEnd?: boolean;
     } = {}
   ): Promise<T> {
+    let startTimestamp = Date.now();
     try {
       this.setBuildPhase(buildPhase, { doNotMarkStart });
+      startTimestamp = Date.now();
       const result = await phase();
+      const durationMs = Date.now() - startTimestamp;
       const buildPhaseResult: BuildPhaseResult = this.buildPhaseSkipped
         ? BuildPhaseResult.SKIPPED
         : this.buildPhaseHasWarnings
         ? BuildPhaseResult.WARNING
         : BuildPhaseResult.SUCCESS;
-      this.endCurrentBuildPhase({ result: buildPhaseResult, doNotMarkEnd });
+      this.endCurrentBuildPhase({ result: buildPhaseResult, doNotMarkEnd, durationMs });
       return result;
     } catch (err: any) {
+      const durationMs = Date.now() - startTimestamp;
       const resolvedError = await this.handleBuildPhaseErrorAsync(err, buildPhase);
-      this.endCurrentBuildPhase({ result: BuildPhaseResult.FAIL });
+      this.endCurrentBuildPhase({ result: BuildPhaseResult.FAIL, durationMs });
       throw resolvedError;
     }
   }
@@ -229,15 +242,23 @@ export class BuildContext<TJob extends Job> {
   private endCurrentBuildPhase({
     result,
     doNotMarkEnd = false,
+    durationMs,
   }: {
     result: BuildPhaseResult;
     doNotMarkEnd?: boolean;
+    durationMs: number;
   }): void {
     if (!this.buildPhase) {
       return;
     }
+
+    this.reportBuildPhaseStats?.(this.buildPhase, { result, durationMs });
+
     if (!doNotMarkEnd) {
-      this.logger.info({ marker: LogMarker.END_PHASE, result }, `End phase: ${this.buildPhase}`);
+      this.logger.info(
+        { marker: LogMarker.END_PHASE, result, durationMs },
+        `End phase: ${this.buildPhase}`
+      );
     }
     this.logger = this.defaultLogger;
     this.buildPhase = undefined;

--- a/packages/eas-build-job/src/common.ts
+++ b/packages/eas-build-job/src/common.ts
@@ -1,5 +1,7 @@
 import Joi from 'joi';
 
+import { BuildPhase, BuildPhaseResult } from './logs';
+
 export enum Workflow {
   GENERIC = 'generic',
   MANAGED = 'managed',
@@ -82,3 +84,9 @@ export const CacheSchema = Joi.object({
   cacheDefaultPaths: Joi.boolean().default(true),
   customPaths: Joi.array().items(Joi.string()).default([]),
 });
+
+export interface BuildPhaseStats {
+  buildPhase: BuildPhase;
+  result: BuildPhaseResult;
+  durationMs: number;
+}

--- a/packages/eas-build-job/src/index.ts
+++ b/packages/eas-build-job/src/index.ts
@@ -3,6 +3,7 @@ export * as Ios from './ios';
 export {
   ArchiveSourceType,
   ArchiveSource,
+  BuildPhaseStats,
   Env,
   EnvironmentSecret,
   EnvironmentSecretType,


### PR DESCRIPTION
# Why

We want to measure build phase durations and send them to Datadog.

# How

Measure build phase duration and report it to worker with `reportBuildPhaseStats` (this will be passed from worker).

# Test Plan

None