### PR TITLE
[ENG-6817][build-tools] add better error message when `pod install` fails due to deployment target

### DIFF
--- a/packages/build-tools/src/buildErrors/__tests__/detectError.test.ts
+++ b/packages/build-tools/src/buildErrors/__tests__/detectError.test.ts
@@ -114,4 +114,22 @@ describe(resolveBuildPhaseErrorAsync, () => {
     expect(err.errorCode).toBe('XCODE_RESOURCE_BUNDLE_CODE_SIGNING_ERROR');
     expect(err.userFacingErrorCode).toBe('XCODE_RESOURCE_BUNDLE_CODE_SIGNING_ERROR');
   });
+
+  it('detects minimum deployment target error correctly', async () => {
+    const fakeError = new Error();
+    const err = await resolveBuildPhaseErrorAsync(
+      fakeError,
+      [
+        'CocoaPods could not find compatible versions for pod "react-native-google-maps":16  In Podfile:17    react-native-google-maps (from `/Users/expo/workingdir/build/node_modules/react-native-maps`)18Specs satisfying the `react-native-google-maps (from `/Users/expo/workingdir/build/node_modules/react-native-maps`)` dependency were found, but they required a higher minimum deployment target.19Error: Compatible versions of some pods could not be resolved.',
+      ],
+      {
+        job: { platform: Platform.IOS } as Job,
+        phase: BuildPhase.INSTALL_PODS,
+        env: {},
+      },
+      '/fake/path'
+    );
+    expect(err.errorCode).toBe('EAS_BUILD_HIGHER_MINIMUM_DEPLOYMENT_TARGET_ERROR');
+    expect(err.userFacingErrorCode).toBe('EAS_BUILD_HIGHER_MINIMUM_DEPLOYMENT_TARGET_ERROR');
+  });
 });

--- a/packages/build-tools/src/buildErrors/userErrorHandlers.ts
+++ b/packages/build-tools/src/buildErrors/userErrorHandlers.ts
@@ -104,6 +104,29 @@ export const userErrorHandlers: ErrorHandler<UserFacingError>[] = [
     platform: Platform.IOS,
     phase: BuildPhase.INSTALL_PODS,
     // example log:
+    // [!] CocoaPods could not find compatible versions for pod "react-native-google-maps"
+    // In Podfile:
+    // react-native-google-maps (from `/Users/expo/workingdir/build/node_modules/react-native-maps`)
+    // Specs satisfying the `react-native-google-maps (from `/Users/expo/workingdir/build/node_modules/react-native-maps`)` dependency were found, but they required a higher minimum deployment target.
+    // Error: Compatible versions of some pods could not be resolved.
+    regexp: /Specs satisfying the `(.*)` dependency were found, but they required a higher minimum deployment target/,
+    createError: (_, { job }) => {
+      return new UserFacingError(
+        'EAS_BUILD_HIGHER_MINIMUM_DEPLOYMENT_TARGET_ERROR',
+        `Some pods require a higher minimum deployment target.
+${
+  job.type === Workflow.MANAGED
+    ? 'You can use expo-build-properties config plugin (https://docs.expo.dev/versions/latest/sdk/build-properties/) to override the default native build properties and set different minimum deployment target.'
+    : 'You need to manually update the minimum deployment target in your project to resolve this issue.'
+}
+`
+      );
+    },
+  },
+  {
+    platform: Platform.IOS,
+    phase: BuildPhase.INSTALL_PODS,
+    // example log:
     // [!] CocoaPods could not find compatible versions for pod "Firebase/Core":
     //   In snapshot (Podfile.lock):
     //     Firebase/Core (= 6.14.0)

--- a/packages/build-tools/src/buildErrors/userErrorHandlers.ts
+++ b/packages/build-tools/src/buildErrors/userErrorHandlers.ts
@@ -116,7 +116,7 @@ export const userErrorHandlers: ErrorHandler<UserFacingError>[] = [
         `Some pods require a higher minimum deployment target.
 ${
   job.type === Workflow.MANAGED
-    ? 'You can use expo-build-properties config plugin (https://docs.expo.dev/versions/latest/sdk/build-properties/) to override the default native build properties and set different minimum deployment target.'
+    ? 'You can use the expo-build-properties config plugin (https://docs.expo.dev/versions/latest/sdk/build-properties/) to override the default native build properties and set a different minimum deployment target.'
     : 'You need to manually update the minimum deployment target in your project to resolve this issue.'
 }
 `


### PR DESCRIPTION
# Why

https://linear.app/expo/issue/ENG-6817/better-error-message-when-pod-install-fails-due-to-deployment-target

# How

Add a new error handler with a higher priority than the previous one which was handling this error incorrectly.

# Test Plan

Automated test
