### PR TITLE
[ENG-6429] [build-tools] set EAS Update default channel to the build profile name

### DIFF
--- a/packages/build-tools/src/android/expoUpdates.ts
+++ b/packages/build-tools/src/android/expoUpdates.ts
@@ -35,9 +35,10 @@ export async function androidSetRuntimeVersionNativelyAsync(
   await AndroidConfig.Manifest.writeAndroidManifestAsync(manifestPath, androidManifest);
 }
 
-export async function androidSetChannelNativelyAsync(ctx: BuildContext<Job>): Promise<void> {
-  assert(ctx.job.updates?.channel, 'updates.channel must be defined');
-
+export async function androidSetChannelNativelyAsync(
+  ctx: BuildContext<Job>,
+  channel: string
+): Promise<void> {
   const manifestPath = await AndroidConfig.Paths.getAndroidManifestAsync(
     ctx.reactNativeProjectDirectory
   );
@@ -57,7 +58,7 @@ export async function androidSetChannelNativelyAsync(ctx: BuildContext<Job>): Pr
     AndroidMetadataName.UPDATES_CONFIGURATION_REQUEST_HEADERS_KEY,
     JSON.stringify({
       ...JSON.parse(stringifiedUpdatesRequestHeaders ?? '{}'),
-      'expo-channel-name': ctx.job.updates.channel,
+      'expo-channel-name': channel,
     }),
     'value'
   );

--- a/packages/build-tools/src/ios/expoUpdates.ts
+++ b/packages/build-tools/src/ios/expoUpdates.ts
@@ -31,9 +31,10 @@ export async function iosSetRuntimeVersionNativelyAsync(
   await fs.writeFile(expoPlistPath, updatedExpoPlistContents);
 }
 
-export async function iosSetChannelNativelyAsync(ctx: BuildContext<Job>): Promise<void> {
-  assert(ctx.job.updates?.channel, 'updates.channel must be defined');
-
+export async function iosSetChannelNativelyAsync(
+  ctx: BuildContext<Job>,
+  channel: string
+): Promise<void> {
   const expoPlistPath = IOSConfig.Paths.getExpoPlistPath(ctx.reactNativeProjectDirectory);
 
   if (!(await fs.pathExists(expoPlistPath))) {
@@ -47,7 +48,7 @@ export async function iosSetChannelNativelyAsync(ctx: BuildContext<Job>): Promis
       string,
       string
     >) ?? {}),
-    'expo-channel-name': ctx.job.updates.channel,
+    'expo-channel-name': channel,
   };
   const updatedExpoPlistContents = plist.build(items);
 

--- a/packages/build-tools/src/utils/expoUpdates.ts
+++ b/packages/build-tools/src/utils/expoUpdates.ts
@@ -42,10 +42,12 @@ export async function setRuntimeVersionNativelyAsync(
 /**
  * Used for when Expo Updates is pointed at an EAS server.
  */
-export async function setChannelNativelyAsync(ctx: BuildContext<Job>): Promise<void> {
-  assert(ctx.job.updates?.channel, 'updates.channel must be defined');
+export async function setChannelNativelyAsync(
+  ctx: BuildContext<Job>,
+  channel: string
+): Promise<void> {
   const newUpdateRequestHeaders: Record<string, string> = {
-    'expo-channel-name': ctx.job.updates.channel,
+    'expo-channel-name': channel,
   };
 
   const configFile = ctx.job.platform === Platform.ANDROID ? 'AndroidManifest.xml' : 'Expo.plist';
@@ -57,11 +59,11 @@ export async function setChannelNativelyAsync(ctx: BuildContext<Job>): Promise<v
 
   switch (ctx.job.platform) {
     case Platform.ANDROID: {
-      await androidSetChannelNativelyAsync(ctx);
+      await androidSetChannelNativelyAsync(ctx, channel);
       return;
     }
     case Platform.IOS: {
-      await iosSetChannelNativelyAsync(ctx);
+      await iosSetChannelNativelyAsync(ctx, channel);
       return;
     }
     default:
@@ -131,8 +133,11 @@ export async function configureClassicExpoUpdatesAsync(ctx: BuildContext<Job>): 
   }
 }
 
-export async function configureEASExpoUpdatesAsync(ctx: BuildContext<Job>): Promise<void> {
-  await setChannelNativelyAsync(ctx);
+export async function configureEASExpoUpdatesAsync(
+  ctx: BuildContext<Job>,
+  channel: string
+): Promise<void> {
+  await setChannelNativelyAsync(ctx, channel);
 }
 
 export async function configureExpoUpdatesIfInstalledAsync(ctx: BuildContext<Job>): Promise<void> {
@@ -152,8 +157,9 @@ export async function configureExpoUpdatesIfInstalledAsync(ctx: BuildContext<Job
     );
   }
 
-  if (ctx.job.updates?.channel) {
-    await configureEASExpoUpdatesAsync(ctx);
+  const channel = ctx.job.updates?.channel ?? ctx.metadata?.buildProfile;
+  if (ctx.appConfig.updates?.url && channel) {
+    await configureEASExpoUpdatesAsync(ctx, channel);
   } else {
     await configureClassicExpoUpdatesAsync(ctx);
   }


### PR DESCRIPTION
# Why

Companion to https://github.com/expo/eas-cli/pull/1503
We want to set the default channel for EAS Update to the build profile name.

# How

Configure EAS Update only if `updates.url` is set. Use the build profile name as the fallback for channel (this makes it possible to change this behavior for users with old EAS CLI versions!). 
# Test Plan

TODO - unit tests
