### PR TITLE
[build-tools] use correct server depending on the build environment

### DIFF
--- a/packages/build-tools/src/common/easBuildInternal.ts
+++ b/packages/build-tools/src/common/easBuildInternal.ts
@@ -21,7 +21,6 @@ export async function runEasBuildInternalAsync<TJob extends Job>(
   const { cmd, args, extraEnv } = resolveEasCommandPrefixAndEnv();
   const { buildProfile } = ctx.job;
   assert(buildProfile, 'build profile is missing in a build from git-based integration.');
-  ctx.logger.info(ctx.job.secrets);
   const result = await spawn(
     cmd,
     [...args, 'build:internal', '--platform', ctx.job.platform, '--profile', buildProfile],


### PR DESCRIPTION
# Why

eas-cli needs to be aware in what environment it's executed, so it can communicate with local, staging or production environments

# How

pass EXPO_LOCAL=1 or EXPO_STAGING=1 to eas calls

# Test Plan

not tested
