### PR TITLE
[local-build-plugin] downgrade chalk

### DIFF
--- a/packages/local-build-plugin/package.json
+++ b/packages/local-build-plugin/package.json
@@ -25,7 +25,7 @@
     "@expo/eas-build-job": "0.2.106",
     "@expo/spawn-async": "^1.7.0",
     "@expo/turtle-spawn": "0.0.28",
-    "chalk": "^5.2.0",
+    "chalk": "^4.1.2",
     "env-paths": "^3.0.0",
     "fs-extra": "^11.1.0",
     "joi": "^17.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3060,11 +3060,6 @@ chalk@^4.0.2, chalk@^4.1.1, chalk@^4.1.2:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
-chalk@^5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-5.2.0.tgz#249623b7d66869c673699fb66d65723e54dfcfb3"
-  integrity sha512-ree3Gqw/nazQAPuJJEy+avdl7QfZMcUvmHIKgEZkGL+xOBzRvup5Hxo6LHuMceSxOabuJLJm5Yp/92R9eMmMvA==
-
 char-regex@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/char-regex/-/char-regex-1.0.2.tgz#d744358226217f981ed58f479b1d6bcc29545dcf"


### PR DESCRIPTION
# Why

`chalk` switched to ESM in v5

# How

downgrade

# Test Plan

run local build
