### PR TITLE
[ENG-7058][build-tools] fix resigning builds

### DIFF
--- a/packages/build-tools/src/ios/credentials/__tests__/fixtures.ts
+++ b/packages/build-tools/src/ios/credentials/__tests__/fixtures.ts
@@ -73,7 +73,7 @@ GgUABBRjUf5i17qdTqM0ehCmFy23BvGeLwQIF+s7XPPZnqoCAggA`,
   serialNumber: '78874DA5949778D6DF6E4F07A7964747',
   fingerprint: '0DACC0F7DFA33B1ECFCE1D3D780C76F16A3F0C20',
   teamId: 'QL76XYH73P',
-  commonName: 'iPhone Distribution: Alicja WarchaÅ (QL76XYH73P)',
+  commonName: 'iPhone Distribution: Alicja Warchał (QL76XYH73P)',
 };
 
 // this provisioning profile is invalidated

--- a/packages/build-tools/src/ios/credentials/distributionCertificate.ts
+++ b/packages/build-tools/src/ios/credentials/distributionCertificate.ts
@@ -15,7 +15,7 @@ export function getCommonName({ dataBase64, password }: Ios.DistributionCertific
   const commonNameAttribute = attributes.find(
     ({ name }: { name?: string }) => name === 'commonName'
   );
-  return commonNameAttribute.value;
+  return Buffer.from(commonNameAttribute.value, 'ascii').toString();
 }
 
 function getCertData(certificateBase64: string, password: string): any {

--- a/packages/build-tools/src/ios/credentials/provisioningProfile.ts
+++ b/packages/build-tools/src/ios/credentials/provisioningProfile.ts
@@ -116,7 +116,7 @@ Profile's certificate fingerprint = ${devCertFingerprint}, distribution certific
     const bundleIdentifier = applicationIdentifier.replace(/^.+?\./, '');
 
     this.profileData = {
-      path: this.keychainPath,
+      path: this.profilePath,
       target: this.target,
       bundleIdentifier,
       teamId: (plistData.TeamIdentifier as string[])[0],

--- a/packages/build-tools/src/ios/fastlane.ts
+++ b/packages/build-tools/src/ios/fastlane.ts
@@ -57,7 +57,9 @@ export async function runFastlaneResign<TJob extends Ios.Job>(
 ): Promise<void> {
   const { certificateCommonName } = credentials.applicationTargetProvisioningProfile.data;
 
-  const fastfilePath = path.join(ctx.buildDirectory, 'Fastfile');
+  const fastlaneDirPath = path.join(ctx.buildDirectory, 'fastlane');
+  await fs.ensureDir(fastlaneDirPath);
+  const fastfilePath = path.join(fastlaneDirPath, 'Fastfile');
   await createFastfileForResigningBuild({
     outputFile: fastfilePath,
     ipaPath,
@@ -66,7 +68,7 @@ export async function runFastlaneResign<TJob extends Ios.Job>(
     targetProvisioningProfiles: credentials.targetProvisioningProfiles,
   });
 
-  await runFastlane(['resign'], {
+  await runFastlane(['do_resign'], {
     cwd: ctx.buildDirectory,
     logger: ctx.logger,
     env: ctx.env,

--- a/packages/build-tools/templates/Fastfile.resign.template
+++ b/packages/build-tools/templates/Fastfile.resign.template
@@ -1,8 +1,10 @@
-resign(
-  ipa: "<%- IPA_PATH %>",
-  signing_identity: "<%- SIGNING_IDENTITY %>",
-  provisioning_profile: {<% _.forEach(PROFILES, function(profile) { %>
-    "<%- profile.BUNDLE_ID %>" => "<%- profile.PATH %>",<% }); %>
-  },
-  keychain_path: "<%- KEYCHAIN_PATH %>"
-)
+lane :do_resign do
+  resign(
+    ipa: "<%- IPA_PATH %>",
+    signing_identity: "<%- SIGNING_IDENTITY %>",
+    provisioning_profile: {<% _.forEach(PROFILES, function(profile) { %>
+      "<%- profile.BUNDLE_ID %>" => "<%- profile.PATH %>",<% }); %>
+    },
+    keychain_path: "<%- KEYCHAIN_PATH %>"
+  )
+end


### PR DESCRIPTION
# Why

Fixes resigning builds introduced in https://github.com/expo/eas-build/pull/179

# How

- Fix signing identity encoding.
- Set correct provisioning profile path in Fastfile.
- Save Fastfile to `fastlane` directory.
- Use named lane in Fastfile.

# Test Plan

Tested locally.
