### PR TITLE
[ENG-7565] integrate @expo/build-tools with @expo/steps

### DIFF
--- a/packages/build-tools/package.json
+++ b/packages/build-tools/package.json
@@ -27,6 +27,7 @@
     "@expo/logger": "0.0.27",
     "@expo/package-manager": "^0.0.57",
     "@expo/plist": "^0.0.20",
+    "@expo/steps": "^0.0.1",
     "@expo/template-file": "0.1.25",
     "@expo/turtle-spawn": "0.0.28",
     "@expo/xcpretty": "^4.2.2",

--- a/packages/build-tools/src/android/credentials.ts
+++ b/packages/build-tools/src/android/credentials.ts
@@ -2,12 +2,16 @@ import path from 'path';
 
 import { Android } from '@expo/eas-build-job';
 import fs from 'fs-extra';
+import nullthrows from 'nullthrows';
 import { v4 as uuidv4 } from 'uuid';
 
 import { BuildContext } from '../context';
 
 async function restoreCredentials(ctx: BuildContext<Android.Job>): Promise<void> {
-  const { buildCredentials } = ctx.job.secrets;
+  const { buildCredentials } = nullthrows(
+    ctx.job.secrets,
+    'Secrets must be defined for non-custom builds'
+  );
   if (!buildCredentials) {
     // TODO: sentry (should be detected earlier)
     throw new Error('secrets are missing in the job object');

--- a/packages/build-tools/src/builders/custom.ts
+++ b/packages/build-tools/src/builders/custom.ts
@@ -1,0 +1,31 @@
+import path from 'path';
+
+import { BuildPhase, Job } from '@expo/eas-build-job';
+import { BuildConfigParser, BuildStepContext } from '@expo/steps';
+import nullthrows from 'nullthrows';
+
+import { Artifacts, BuildContext } from '../context';
+import { prepareProjectSourcesAsync } from '../common/projectSources';
+
+export async function runCustomBuildAsync<T extends Job>(ctx: BuildContext<T>): Promise<Artifacts> {
+  await prepareProjectSourcesAsync(ctx);
+
+  const relativeConfigPath = nullthrows(
+    ctx.job.customBuildConfig?.path,
+    'Custom build config must be defined for custom builds'
+  );
+  const configPath = path.join(ctx.reactNativeProjectDirectory, relativeConfigPath);
+
+  const buildStepContext = new BuildStepContext(
+    ctx.env.EAS_BUILD_ID,
+    ctx.logger.child({ phase: BuildPhase.CUSTOM }),
+    false,
+    ctx.reactNativeProjectDirectory
+  );
+  const parser = new BuildConfigParser(buildStepContext, { configPath });
+  const workflow = await parser.parseAsync();
+  await workflow.executeAsync();
+
+  // TOOD: return application archive and build artifacts
+  return {};
+}

--- a/packages/build-tools/src/builders/ios.ts
+++ b/packages/build-tools/src/builders/ios.ts
@@ -18,12 +18,17 @@ import { setupAsync } from '../common/setup';
 import { prebuildAsync } from '../common/prebuild';
 
 import { runBuilderWithHooksAsync } from './common';
+import { runCustomBuildAsync } from './custom';
 
 export default async function iosBuilder(ctx: BuildContext<Ios.Job>): Promise<Artifacts> {
   if (ctx.job.mode === BuildMode.BUILD) {
     return await runBuilderWithHooksAsync(ctx, buildAsync);
-  } else {
+  } else if (ctx.job.mode === BuildMode.RESIGN) {
     return await resignAsync(ctx);
+  } else if (ctx.job.mode === BuildMode.CUSTOM) {
+    return await runCustomBuildAsync(ctx);
+  } else {
+    throw new Error('Not implemented');
   }
 }
 

--- a/packages/build-tools/src/common/easBuildInternal.ts
+++ b/packages/build-tools/src/common/easBuildInternal.ts
@@ -4,6 +4,7 @@ import { Env, Job, Metadata, sanitizeJob, sanitizeMetadata } from '@expo/eas-bui
 import { PipeMode } from '@expo/logger';
 import spawn from '@expo/turtle-spawn';
 import Joi from 'joi';
+import nullthrows from 'nullthrows';
 
 import { BuildContext } from '../context';
 
@@ -26,7 +27,12 @@ export async function runEasBuildInternalAsync<TJob extends Job>(
     [...args, 'build:internal', '--platform', ctx.job.platform, '--profile', buildProfile],
     {
       cwd: ctx.reactNativeProjectDirectory,
-      env: { ...ctx.env, EXPO_TOKEN: ctx.job.secrets.robotAccessToken, ...extraEnv },
+      env: {
+        ...ctx.env,
+        EXPO_TOKEN: nullthrows(ctx.job.secrets, 'Secrets must be defined for non-custom builds')
+          .robotAccessToken,
+        ...extraEnv,
+      },
       logger: ctx.logger,
       mode: PipeMode.STDERR_ONLY_AS_STDOUT,
     }

--- a/packages/build-tools/src/ios/credentials/manager.ts
+++ b/packages/build-tools/src/ios/credentials/manager.ts
@@ -5,6 +5,7 @@ import path from 'path';
 import { Ios } from '@expo/eas-build-job';
 import fs from 'fs-extra';
 import { orderBy } from 'lodash';
+import nullthrows from 'nullthrows';
 import { v4 as uuid } from 'uuid';
 
 import { BuildContext } from '../../context';
@@ -38,7 +39,10 @@ export default class IosCredentialsManager<TJob extends Ios.Job> {
       return null;
     }
 
-    const { buildCredentials } = this.ctx.job.secrets;
+    const { buildCredentials } = nullthrows(
+      this.ctx.job.secrets,
+      'Secrets must be defined for non-custom builds'
+    );
     if (!buildCredentials) {
       throw new Error('credentials are required for an iOS build');
     }

--- a/packages/eas-build-job/src/__tests__/android.test.ts
+++ b/packages/eas-build-job/src/__tests__/android.test.ts
@@ -1,7 +1,7 @@
 import Joi from 'joi';
 
 import * as Android from '../android';
-import { ArchiveSourceType, BuildTrigger, Platform, Workflow } from '../common';
+import { ArchiveSourceType, BuildMode, BuildTrigger, Platform, Workflow } from '../common';
 
 const joiOptions: Joi.ValidationOptions = {
   stripUnknown: true,
@@ -21,7 +21,7 @@ const secrets = {
 };
 
 describe('Android.JobSchema', () => {
-  test('valid job', () => {
+  test('valid generic job', () => {
     const genericJob = {
       secrets,
       platform: Platform.ANDROID,
@@ -50,7 +50,7 @@ describe('Android.JobSchema', () => {
     expect(error).toBeFalsy();
   });
 
-  test('invalid job', () => {
+  test('invalid generic job', () => {
     const genericJob = {
       secrets,
       platform: Platform.ANDROID,
@@ -70,10 +70,8 @@ describe('Android.JobSchema', () => {
     );
     expect(value).not.toMatchObject(genericJob);
   });
-});
 
-describe('Android.JobSchema', () => {
-  test('valid job', () => {
+  test('valid managed job', () => {
     const managedJob = {
       secrets,
       platform: Platform.ANDROID,
@@ -102,7 +100,7 @@ describe('Android.JobSchema', () => {
     expect(error).toBeFalsy();
   });
 
-  test('invalid job', () => {
+  test('invalid managed job', () => {
     const managedJob = {
       secrets,
       platform: Platform.ANDROID,
@@ -123,6 +121,7 @@ describe('Android.JobSchema', () => {
     );
     expect(value).not.toMatchObject(managedJob);
   });
+
   test('validates channel', () => {
     const managedJob = {
       secrets,
@@ -142,6 +141,7 @@ describe('Android.JobSchema', () => {
     expect(value).toMatchObject(managedJob);
     expect(error).toBeFalsy();
   });
+
   test('fails when both releaseChannel and updates.channel are defined', () => {
     const managedJob = {
       secrets,
@@ -186,5 +186,25 @@ describe('Android.JobSchema', () => {
 
     const { error } = Android.JobSchema.validate(managedJob, joiOptions);
     expect(error?.message).toBe('"buildProfile" is required');
+  });
+
+  test('valid custom build job', () => {
+    const customBuildJob = {
+      mode: BuildMode.CUSTOM,
+      type: Workflow.UNKNOWN,
+      platform: Platform.ANDROID,
+      projectArchive: {
+        type: ArchiveSourceType.URL,
+        url: 'https://expo.dev/builds/123',
+      },
+      projectRootDirectory: '.',
+      customBuildConfig: {
+        path: 'production.android.yml',
+      },
+    };
+
+    const { value, error } = Android.JobSchema.validate(customBuildJob, joiOptions);
+    expect(value).toMatchObject(customBuildJob);
+    expect(error).toBeFalsy();
   });
 });

--- a/packages/eas-build-job/src/__tests__/ios.test.ts
+++ b/packages/eas-build-job/src/__tests__/ios.test.ts
@@ -77,6 +77,26 @@ describe('Ios.JobSchema', () => {
     expect(error).toBeFalsy();
   });
 
+  test('valid custom build job', () => {
+    const customBuildJob = {
+      mode: BuildMode.CUSTOM,
+      type: Workflow.UNKNOWN,
+      platform: Platform.IOS,
+      projectArchive: {
+        type: ArchiveSourceType.URL,
+        url: 'https://expo.dev/builds/123',
+      },
+      projectRootDirectory: '.',
+      customBuildConfig: {
+        path: 'production.ios.yml',
+      },
+    };
+
+    const { value, error } = Ios.JobSchema.validate(customBuildJob, joiOptions);
+    expect(value).toMatchObject(customBuildJob);
+    expect(error).toBeFalsy();
+  });
+
   test('invalid generic job', () => {
     const genericJob = {
       secrets: {

--- a/packages/eas-build-job/src/common.ts
+++ b/packages/eas-build-job/src/common.ts
@@ -5,6 +5,7 @@ import { BuildPhase, BuildPhaseResult } from './logs';
 export enum BuildMode {
   BUILD = 'build',
   RESIGN = 'resign',
+  CUSTOM = 'custom',
 }
 
 export enum Workflow {

--- a/packages/eas-build-job/src/logs.ts
+++ b/packages/eas-build-job/src/logs.ts
@@ -47,6 +47,9 @@ export enum BuildPhase {
 
   // RESIGN
   DOWNLOAD_APPLICATION_ARCHIVE = 'DOWNLOAD_APPLICATION_ARCHIVE',
+
+  // CUSTOM BUILDS
+  CUSTOM = 'CUSTOM',
 }
 
 export enum BuildPhaseResult {

--- a/packages/eas-build-job/src/metadata.ts
+++ b/packages/eas-build-job/src/metadata.ts
@@ -138,7 +138,7 @@ export type Metadata = {
   /**
    * Build mode
    */
-  buildMode?: 'build' | 'resign';
+  buildMode?: 'build' | 'resign' | 'custom';
 };
 
 export const MetadataSchema = Joi.object({
@@ -167,7 +167,7 @@ export const MetadataSchema = Joi.object({
   message: Joi.string().max(1024),
   runFromCI: Joi.boolean(),
   runWithNoWaitFlag: Joi.boolean(),
-  buildMode: Joi.string().valid('build', 'resign'),
+  buildMode: Joi.string().valid('build', 'resign', 'custom'),
 });
 
 export function sanitizeMetadata(metadata: object): Metadata {

--- a/packages/steps/examples/simple/config.yml
+++ b/packages/steps/examples/simple/config.yml
@@ -28,3 +28,9 @@ build:
         command: |
           echo "Steps can use another shell"
           ps -p $$
+    - run:
+        name: Steps can use comments in commands
+        shell: /bin/zsh
+        command: |
+          # Print something
+          echo "Hello!"

--- a/packages/steps/src/BuildStep.ts
+++ b/packages/steps/src/BuildStep.ts
@@ -22,13 +22,20 @@ export enum BuildStepStatus {
   NEW = 'new',
   IN_PROGRESS = 'in-progress',
   CANCELED = 'canceled',
-  FAILED = 'failed',
-  SUCCEEDED = 'succeeded',
+  FAIL = 'fail',
+  WARNING = 'warning',
+  SUCCESS = 'success',
+}
+
+export enum BuildStepLogMarker {
+  START_STEP = 'start-step',
+  END_STEP = 'end-step',
 }
 
 export class BuildStep {
   public readonly id: string;
   public readonly name?: string;
+  public readonly displayName?: string;
   public readonly inputs?: BuildStepInput[];
   public readonly outputs?: BuildStepOutput[];
   public readonly command: string;
@@ -63,6 +70,7 @@ export class BuildStep {
   ) {
     this.id = id;
     this.name = name;
+    this.displayName = this.getStepDisplayName(name, command);
     this.inputs = inputs;
     this.outputs = outputs;
     this.outputById =
@@ -78,14 +86,21 @@ export class BuildStep {
     this.status = BuildStepStatus.NEW;
 
     this.internalId = uuidv4();
-    this.logger = ctx.logger.child({ buildStepInternalId: this.internalId, buildStepId: this.id });
+    this.logger = ctx.logger.child({
+      buildStepInternalId: this.internalId,
+      buildStepId: this.id,
+      buildStepDisplayName: this.displayName,
+    });
 
     ctx.registerStep(this);
   }
 
   public async executeAsync(): Promise<void> {
     try {
-      this.logger.debug(`Executing build step "${this.id}"`);
+      this.logger.info(
+        { marker: BuildStepLogMarker.START_STEP },
+        `Executing build step "${this.id}"`
+      );
       this.status = BuildStepStatus.IN_PROGRESS;
 
       const command = this.interpolateInputsInCommand(this.command, this.inputs);
@@ -111,10 +126,18 @@ export class BuildStep {
       await this.collectAndValidateOutputsAsync(outputsDir);
       this.logger.debug('Finished collecting output paramters');
 
-      this.logger.debug('Finished successfully');
-      this.status = BuildStepStatus.SUCCEEDED;
+      this.logger.info(
+        { marker: BuildStepLogMarker.END_STEP, result: BuildStepStatus.SUCCESS },
+        `Finished build step "${this.id}" successfully`
+      );
+      this.status = BuildStepStatus.SUCCESS;
     } catch (err) {
-      this.status = BuildStepStatus.FAILED;
+      this.logger.error({ err });
+      this.logger.error(
+        { marker: BuildStepLogMarker.END_STEP, result: BuildStepStatus.FAIL },
+        `Build step "${this.id}" failed`
+      );
+      this.status = BuildStepStatus.FAIL;
       throw err;
     } finally {
       this.executed = true;
@@ -194,5 +217,21 @@ export class BuildStep {
       __EXPO_STEPS_OUTPUTS_DIR: outputsDir,
       PATH: `${BIN_PATH}:${process.env.PATH}`,
     };
+  }
+
+  private getStepDisplayName(name: string | undefined, command: string): string | undefined {
+    if (name) {
+      return name;
+    }
+    if (command !== '') {
+      const splits = command.trim().split('\n');
+      for (const split of splits) {
+        const trimmed = split.trim();
+        if (trimmed && !trimmed.startsWith('#')) {
+          return trimmed;
+        }
+      }
+    }
+    return undefined;
   }
 }


### PR DESCRIPTION
# Why

Even though the customizable builds (`@expo/steps` library) are in a very early phase of development, we want to let people use them as soon as possible.
This PR integrates `@expo/build-tools` with `@expo/steps`.

# How

- https://github.com/expo/eas-build/pull/194/commits/5ae64045e4a287865b56922f21c18a6510f26001 adds support for custom build in job object:
  - Makes the `secrets` object optional.
  - Adds `customBuildConfig` with field `path` that points at the build config file (.yml).
  - Allows `CUSTOM` for `mode`.
  - Allows `custom` for `buildMode` in metadata.
- https://github.com/expo/eas-build/pull/194/commits/2694dc92a185598b7ed3dbaea26ef680de609b98 integrates `@expo/build-tools` with `@expo/steps`
  - Handles optional `secrets` field.
  - Conditionally runs the regular build workflow or the custom one (with `@expo/steps`).
  - Uploading artifacts is not yet implemented.
- https://github.com/expo/eas-build/pull/194/commits/3ab1cbf896df38323004eb0385b8140114f5278b integrates custom workflow with website (displaying logs).

# Test Plan

Added some tests + tested manually.

<img width="1291" alt="Screenshot 2023-02-16 at 16 35 55" src="https://user-images.githubusercontent.com/5256730/220136799-5de77587-149c-43f3-8494-686072a9f5d7.png">

# Future work

- Add a way to upload artifacts from custom config.
- Propagate user-defined env variables to the custom workflow.
