### PR TITLE
[ENG-6620][build-tools] add docs page to the missing google services file error

### DIFF
--- a/packages/build-tools/src/buildErrors/userErrorHandlers.ts
+++ b/packages/build-tools/src/buildErrors/userErrorHandlers.ts
@@ -69,7 +69,8 @@ export const userErrorHandlers: ErrorHandler<UserFacingError>[] = [
     createError: () =>
       new UserFacingError(
         'EAS_BUILD_MISSING_GOOGLE_SERVICES_JSON_ERROR',
-        '"google-services.json" is missing, make sure that file exists. Remember that EAS Build only uploads the files tracked by git.'
+        '"google-services.json" is missing, make sure that the file exists. Remember that EAS Build only uploads the files tracked by git. Use EAS secrets to provide EAS Build with the file.',
+        'https://docs.expo.dev/build-reference/variables/#how-to-upload-a-secret-file-and'
       ),
   },
   {
@@ -82,7 +83,8 @@ export const userErrorHandlers: ErrorHandler<UserFacingError>[] = [
     createError: () =>
       new UserFacingError(
         'EAS_BUILD_MISSING_GOOGLE_SERVICES_JSON_ERROR',
-        '"google-services.json" is missing, make sure that file exists. Remember that EAS Build only uploads the files tracked by git.'
+        '"google-services.json" is missing, make sure that the file exists. Remember that EAS Build only uploads the files tracked by git. Use EAS secrets to provide EAS Build with the file.',
+        'https://docs.expo.dev/build-reference/variables/#how-to-upload-a-secret-file-and'
       ),
   },
   {
@@ -94,7 +96,8 @@ export const userErrorHandlers: ErrorHandler<UserFacingError>[] = [
     createError: () =>
       new UserFacingError(
         'EAS_BUILD_MISSING_GOOGLE_SERVICES_PLIST_ERROR',
-        '"GoogleService-Info.plist" is missing, make sure that file exists. Remember that EAS Build only uploads the files tracked by git.'
+        '"GoogleService-Info.plist" is missing, make sure that the file exists. Remember that EAS Build only uploads the files tracked by git. Use EAS secrets to provide EAS Build with the file.',
+        'https://docs.expo.dev/build-reference/variables/#how-to-upload-a-secret-file-and'
       ),
   },
   {


### PR DESCRIPTION
Companion to https://github.com/expo/expo/pull/19719
This PR adds the docs page to the error message