### PR TITLE
[ENG-6878][build-tools] print log if .npmrc is present in project dir

### DIFF
--- a/packages/build-tools/src/utils/npmrc.ts
+++ b/packages/build-tools/src/utils/npmrc.ts
@@ -5,6 +5,8 @@ import fs from 'fs-extra';
 
 import { BuildContext } from '../context';
 
+import { findPackagerRootDir } from './packageManager';
+
 const NPMRC_TEMPLATE_PATH = path.join(__dirname, '../../templates/npmrc');
 
 export async function createNpmrcIfNotExistsAsync(ctx: BuildContext<Job>): Promise<void> {
@@ -21,8 +23,11 @@ export async function createNpmrcIfNotExistsAsync(ctx: BuildContext<Job>): Promi
 }
 
 export async function logIfNpmrcExistsAsync(ctx: BuildContext<Job>): Promise<void> {
-  const projectNpmrcPath = path.join(ctx.buildDirectory, '.npmrc');
+  const projectNpmrcPath = path.join(
+    findPackagerRootDir(ctx.reactNativeProjectDirectory),
+    '.npmrc'
+  );
   if (await fs.pathExists(projectNpmrcPath)) {
-    ctx.logger.info('.npmrc is present in your project directory');
+    ctx.logger.info(`.npmrc found at ${path.relative(ctx.buildDirectory, projectNpmrcPath)}`);
   }
 }

--- a/packages/build-tools/src/utils/npmrc.ts
+++ b/packages/build-tools/src/utils/npmrc.ts
@@ -19,3 +19,10 @@ export async function createNpmrcIfNotExistsAsync(ctx: BuildContext<Job>): Promi
     await fs.copy(NPMRC_TEMPLATE_PATH, projectNpmrcPath);
   }
 }
+
+export async function logIfNpmrcExistsAsync(ctx: BuildContext<Job>): Promise<void> {
+  const projectNpmrcPath = path.join(ctx.buildDirectory, '.npmrc');
+  if (await fs.pathExists(projectNpmrcPath)) {
+    ctx.logger.info('.npmrc is present in your project directory');
+  }
+}

--- a/packages/build-tools/src/utils/project.ts
+++ b/packages/build-tools/src/utils/project.ts
@@ -10,7 +10,7 @@ import { BuildContext } from '../context';
 import { deleteXcodeEnvLocalIfExistsAsync } from '../ios/xcodeEnv';
 
 import { Hook, runHookIfPresent } from './hooks';
-import { createNpmrcIfNotExistsAsync } from './npmrc';
+import { createNpmrcIfNotExistsAsync, logIfNpmrcExistsAsync } from './npmrc';
 import { findPackagerRootDir, PackageManager } from './packageManager';
 
 const MAX_EXPO_DOCTOR_TIMEOUT_MS = 20 * 1000;
@@ -20,6 +20,8 @@ export async function setup<TJob extends Job>(ctx: BuildContext<TJob>): Promise<
     await downloadAndUnpackProject(ctx);
     if (ctx.env.NPM_TOKEN) {
       await createNpmrcIfNotExistsAsync(ctx);
+    } else {
+      await logIfNpmrcExistsAsync(ctx);
     }
     if (ctx.job.platform === Platform.IOS && ctx.env.EAS_BUILD_RUNNER === 'eas-build') {
       await deleteXcodeEnvLocalIfExistsAsync(ctx as BuildContext<Ios.Job>);


### PR DESCRIPTION
Print log if .npmrc is present in project dir. Print only if `NPM_TOKEN` is not set (so the info is not duplicated).

https://linear.app/expo/issue/ENG-6878/log-npmrc-detection-in-eas-build