### PR TITLE
[ENG-7649][steps] propagate build env to steps

### DIFF
--- a/packages/build-tools/src/builders/custom.ts
+++ b/packages/build-tools/src/builders/custom.ts
@@ -24,7 +24,7 @@ export async function runCustomBuildAsync<T extends Job>(ctx: BuildContext<T>): 
   );
   const parser = new BuildConfigParser(buildStepContext, { configPath });
   const workflow = await parser.parseAsync();
-  await workflow.executeAsync();
+  await workflow.executeAsync(ctx.env);
 
   // TOOD: return application archive and build artifacts
   return {};

--- a/packages/steps/src/BuildStepEnv.ts
+++ b/packages/steps/src/BuildStepEnv.ts
@@ -1,0 +1,1 @@
+export type BuildStepEnv = Record<string, string | undefined>;

--- a/packages/steps/src/BuildWorkflow.ts
+++ b/packages/steps/src/BuildWorkflow.ts
@@ -1,4 +1,5 @@
 import { BuildStep } from './BuildStep.js';
+import { BuildStepEnv } from './BuildStepEnv.js';
 
 export class BuildWorkflow {
   public readonly buildSteps: BuildStep[];
@@ -7,9 +8,9 @@ export class BuildWorkflow {
     this.buildSteps = buildSteps;
   }
 
-  public async executeAsync(): Promise<void> {
+  public async executeAsync(env: BuildStepEnv = process.env): Promise<void> {
     for (const step of this.buildSteps) {
-      await step.executeAsync();
+      await step.executeAsync(env);
     }
   }
 }

--- a/packages/steps/src/__tests__/BuildStep-test.ts
+++ b/packages/steps/src/__tests__/BuildStep-test.ts
@@ -255,5 +255,25 @@ describe(BuildStep, () => {
       await step.executeAsync();
       expect(step.getOutputValueByName('abc')).toBe('123');
     });
+
+    it('propagates environment variables to the script', async () => {
+      const logger = createMockLogger();
+      const lines: string[] = [];
+      jest.mocked(logger.info as any).mockImplementation((obj: object | string, line?: string) => {
+        if (typeof obj === 'string') {
+          lines.push(obj);
+        } else if (line) {
+          lines.push(line);
+        }
+      });
+      const ctx = cloneContextWithOverrides(baseStepCtx, { logger });
+      const step = new BuildStep(ctx, {
+        id: 'test1',
+        command: 'echo $TEST_ABC',
+        workingDirectory: ctx.workingDirectory,
+      });
+      await step.executeAsync({ TEST_ABC: 'lorem ipsum' });
+      expect(lines.find((line) => line.match('lorem ipsum'))).toBeTruthy();
+    });
   });
 });

--- a/packages/steps/src/__tests__/BuildWorkflow-test.ts
+++ b/packages/steps/src/__tests__/BuildWorkflow-test.ts
@@ -1,6 +1,7 @@
-import { instance, mock, verify } from 'ts-mockito';
+import { anything, instance, mock, verify } from 'ts-mockito';
 
 import { BuildStep } from '../BuildStep.js';
+import { BuildStepEnv } from '../BuildStepEnv.js';
 import { BuildWorkflow } from '../BuildWorkflow.js';
 
 describe(BuildWorkflow, () => {
@@ -19,10 +20,10 @@ describe(BuildWorkflow, () => {
 
       const workflow = new BuildWorkflow({ buildSteps });
       await workflow.executeAsync();
-      verify(mockBuildStep1.executeAsync()).once();
-      verify(mockBuildStep2.executeAsync()).once();
-      verify(mockBuildStep3.executeAsync()).once();
-      verify(mockBuildStep4.executeAsync()).never();
+      verify(mockBuildStep1.executeAsync(anything())).once();
+      verify(mockBuildStep2.executeAsync(anything())).once();
+      verify(mockBuildStep3.executeAsync(anything())).once();
+      verify(mockBuildStep4.executeAsync(anything())).never();
     });
 
     it('executes steps in correct order', async () => {
@@ -38,9 +39,33 @@ describe(BuildWorkflow, () => {
 
       const workflow = new BuildWorkflow({ buildSteps });
       await workflow.executeAsync();
-      verify(mockBuildStep1.executeAsync()).calledBefore(mockBuildStep3.executeAsync());
-      verify(mockBuildStep3.executeAsync()).calledBefore(mockBuildStep2.executeAsync());
-      verify(mockBuildStep2.executeAsync()).once();
+      verify(mockBuildStep1.executeAsync(anything())).calledBefore(
+        mockBuildStep3.executeAsync(anything())
+      );
+      verify(mockBuildStep3.executeAsync(anything())).calledBefore(
+        mockBuildStep2.executeAsync(anything())
+      );
+      verify(mockBuildStep2.executeAsync(anything())).once();
+    });
+
+    it('executes steps with environment variables passed to the workflow', async () => {
+      const mockBuildStep1 = mock<BuildStep>();
+      const mockBuildStep2 = mock<BuildStep>();
+      const mockBuildStep3 = mock<BuildStep>();
+
+      const buildSteps: BuildStep[] = [
+        instance(mockBuildStep1),
+        instance(mockBuildStep3),
+        instance(mockBuildStep2),
+      ];
+
+      const mockEnv: BuildStepEnv = { ABC: '123' };
+
+      const workflow = new BuildWorkflow({ buildSteps });
+      await workflow.executeAsync(mockEnv);
+      verify(mockBuildStep1.executeAsync(mockEnv));
+      verify(mockBuildStep2.executeAsync(mockEnv));
+      verify(mockBuildStep3.executeAsync(mockEnv));
     });
   });
 });


### PR DESCRIPTION
# Why

Fixes https://linear.app/expo/issue/ENG-7649/make-sure-env-vars-are-propagated-to-build-steps

Custom builds don't use the same env as is used for regular builds.

# How

- Execute steps with the env object passed to the workflow. Default to `process.env`.
- In build-tools, use the same env object as for regular builds.

# Test Plan

Tests.