### PR TITLE
Stream output from `yarn watch` and `yarn start` commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "eas-build",
   "private": "true",
   "scripts": {
-    "start": "lerna bootstrap && lerna run start --parallel",
-    "watch": "lerna bootstrap && lerna run watch --parallel",
+    "start": "lerna bootstrap && lerna run start --stream --parallel",
+    "watch": "lerna bootstrap && lerna run watch --stream --parallel",
     "build": "lerna bootstrap && lerna run build",
     "lint": "eslint 'packages/*/src/**/*.ts'",
     "test": "lerna run test",


### PR DESCRIPTION
# Why

After some deps update `yarn watch` and `yarn start` in root directory do not show output.

# How

`--stream` flag will make learna stream output of the commands that are running.

# Test Plan

Run yarn start
