### PR TITLE
[ENG-7036][build-tools] configure EAS Update if updates.url (app config) is set

### DIFF
--- a/packages/build-tools/src/android/__tests__/expoUpdates.test.ts
+++ b/packages/build-tools/src/android/__tests__/expoUpdates.test.ts
@@ -7,6 +7,7 @@ import {
   AndroidMetadataName,
   androidGetNativelyDefinedClassicReleaseChannelAsync,
   androidSetChannelNativelyAsync,
+  androidGetNativelyDefinedChannelAsync,
   androidSetClassicReleaseChannelNativelyAsync,
   androidGetNativelyDefinedRuntimeVersionAsync,
   androidSetRuntimeVersionNativelyAsync,
@@ -87,6 +88,26 @@ describe(androidSetChannelNativelyAsync, () => {
     );
     expect(newValue).toBeDefined();
     expect(JSON.parse(newValue!)).toEqual({ 'expo-channel-name': channel });
+  });
+});
+
+describe(androidGetNativelyDefinedChannelAsync, () => {
+  it('gets the channel', async () => {
+    vol.fromJSON(
+      {
+        'android/app/src/main/AndroidManifest.xml': originalFs.readFileSync(
+          path.join(__dirname, 'fixtures/AndroidManifestWithChannel.xml'),
+          'utf-8'
+        ),
+      },
+      '/app'
+    );
+    const ctx = {
+      reactNativeProjectDirectory: '/app',
+      logger: { info: () => {} },
+    };
+
+    await expect(androidGetNativelyDefinedChannelAsync(ctx as any)).resolves.toBe('staging-123');
   });
 });
 

--- a/packages/build-tools/src/android/__tests__/fixtures/AndroidManifestWithChannel.xml
+++ b/packages/build-tools/src/android/__tests__/fixtures/AndroidManifestWithChannel.xml
@@ -1,0 +1,14 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.expo.mycoolapp">
+    <uses-permission android:name="android.permission.INTERNET"/>
+    <application android:name=".MainApplication" android:label="@string/app_name" android:icon="@mipmap/ic_launcher" android:roundIcon="@mipmap/ic_launcher_round" android:allowBackup="true" android:theme="@style/AppTheme">
+        <activity android:name=".MainActivity" android:launchMode="singleTask" android:label="@string/app_name" android:configChanges="keyboard|keyboardHidden|orientation|screenSize" android:windowSoftInputMode="adjustResize">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN"/>
+                <category android:name="android.intent.category.LAUNCHER"/>
+            </intent-filter>
+        </activity>
+        <activity android:name="com.facebook.react.devsupport.DevSettingsActivity"/>
+        <meta-data android:name="expo.modules.updates.EXPO_RELEASE_CHANNEL" android:value="default"/>
+        <meta-data android:name="expo.modules.updates.UPDATES_CONFIGURATION_REQUEST_HEADERS_KEY"  android:value="{&quot;expo-channel-name&quot;:&quot;staging-123&quot;}"/>
+    </application>
+</manifest>

--- a/packages/build-tools/src/android/expoUpdates.ts
+++ b/packages/build-tools/src/android/expoUpdates.ts
@@ -64,6 +64,32 @@ export async function androidSetChannelNativelyAsync(ctx: BuildContext<Job>): Pr
   await AndroidConfig.Manifest.writeAndroidManifestAsync(manifestPath, androidManifest);
 }
 
+export async function androidGetNativelyDefinedChannelAsync(
+  ctx: BuildContext<Job>
+): Promise<string | null> {
+  const manifestPath = await AndroidConfig.Paths.getAndroidManifestAsync(
+    ctx.reactNativeProjectDirectory
+  );
+
+  if (!(await fs.pathExists(manifestPath))) {
+    return null;
+  }
+
+  const androidManifest = await AndroidConfig.Manifest.readAndroidManifestAsync(manifestPath);
+  const stringifiedUpdatesRequestHeaders = AndroidConfig.Manifest.getMainApplicationMetaDataValue(
+    androidManifest,
+    AndroidMetadataName.UPDATES_CONFIGURATION_REQUEST_HEADERS_KEY
+  );
+  try {
+    const updatesRequestHeaders = JSON.parse(stringifiedUpdatesRequestHeaders ?? '{}');
+    return updatesRequestHeaders['expo-channel-name'] ?? null;
+  } catch (err: any) {
+    throw new Error(
+      `Failed to parse ${AndroidMetadataName.UPDATES_CONFIGURATION_REQUEST_HEADERS_KEY} from AndroidManifest.xml: ${err.message}`
+    );
+  }
+}
+
 export async function androidSetClassicReleaseChannelNativelyAsync(
   ctx: BuildContext<Job>
 ): Promise<void> {

--- a/packages/build-tools/src/ios/__tests__/expoUpdates.test.ts
+++ b/packages/build-tools/src/ios/__tests__/expoUpdates.test.ts
@@ -6,6 +6,7 @@ import {
   iosGetNativelyDefinedClassicReleaseChannelAsync,
   IosMetadataName,
   iosSetChannelNativelyAsync,
+  iosGetNativelyDefinedChannelAsync,
   iosSetClassicReleaseChannelNativelyAsync,
   iosGetNativelyDefinedRuntimeVersionAsync,
   iosSetRuntimeVersionNativelyAsync,
@@ -73,6 +74,39 @@ describe(iosSetChannelNativelyAsync, () => {
     expect(
       plist.parse(newExpoPlist)[IosMetadataName.UPDATES_CONFIGURATION_REQUEST_HEADERS_KEY]
     ).toEqual({ 'expo-channel-name': channel });
+  });
+});
+
+describe(iosGetNativelyDefinedChannelAsync, () => {
+  it('gets the channel', async () => {
+    const expoPlist = `
+      <?xml version="1.0" encoding="UTF-8"?>
+      <!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+      <plist version="1.0">
+        <dict>
+          <key>EXUpdatesRequestHeaders</key>
+          <dict>
+            <key>expo-channel-name</key>
+            <string>staging-123</string>
+          </dict>
+        </dict>
+      </plist>
+    `;
+
+    vol.fromJSON(
+      {
+        'ios/testapp/Supporting/Expo.plist': expoPlist,
+        'ios/testapp.xcodeproj/project.pbxproj': 'placeholder',
+        'ios/testapp/AppDelegate.m': 'placeholder',
+      },
+      '/app'
+    );
+
+    const ctx = {
+      reactNativeProjectDirectory: '/app',
+      logger: { info: () => {} },
+    };
+    await expect(iosGetNativelyDefinedChannelAsync(ctx as any)).resolves.toBe('staging-123');
   });
 });
 

--- a/packages/build-tools/src/ios/expoUpdates.ts
+++ b/packages/build-tools/src/ios/expoUpdates.ts
@@ -54,6 +54,29 @@ export async function iosSetChannelNativelyAsync(ctx: BuildContext<Job>): Promis
   await fs.writeFile(expoPlistPath, updatedExpoPlistContents);
 }
 
+export async function iosGetNativelyDefinedChannelAsync(
+  ctx: BuildContext<Job>
+): Promise<string | null> {
+  const expoPlistPath = IOSConfig.Paths.getExpoPlistPath(ctx.reactNativeProjectDirectory);
+
+  if (!(await fs.pathExists(expoPlistPath))) {
+    return null;
+  }
+
+  const expoPlistContents = await fs.readFile(expoPlistPath, 'utf8');
+  try {
+    const items: Record<string, string | Record<string, string>> = plist.parse(expoPlistContents);
+    const updatesRequestHeaders = (items[
+      IosMetadataName.UPDATES_CONFIGURATION_REQUEST_HEADERS_KEY
+    ] ?? {}) as Record<string, string>;
+    return updatesRequestHeaders['expo-channel-name'] ?? null;
+  } catch (err: any) {
+    throw new Error(
+      `Failed to parse ${IosMetadataName.UPDATES_CONFIGURATION_REQUEST_HEADERS_KEY} from Expo.plist: ${err.message}`
+    );
+  }
+}
+
 export async function iosSetClassicReleaseChannelNativelyAsync(
   ctx: BuildContext<Job>
 ): Promise<void> {

--- a/packages/build-tools/src/utils/expoUpdates.ts
+++ b/packages/build-tools/src/utils/expoUpdates.ts
@@ -173,6 +173,7 @@ export async function configureExpoUpdatesIfInstalledAsync(ctx: BuildContext<Job
             `This build is configured to query EAS Update for updates, however no channel is set in eas.json.`
           );
         }
+        ctx.markBuildPhaseHasWarnings();
       }
     }
   } else {

--- a/packages/build-tools/src/utils/expoUpdates.ts
+++ b/packages/build-tools/src/utils/expoUpdates.ts
@@ -9,6 +9,7 @@ import {
   androidSetClassicReleaseChannelNativelyAsync,
   androidGetNativelyDefinedClassicReleaseChannelAsync,
   androidGetNativelyDefinedRuntimeVersionAsync,
+  androidGetNativelyDefinedChannelAsync,
 } from '../android/expoUpdates';
 import {
   iosSetRuntimeVersionNativelyAsync,
@@ -16,6 +17,7 @@ import {
   iosSetClassicReleaseChannelNativelyAsync,
   iosGetNativelyDefinedClassicReleaseChannelAsync,
   iosGetNativelyDefinedRuntimeVersionAsync,
+  iosGetNativelyDefinedChannelAsync,
 } from '../ios/expoUpdates';
 import { BuildContext } from '../context';
 
@@ -50,7 +52,7 @@ export async function setChannelNativelyAsync(ctx: BuildContext<Job>): Promise<v
 
   const configFile = ctx.job.platform === Platform.ANDROID ? 'AndroidManifest.xml' : 'Expo.plist';
   ctx.logger.info(
-    `Setting the update response headers in '${configFile}' to '${JSON.stringify(
+    `Setting the update request headers in '${configFile}' to '${JSON.stringify(
       newUpdateRequestHeaders
     )}'`
   );
@@ -152,8 +154,27 @@ export async function configureExpoUpdatesIfInstalledAsync(ctx: BuildContext<Job
     );
   }
 
-  if (ctx.job.updates?.channel) {
-    await configureEASExpoUpdatesAsync(ctx);
+  if (isEASUpdateConfigured(ctx)) {
+    if (ctx.job.updates?.channel !== undefined) {
+      await configureEASExpoUpdatesAsync(ctx);
+    } else {
+      const channel = await getChannelAsync(ctx);
+      if (channel !== null) {
+        const configFile =
+          ctx.job.platform === Platform.ANDROID ? 'AndroidManifest.xml' : 'Expo.plist';
+        ctx.logger.info(`The channel name for EAS Update in ${configFile} is set to "${channel}"`);
+      } else {
+        if (ctx.job.releaseChannel !== undefined) {
+          ctx.logger.warn(
+            `This build is configured with EAS Update however has a Classic Updates releaseChannel set instead of having an EAS Update channel.`
+          );
+        } else {
+          ctx.logger.warn(
+            `This build is configured to query EAS Update for updates, however no channel is set in eas.json.`
+          );
+        }
+      }
+    }
   } else {
     await configureClassicExpoUpdatesAsync(ctx);
   }
@@ -161,6 +182,19 @@ export async function configureExpoUpdatesIfInstalledAsync(ctx: BuildContext<Job
   if (ctx.job.version?.runtimeVersion) {
     ctx.logger.info('Updating runtimeVersion in Expo.plist');
     await setRuntimeVersionNativelyAsync(ctx, ctx.job.version.runtimeVersion);
+  }
+}
+
+export async function getChannelAsync(ctx: BuildContext<Job>): Promise<string | null> {
+  switch (ctx.job.platform) {
+    case Platform.ANDROID: {
+      return await androidGetNativelyDefinedChannelAsync(ctx);
+    }
+    case Platform.IOS: {
+      return await iosGetNativelyDefinedChannelAsync(ctx);
+    }
+    default:
+      throw new Error(`Platform is not supported.`);
   }
 }
 
@@ -174,5 +208,20 @@ export async function getRuntimeVersionAsync(ctx: BuildContext<Job>): Promise<st
     }
     default:
       throw new Error(`Platform is not supported.`);
+  }
+}
+
+export function isEASUpdateConfigured(ctx: BuildContext<Job>): boolean {
+  const rawUrl = ctx.appConfig.updates?.url;
+  if (!rawUrl) {
+    return false;
+  }
+  try {
+    const url = new URL(rawUrl);
+    return ['u.expo.dev', 'staging-u.expo.dev'].includes(url.hostname);
+  } catch (err) {
+    ctx.logger.error({ err }, `Cannot parse expo.updates.url = ${rawUrl} as URL`);
+    ctx.logger.error(`Assuming EAS Update is not configured`);
+    return false;
   }
 }


### PR DESCRIPTION
# Why

https://linear.app/expo/issue/ENG-7036/log-warning-in-eas-build-with-eas-update-and-no-channel-configured

<img width="949" alt="Screenshot 2022-12-08 at 16 39 31" src="https://user-images.githubusercontent.com/5256730/206489789-c5e449f1-cd47-4d4c-9aa4-20800786a85e.png">

# How

- Implement the logic from the description.
- BREAKING CHANGE: don't configure classic updates when `updates.url` (app config) i set.

# Test Plan

Tests.
