### PR TITLE
Auto resolve iOS image for bare workflow

### DIFF
--- a/packages/eas-build-job/src/__tests__/job.test.ts
+++ b/packages/eas-build-job/src/__tests__/job.test.ts
@@ -1,5 +1,5 @@
 import { Workflow } from '../common';
-import { setAndroidBuilderImage, setIosBuilderImageForManagedJob } from '../job';
+import { setAndroidBuilderImage, setIosBuilderImage } from '../job';
 
 describe(setAndroidBuilderImage, () => {
   test.each([
@@ -12,25 +12,32 @@ describe(setAndroidBuilderImage, () => {
     'selecting image for sdkVersion %s and React Native %s',
     (sdkVersion?: string, reactNativeVersion?: string, expectedImage?: string) => {
       const job: any = { builderEnvironment: {} };
-      setAndroidBuilderImage(job, sdkVersion, reactNativeVersion);
+      setAndroidBuilderImage(job, { sdkVersion, reactNativeVersion, workflow: Workflow.MANAGED });
       expect(job?.builderEnvironment?.image).toBe(expectedImage);
     }
   );
 });
 
-describe(setIosBuilderImageForManagedJob, () => {
+describe(setIosBuilderImage, () => {
   test.each([
-    ['44.0.0', Workflow.MANAGED, 'macos-big-sur-11.4-xcode-13.0'],
-    ['45.0.0', Workflow.MANAGED, 'macos-monterey-12.4-xcode-13.4'],
-    ['46.0.0', Workflow.MANAGED, 'macos-monterey-12.4-xcode-13.4'],
-    ['46.0.0', Workflow.GENERIC, undefined],
-    ['47.0.0', Workflow.MANAGED, 'macos-monterey-12.6-xcode-14.0'],
-    [undefined, Workflow.MANAGED, undefined],
+    ['44.0.0', undefined, Workflow.MANAGED, 'macos-big-sur-11.4-xcode-13.0'],
+    ['45.0.0', undefined, Workflow.MANAGED, 'macos-monterey-12.4-xcode-13.4'],
+    ['46.0.0', undefined, Workflow.MANAGED, 'macos-monterey-12.4-xcode-13.4'],
+    ['46.0.0', undefined, Workflow.GENERIC, undefined],
+    ['47.0.0', undefined, Workflow.MANAGED, 'macos-monterey-12.6-xcode-14.0'],
+    [undefined, undefined, Workflow.MANAGED, undefined],
+    ['47.0.0', undefined, Workflow.MANAGED, 'macos-monterey-12.6-xcode-14.0'],
+    [undefined, '0.70.0', Workflow.GENERIC, 'macos-monterey-12.6-xcode-14.0'],
   ])(
     'selecting image for sdkVersion %s and React Native %s',
-    (sdkVersion: string | undefined, workflow: Workflow, expectedImage: string | undefined) => {
+    (
+      sdkVersion: string | undefined,
+      reactNativeVersion: string | undefined,
+      workflow: Workflow,
+      expectedImage: string | undefined
+    ) => {
       const job: any = { builderEnvironment: {}, type: workflow };
-      setIosBuilderImageForManagedJob(job, sdkVersion);
+      setIosBuilderImage(job, { sdkVersion, reactNativeVersion, workflow });
       expect(job?.builderEnvironment?.image).toBe(expectedImage);
     }
   );

--- a/packages/eas-build-job/src/android.ts
+++ b/packages/eas-build-job/src/android.ts
@@ -11,6 +11,7 @@ import {
   CacheSchema,
   EnvironmentSecretsSchema,
   EnvironmentSecret,
+  ImageMatchRule,
 } from './common';
 
 export interface Keystore {
@@ -46,13 +47,7 @@ export const builderBaseImages = [
   'ubuntu-22.04-jdk-11-ndk-r21e',
 ] as const;
 
-interface ImageMatchRule {
-  image: typeof builderBaseImages[number];
-  reactNativeSemverRange: string;
-  sdkSemverRange: string;
-}
-
-export const reactNativeImageMatchRules: ImageMatchRule[] = [
+export const imageMatchRules: ImageMatchRule<typeof builderBaseImages[number]>[] = [
   {
     image: 'ubuntu-18.04-jdk-11-ndk-r19c',
     reactNativeSemverRange: '>=0.68.0',

--- a/packages/eas-build-job/src/common.ts
+++ b/packages/eas-build-job/src/common.ts
@@ -98,3 +98,10 @@ export interface BuildPhaseStats {
   result: BuildPhaseResult;
   durationMs: number;
 }
+
+export interface ImageMatchRule<Image extends string> {
+  image: Image;
+  reactNativeSemverRange?: string;
+  sdkSemverRange?: string;
+  workflows?: Workflow[];
+}

--- a/packages/eas-build-job/src/ios.ts
+++ b/packages/eas-build-job/src/ios.ts
@@ -11,6 +11,7 @@ import {
   CacheSchema,
   EnvironmentSecretsSchema,
   EnvironmentSecret,
+  ImageMatchRule,
 } from './common';
 
 export type DistributionType = 'store' | 'internal' | 'simulator';
@@ -54,11 +55,26 @@ export const builderBaseImages = [
   'macos-monterey-12.6-xcode-14.1',
 ] as const;
 
-export const sdkVersionToDefaultBuilderImage: Record<string, typeof builderBaseImages[number]> = {
-  '<=44': 'macos-big-sur-11.4-xcode-13.0',
-  '>=45 <47': 'macos-monterey-12.4-xcode-13.4',
-  '>=47': 'macos-monterey-12.6-xcode-14.0',
-};
+export const imageMatchRules: ImageMatchRule<typeof builderBaseImages[number]>[] = [
+  {
+    image: 'macos-big-sur-11.4-xcode-13.0',
+    sdkSemverRange: '<=44',
+    workflows: [Workflow.MANAGED],
+  },
+  {
+    image: 'macos-monterey-12.4-xcode-13.4',
+    sdkSemverRange: '>=45 <47',
+    workflows: [Workflow.MANAGED],
+  },
+  {
+    image: 'macos-monterey-12.6-xcode-14.0',
+    sdkSemverRange: '>=47',
+  },
+  {
+    image: 'macos-monterey-12.6-xcode-14.0',
+    reactNativeSemverRange: '>=0.70.0',
+  },
+];
 
 export interface BuilderEnvironment {
   image?: typeof builderBaseImages[number];


### PR DESCRIPTION
# Why

https://linear.app/expo/issue/ENG-6903/update-default-image-for-ios-workers-to-xcode-14

# How

- Keep old behavior for all older version of react-native and SDK,
- For SDK 47 or RN 0.70 use xcode 14 regardless of the workflow

# Test Plan

tests
