### PR TITLE
[ENG-7014][build-tools] Add instruction how to fix incompatible peer deps

### DIFF
--- a/packages/build-tools/src/buildErrors/userErrorHandlers.ts
+++ b/packages/build-tools/src/buildErrors/userErrorHandlers.ts
@@ -152,6 +152,26 @@ You are seeing this error because either:
   {
     phase: BuildPhase.INSTALL_DEPENDENCIES,
     // example log:
+    // [stderr] npm ERR! Fix the upstream dependency conflict, or retry
+    // [stderr] npm ERR! this command with --force, or --legacy-peer-deps
+    // [stderr] npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
+    regexp: /Fix the upstream dependency conflict, or retry.*\s.*this command with --force, or --legacy-peer-deps/,
+    createError: (matchResult: RegExpMatchArray) => {
+      if (matchResult.length >= 2) {
+        return new UserFacingError(
+          'EAS_BUILD_NPM_CONFLICTING_PEER_DEPENDENCIES',
+          `Some of your peer dependencies are not compatible. The recommended approach is to fix your dependencies by resolving any conflicts listed by "npm install". As a temporary workaround you can:
+- Add ".npmrc" file with "legacy-peer-deps=true" and commit that to your repo.
+- Delete package-lock.json and use yarn instead. It does not enforce peer dependencies.
+- Downgrade to older version of npm on EAS Build, by adding "npm install -g npm@version" in "eas-build-pre-install" script in package.json.`
+        );
+      }
+      return undefined;
+    },
+  },
+  {
+    phase: BuildPhase.INSTALL_DEPENDENCIES,
+    // example log:
     // [stderr] error https://github.com/expo/react-native/archive/sdk-41.0.0.tar.gz: Integrity check failed for "react-native" (computed integrity doesn't match our records, got "sha512-3jHI2YufrJi7eIABRf/DN/I2yOkmIZ0vAyezTz+PAUJiEs4v//5LLojWEU+W53AZsnuaEMcl/4fVy4bd+OuUbA== sha1-o9QuQTXIkc8VozXPaZIullB9a40=")
     regexp: /Integrity check failed for "(.*)" \(computed integrity doesn't match our records, got/,
     createError: (matchResult: RegExpMatchArray) => {


### PR DESCRIPTION
# Why

After a recent npm update on EAS Build, some previously working projects started to fail with peer deps errors.

# How

Add instructions on how to fix that.

# Test Plan

tested regexp in console
