### PR TITLE
[ENG-7267][build-tools] indicate in the error message that "Run fastlane" phase doesn't contain all the logs

### DIFF
--- a/packages/build-tools/src/buildErrors/userErrorHandlers.ts
+++ b/packages/build-tools/src/buildErrors/userErrorHandlers.ts
@@ -256,7 +256,7 @@ To resolve this issue, downgrade to an older Xcode version using the "image" fie
     createError: () =>
       new UserFacingError(
         errors.ErrorCode.UNKNOWN_FASTLANE_ERROR,
-        `Fastlane build failed with unknown error. See logs for the "Run fastlane" and "Xcode Logs" phases for more information.
+        `Fastlane build failed with unknown error. See logs for the "Run fastlane" (it contains filtered build logs) and "Xcode Logs" (it contains full build logs) phases for more information.
 Fastlane errors in most cases are not printed at the end of the output, so you may not find any useful information in the last lines of output when looking for an error message.`
       ),
   },

--- a/packages/build-tools/src/buildErrors/userErrorHandlers.ts
+++ b/packages/build-tools/src/buildErrors/userErrorHandlers.ts
@@ -79,7 +79,8 @@ export const userErrorHandlers: ErrorHandler<UserFacingError>[] = [
     // Execution failed for task ':app:processReleaseGoogleServices'.
     // > File google-services.json is missing. The Google Services Plugin cannot function without it.
     //    Searched Location:
-    regexp: /File google-services\.json is missing\. The Google Services Plugin cannot function without it/,
+    regexp:
+      /File google-services\.json is missing\. The Google Services Plugin cannot function without it/,
     createError: () =>
       new UserFacingError(
         'EAS_BUILD_MISSING_GOOGLE_SERVICES_JSON_ERROR',
@@ -109,7 +110,8 @@ export const userErrorHandlers: ErrorHandler<UserFacingError>[] = [
     // react-native-google-maps (from `/Users/expo/workingdir/build/node_modules/react-native-maps`)
     // Specs satisfying the `react-native-google-maps (from `/Users/expo/workingdir/build/node_modules/react-native-maps`)` dependency were found, but they required a higher minimum deployment target.
     // Error: Compatible versions of some pods could not be resolved.
-    regexp: /Specs satisfying the `(.*)` dependency were found, but they required a higher minimum deployment target/,
+    regexp:
+      /Specs satisfying the `(.*)` dependency were found, but they required a higher minimum deployment target/,
     createError: (_, { job }) => {
       return new UserFacingError(
         'EAS_BUILD_HIGHER_MINIMUM_DEPLOYMENT_TARGET_ERROR',
@@ -155,7 +157,8 @@ You are seeing this error because either:
     // [stderr] npm ERR! Fix the upstream dependency conflict, or retry
     // [stderr] npm ERR! this command with --force, or --legacy-peer-deps
     // [stderr] npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
-    regexp: /Fix the upstream dependency conflict, or retry.*\s.*this command with --force, or --legacy-peer-deps/,
+    regexp:
+      /Fix the upstream dependency conflict, or retry.*\s.*this command with --force, or --legacy-peer-deps/,
     createError: (matchResult: RegExpMatchArray) => {
       if (matchResult.length >= 2) {
         return new UserFacingError(
@@ -196,7 +199,8 @@ You are seeing this error because either:
     // [1/4] Resolving packages...
     // [2/4] Fetching packages...
     // [stderr] error https://registry.yarnpkg.com/jest-util/-/jest-util-26.6.2.tgz: Extracting tar content of undefined failed, the file appears to be corrupt: "ENOENT: no such file or directory, chmod '/Users/expo/Library/Caches/Yarn/v6/npm-jest-util-26.6.2-907535dbe4d5a6cb4c47ac9b926f6af29576cbc1-integrity/node_modules/jest-util/build/pluralize.d.ts'"
-    regexp: /\[1\/4\] Resolving packages...\s*\[2\/4\] Fetching packages...\s*\[1\/4\] Resolving packages...\s*\[2\/4\] Fetching packages.../,
+    regexp:
+      /\[1\/4\] Resolving packages...\s*\[2\/4\] Fetching packages...\s*\[1\/4\] Resolving packages...\s*\[2\/4\] Fetching packages.../,
     createError: (matchResult: RegExpMatchArray) => {
       if (matchResult) {
         return new UserFacingError(
@@ -256,8 +260,7 @@ To resolve this issue, downgrade to an older Xcode version using the "image" fie
     createError: () =>
       new UserFacingError(
         errors.ErrorCode.UNKNOWN_FASTLANE_ERROR,
-        `Fastlane build failed with unknown error. See logs for the "Run fastlane" (it contains filtered build logs) and "Xcode Logs" (it contains full build logs) phases for more information.
-Fastlane errors in most cases are not printed at the end of the output, so you may not find any useful information in the last lines of output when looking for an error message.`
+        `The "Run fastlane" step failed with an unknown error. Refer to "Xcode Logs" below for additional, more detailed logs.`
       ),
   },
 ];


### PR DESCRIPTION
# Why

https://linear.app/expo/issue/ENG-7267/help-users-find-the-xcode-logs-phase-more-easily

# How

Improve error message
