### PR TITLE
[ENG-7648][steps] add support for uploading artifacts

### DIFF
--- a/packages/steps/bin/set-output
+++ b/packages/steps/bin/set-output
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -eo pipefail
+
 NAME=$1
 VALUE=$2
 

--- a/packages/steps/bin/upload-artifact
+++ b/packages/steps/bin/upload-artifact
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+if [[ -z "$__EXPO_STEPS_BUILD_ID" || -z "$__EXPO_STEPS_WORKING_DIRECTORY" ]]; then
+  echo "Set __EXPO_STEPS_BUILD_ID and __EXPO_STEPS_WORKING_DIRECTORY"
+  exit 1
+fi
+
+STEPS_ROOT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )"/.. && pwd )"
+
+node $STEPS_ROOT_DIR/dist_commonjs/bin/uploadArtifact.cjs $@

--- a/packages/steps/examples/upload-artifacts/config.yml
+++ b/packages/steps/examples/upload-artifacts/config.yml
@@ -1,0 +1,6 @@
+build:
+  name: Upload artifacts
+  steps:
+    - run: upload-artifact abc
+    - run: upload-artifact --type build-artifact def
+    - run: upload-artifact --type build-artifact ghi

--- a/packages/steps/examples/upload-artifacts/project/abc
+++ b/packages/steps/examples/upload-artifacts/project/abc
@@ -1,0 +1,1 @@
+lorem ipsum 123

--- a/packages/steps/examples/upload-artifacts/project/def
+++ b/packages/steps/examples/upload-artifacts/project/def
@@ -1,0 +1,1 @@
+lorem ipsum 456

--- a/packages/steps/examples/upload-artifacts/project/ghi
+++ b/packages/steps/examples/upload-artifacts/project/ghi
@@ -1,0 +1,1 @@
+lorem ipsum 789

--- a/packages/steps/package.json
+++ b/packages/steps/package.json
@@ -46,6 +46,7 @@
   "dependencies": {
     "@expo/logger": "0.0.27",
     "@expo/spawn-async": "^1.7.0",
+    "arg": "^5.0.2",
     "joi": "^17.7.0",
     "this-file": "^2.0.3",
     "uuid": "^9.0.0",

--- a/packages/steps/src/BuildArtifacts.ts
+++ b/packages/steps/src/BuildArtifacts.ts
@@ -1,0 +1,6 @@
+export enum BuildArtifactType {
+  APPLICATION_ARCHIVE = 'application-archive',
+  BUILD_ARTIFACT = 'build-artifact',
+}
+
+export type BuildArtifacts = Partial<Record<BuildArtifactType, string[]>>;

--- a/packages/steps/src/BuildConfigParser.ts
+++ b/packages/steps/src/BuildConfigParser.ts
@@ -1,4 +1,4 @@
-import fs from 'fs';
+import fs from 'fs/promises';
 import path from 'path';
 
 import { v4 as uuidv4 } from 'uuid';
@@ -36,7 +36,7 @@ export class BuildConfigParser {
   }
 
   private async readRawConfigAsync(): Promise<any> {
-    const contents = await fs.promises.readFile(this.configPath, 'utf-8');
+    const contents = await fs.readFile(this.configPath, 'utf-8');
     return YAML.parse(contents);
   }
 

--- a/packages/steps/src/BuildConfigParser.ts
+++ b/packages/steps/src/BuildConfigParser.ts
@@ -30,7 +30,7 @@ export class BuildConfigParser {
     const steps = config.build.steps.map((stepConfig) =>
       this.createBuildStepFromConfig(stepConfig)
     );
-    const workflow = new BuildWorkflow({ buildSteps: steps });
+    const workflow = new BuildWorkflow(this.ctx, { buildSteps: steps });
     new BuildWorkflowValidator(workflow).validate();
     return workflow;
   }

--- a/packages/steps/src/BuildStep.ts
+++ b/packages/steps/src/BuildStep.ts
@@ -217,7 +217,9 @@ export class BuildStep {
     const newPath = currentPath ? `${BIN_PATH}:${currentPath}` : BIN_PATH;
     return {
       ...env,
+      __EXPO_STEPS_BUILD_ID: this.ctx.buildId,
       __EXPO_STEPS_OUTPUTS_DIR: outputsDir,
+      __EXPO_STEPS_WORKING_DIRECTORY: this.ctx.workingDirectory,
       PATH: newPath,
     };
   }

--- a/packages/steps/src/BuildStep.ts
+++ b/packages/steps/src/BuildStep.ts
@@ -10,10 +10,10 @@ import { BuildStepOutput } from './BuildStepOutput.js';
 import { BIN_PATH } from './utils/shell/bin.js';
 import { getDefaultShell, getShellCommandAndArgs } from './utils/shell/command.js';
 import {
-  cleanUpTemporaryDirectoriesAsync,
+  cleanUpStepTemporaryDirectoriesAsync,
   createTemporaryOutputsDirectoryAsync,
   saveScriptToTemporaryFileAsync,
-} from './utils/shell/temporaryFiles.js';
+} from './BuildTemporaryFiles.js';
 import { spawnAsync } from './utils/shell/spawn.js';
 import { interpolateWithInputs } from './utils/template.js';
 import { BuildStepRuntimeError } from './errors/BuildStepRuntimeError.js';
@@ -142,7 +142,7 @@ export class BuildStep {
       throw err;
     } finally {
       this.executed = true;
-      await cleanUpTemporaryDirectoriesAsync(this.ctx, this.id);
+      await cleanUpStepTemporaryDirectoriesAsync(this.ctx, this.id);
     }
   }
 

--- a/packages/steps/src/BuildStep.ts
+++ b/packages/steps/src/BuildStep.ts
@@ -1,4 +1,4 @@
-import fs from 'fs';
+import fs from 'fs/promises';
 import path from 'path';
 
 import { bunyan } from '@expo/logger';
@@ -174,7 +174,7 @@ export class BuildStep {
   }
 
   private async collectAndValidateOutputsAsync(outputsDir: string): Promise<void> {
-    const files = await fs.promises.readdir(outputsDir);
+    const files = await fs.readdir(outputsDir);
 
     const nonDefinedOutputIds: string[] = [];
     for (const outputId of files) {
@@ -182,7 +182,7 @@ export class BuildStep {
         nonDefinedOutputIds.push(outputId);
       } else {
         const file = path.join(outputsDir, outputId);
-        const rawContents = await fs.promises.readFile(file, 'utf-8');
+        const rawContents = await fs.readFile(file, 'utf-8');
         const value = rawContents.trim();
         this.outputById[outputId].set(value);
       }

--- a/packages/steps/src/BuildTemporaryFiles.ts
+++ b/packages/steps/src/BuildTemporaryFiles.ts
@@ -3,7 +3,7 @@ import fs from 'fs';
 
 import { v4 as uuidv4 } from 'uuid';
 
-import { BuildStepContext } from '../../BuildStepContext.js';
+import { BuildStepContext } from './BuildStepContext.js';
 
 export async function saveScriptToTemporaryFileAsync(
   ctx: BuildStepContext,
@@ -26,7 +26,7 @@ export async function createTemporaryOutputsDirectoryAsync(
   return directory;
 }
 
-export async function cleanUpTemporaryDirectoriesAsync(
+export async function cleanUpStepTemporaryDirectoriesAsync(
   ctx: BuildStepContext,
   stepId: string
 ): Promise<void> {

--- a/packages/steps/src/BuildTemporaryFiles.ts
+++ b/packages/steps/src/BuildTemporaryFiles.ts
@@ -77,7 +77,6 @@ export async function findArtifactsByTypeAsync(
   }
 }
 
-// TODO: use it in build-tools
 export async function cleanUpStepTemporaryDirectoriesAsync(
   ctx: BuildStepContext,
   stepId: string

--- a/packages/steps/src/BuildTemporaryFiles.ts
+++ b/packages/steps/src/BuildTemporaryFiles.ts
@@ -1,5 +1,5 @@
 import path from 'path';
-import fs from 'fs';
+import fs from 'fs/promises';
 
 import { v4 as uuidv4 } from 'uuid';
 
@@ -13,9 +13,9 @@ export async function saveScriptToTemporaryFileAsync(
   scriptContents: string
 ): Promise<string> {
   const scriptsDir = getTemporaryScriptsDirPath(ctx, stepId);
-  await fs.promises.mkdir(scriptsDir, { recursive: true });
+  await fs.mkdir(scriptsDir, { recursive: true });
   const temporaryScriptPath = path.join(scriptsDir, `${uuidv4()}.sh`);
-  await fs.promises.writeFile(temporaryScriptPath, scriptContents);
+  await fs.writeFile(temporaryScriptPath, scriptContents);
   return temporaryScriptPath;
 }
 
@@ -39,8 +39,8 @@ export async function saveArtifactToTemporaryDirectoryAsync(
     throw new BuildInternalError(`Uploading artifacts of type "${type}" is not implemented.`);
   }
 
-  await fs.promises.mkdir(path.dirname(targetArtifactPath), { recursive: true });
-  await fs.promises.copyFile(artifactPath, targetArtifactPath);
+  await fs.mkdir(path.dirname(targetArtifactPath), { recursive: true });
+  await fs.copyFile(artifactPath, targetArtifactPath);
   return targetArtifactPath;
 }
 
@@ -49,7 +49,7 @@ export async function createTemporaryOutputsDirectoryAsync(
   stepId: string
 ): Promise<string> {
   const directory = getTemporaryOutputsDirPath(ctx, stepId);
-  await fs.promises.mkdir(directory, { recursive: true });
+  await fs.mkdir(directory, { recursive: true });
   return directory;
 }
 
@@ -66,7 +66,7 @@ export async function findArtifactsByTypeAsync(
     throw new BuildInternalError(`Finding artifacts of type "${type}" is not implemented.`);
   }
   try {
-    const filenames = await fs.promises.readdir(artifactsDirPath);
+    const filenames = await fs.readdir(artifactsDirPath);
     return filenames.map((filename) => path.join(artifactsDirPath, filename));
   } catch (err) {
     ctx.logger.debug(
@@ -85,7 +85,7 @@ export async function cleanUpStepTemporaryDirectoriesAsync(
     return;
   }
   const stepTemporaryDirectory = getTemporaryStepDirPath(ctx, stepId);
-  await fs.promises.rm(stepTemporaryDirectory, { recursive: true });
+  await fs.rm(stepTemporaryDirectory, { recursive: true });
   ctx.logger.debug({ stepTemporaryDirectory }, 'Removed step temporary directory');
 }
 
@@ -97,7 +97,7 @@ export async function cleanUpWorkflowTemporaryDirectoriesAsync(
   }
 
   const temporaryDirectories: string[] = [getTemporaryArtifactsDirPath(ctx)];
-  const rmPromises = temporaryDirectories.map((dir) => fs.promises.rm(dir, { recursive: true }));
+  const rmPromises = temporaryDirectories.map((dir) => fs.rm(dir, { recursive: true }));
   await Promise.all(rmPromises);
   ctx.logger.debug({ temporaryDirectories }, 'Removed temporary directories');
 }

--- a/packages/steps/src/BuildTemporaryFiles.ts
+++ b/packages/steps/src/BuildTemporaryFiles.ts
@@ -4,6 +4,8 @@ import fs from 'fs';
 import { v4 as uuidv4 } from 'uuid';
 
 import { BuildStepContext } from './BuildStepContext.js';
+import { BuildArtifactType } from './BuildArtifacts.js';
+import { BuildInternalError } from './errors/BuildInternalError.js';
 
 export async function saveScriptToTemporaryFileAsync(
   ctx: BuildStepContext,
@@ -17,6 +19,31 @@ export async function saveScriptToTemporaryFileAsync(
   return temporaryScriptPath;
 }
 
+export async function saveArtifactToTemporaryDirectoryAsync(
+  ctx: BuildStepContext,
+  type: BuildArtifactType,
+  artifactPath: string
+): Promise<string> {
+  let targetArtifactPath: string;
+  if (type === BuildArtifactType.APPLICATION_ARCHIVE) {
+    targetArtifactPath = path.join(
+      getTemporaryApplicationArchiveDirPath(ctx),
+      path.basename(artifactPath)
+    );
+  } else if (type === BuildArtifactType.BUILD_ARTIFACT) {
+    targetArtifactPath = path.join(
+      getTemporaryBuildArtifactsDirPath(ctx),
+      path.basename(artifactPath)
+    );
+  } else {
+    throw new BuildInternalError(`Uploading artifacts of type "${type}" is not implemented.`);
+  }
+
+  await fs.promises.mkdir(path.dirname(targetArtifactPath), { recursive: true });
+  await fs.promises.copyFile(artifactPath, targetArtifactPath);
+  return targetArtifactPath;
+}
+
 export async function createTemporaryOutputsDirectoryAsync(
   ctx: BuildStepContext,
   stepId: string
@@ -26,6 +53,31 @@ export async function createTemporaryOutputsDirectoryAsync(
   return directory;
 }
 
+export async function findArtifactsByTypeAsync(
+  ctx: BuildStepContext,
+  type: BuildArtifactType
+): Promise<string[]> {
+  let artifactsDirPath: string;
+  if (type === BuildArtifactType.APPLICATION_ARCHIVE) {
+    artifactsDirPath = getTemporaryApplicationArchiveDirPath(ctx);
+  } else if (type === BuildArtifactType.BUILD_ARTIFACT) {
+    artifactsDirPath = getTemporaryBuildArtifactsDirPath(ctx);
+  } else {
+    throw new BuildInternalError(`Finding artifacts of type "${type}" is not implemented.`);
+  }
+  try {
+    const filenames = await fs.promises.readdir(artifactsDirPath);
+    return filenames.map((filename) => path.join(artifactsDirPath, filename));
+  } catch (err) {
+    ctx.logger.debug(
+      { err },
+      `Failed reading artifacts of type "${type}" from "${artifactsDirPath}". The directory probably doesn't exist.`
+    );
+    return [];
+  }
+}
+
+// TODO: use it in build-tools
 export async function cleanUpStepTemporaryDirectoriesAsync(
   ctx: BuildStepContext,
   stepId: string
@@ -38,6 +90,19 @@ export async function cleanUpStepTemporaryDirectoriesAsync(
   ctx.logger.debug({ stepTemporaryDirectory }, 'Removed step temporary directory');
 }
 
+export async function cleanUpWorkflowTemporaryDirectoriesAsync(
+  ctx: BuildStepContext
+): Promise<void> {
+  if (ctx.skipCleanup) {
+    return;
+  }
+
+  const temporaryDirectories: string[] = [getTemporaryArtifactsDirPath(ctx)];
+  const rmPromises = temporaryDirectories.map((dir) => fs.promises.rm(dir, { recursive: true }));
+  await Promise.all(rmPromises);
+  ctx.logger.debug({ temporaryDirectories }, 'Removed temporary directories');
+}
+
 function getTemporaryStepDirPath(ctx: BuildStepContext, stepId: string): string {
   return path.join(ctx.baseWorkingDirectory, 'steps', stepId);
 }
@@ -48,4 +113,16 @@ function getTemporaryScriptsDirPath(ctx: BuildStepContext, stepId: string): stri
 
 function getTemporaryOutputsDirPath(ctx: BuildStepContext, stepId: string): string {
   return path.join(getTemporaryStepDirPath(ctx, stepId), 'outputs');
+}
+
+function getTemporaryApplicationArchiveDirPath(ctx: BuildStepContext): string {
+  return path.join(getTemporaryArtifactsDirPath(ctx), 'application-archive');
+}
+
+function getTemporaryBuildArtifactsDirPath(ctx: BuildStepContext): string {
+  return path.join(getTemporaryArtifactsDirPath(ctx), 'build-artifacts');
+}
+
+function getTemporaryArtifactsDirPath(ctx: BuildStepContext): string {
+  return path.join(ctx.baseWorkingDirectory, 'artifacts');
 }

--- a/packages/steps/src/BuildWorkflow.ts
+++ b/packages/steps/src/BuildWorkflow.ts
@@ -2,7 +2,10 @@ import { BuildArtifacts, BuildArtifactType } from './BuildArtifacts.js';
 import { BuildStep } from './BuildStep.js';
 import { BuildStepContext } from './BuildStepContext.js';
 import { BuildStepEnv } from './BuildStepEnv.js';
-import { findArtifactsByTypeAsync } from './BuildTemporaryFiles.js';
+import {
+  cleanUpWorkflowTemporaryDirectoriesAsync,
+  findArtifactsByTypeAsync,
+} from './BuildTemporaryFiles.js';
 
 export class BuildWorkflow {
   public readonly buildSteps: BuildStep[];
@@ -11,14 +14,13 @@ export class BuildWorkflow {
     this.buildSteps = buildSteps;
   }
 
-  public async executeAsync(env: BuildStepEnv = process.env): Promise<BuildArtifacts> {
+  public async executeAsync(env: BuildStepEnv = process.env): Promise<void> {
     for (const step of this.buildSteps) {
       await step.executeAsync(env);
     }
-    return await this.collectArtifactsAsync();
   }
 
-  private async collectArtifactsAsync(): Promise<BuildArtifacts> {
+  public async collectArtifactsAsync(): Promise<BuildArtifacts> {
     const applicationArchives = await findArtifactsByTypeAsync(
       this.ctx,
       BuildArtifactType.APPLICATION_ARCHIVE
@@ -31,5 +33,9 @@ export class BuildWorkflow {
       [BuildArtifactType.APPLICATION_ARCHIVE]: applicationArchives,
       [BuildArtifactType.BUILD_ARTIFACT]: buildArtifacts,
     };
+  }
+
+  public async cleanUpAsync(): Promise<void> {
+    await cleanUpWorkflowTemporaryDirectoriesAsync(this.ctx);
   }
 }

--- a/packages/steps/src/__tests__/BuildStep-test.ts
+++ b/packages/steps/src/__tests__/BuildStep-test.ts
@@ -1,4 +1,4 @@
-import fs from 'fs';
+import fs from 'fs/promises';
 import path from 'path';
 
 import { jest } from '@jest/globals';
@@ -78,10 +78,10 @@ describe(BuildStep, () => {
 
     beforeEach(async () => {
       baseStepCtx = createMockContext();
-      await fs.promises.mkdir(baseStepCtx.workingDirectory, { recursive: true });
+      await fs.mkdir(baseStepCtx.workingDirectory, { recursive: true });
     });
     afterEach(async () => {
-      await fs.promises.rm(baseStepCtx.baseWorkingDirectory, { recursive: true });
+      await fs.rm(baseStepCtx.baseWorkingDirectory, { recursive: true });
     });
 
     it('executes the command passed to the step', async () => {
@@ -97,9 +97,9 @@ describe(BuildStep, () => {
       const ctx = cloneContextWithOverrides(baseStepCtx, { logger });
 
       await Promise.all([
-        fs.promises.writeFile(path.join(ctx.workingDirectory, 'expo-abc123'), 'lorem ipsum'),
-        fs.promises.writeFile(path.join(ctx.workingDirectory, 'expo-def456'), 'lorem ipsum'),
-        fs.promises.writeFile(path.join(ctx.workingDirectory, 'expo-ghi789'), 'lorem ipsum'),
+        fs.writeFile(path.join(ctx.workingDirectory, 'expo-abc123'), 'lorem ipsum'),
+        fs.writeFile(path.join(ctx.workingDirectory, 'expo-def456'), 'lorem ipsum'),
+        fs.writeFile(path.join(ctx.workingDirectory, 'expo-ghi789'), 'lorem ipsum'),
       ]);
 
       const step = new BuildStep(ctx, {
@@ -210,10 +210,10 @@ describe(BuildStep, () => {
 
     beforeEach(async () => {
       baseStepCtx = createMockContext();
-      await fs.promises.mkdir(baseStepCtx.workingDirectory, { recursive: true });
+      await fs.mkdir(baseStepCtx.workingDirectory, { recursive: true });
     });
     afterEach(async () => {
-      await fs.promises.rm(baseStepCtx.baseWorkingDirectory, { recursive: true });
+      await fs.rm(baseStepCtx.baseWorkingDirectory, { recursive: true });
     });
 
     it('throws an error when the step has not been executed yet', async () => {

--- a/packages/steps/src/__tests__/BuildTemporaryFiles-test.ts
+++ b/packages/steps/src/__tests__/BuildTemporaryFiles-test.ts
@@ -1,13 +1,20 @@
 import fs from 'fs';
 import os from 'os';
+import path from 'path';
 
+import { BuildArtifactType } from '../BuildArtifacts.js';
 import {
   cleanUpStepTemporaryDirectoriesAsync,
+  cleanUpWorkflowTemporaryDirectoriesAsync,
   createTemporaryOutputsDirectoryAsync,
+  findArtifactsByTypeAsync,
+  saveArtifactToTemporaryDirectoryAsync,
   saveScriptToTemporaryFileAsync,
 } from '../BuildTemporaryFiles.js';
+import { BuildInternalError } from '../errors/BuildInternalError.js';
 
 import { createMockContext } from './utils/context.js';
+import { getErrorAsync } from './utils/error.js';
 
 describe(saveScriptToTemporaryFileAsync, () => {
   it('saves the script in a directory inside os.tmpdir()', async () => {
@@ -20,6 +27,52 @@ describe(saveScriptToTemporaryFileAsync, () => {
     const contents = 'echo 123\necho 456';
     const scriptPath = await saveScriptToTemporaryFileAsync(ctx, 'foo', contents);
     await expect(fs.promises.readFile(scriptPath, 'utf-8')).resolves.toBe(contents);
+  });
+});
+
+describe(saveArtifactToTemporaryDirectoryAsync, () => {
+  const originalArtifactPath = path.join(os.tmpdir(), 'app.ipa');
+
+  beforeEach(async () => {
+    await fs.promises.writeFile(originalArtifactPath, 'abc123');
+  });
+  afterEach(async () => {
+    await fs.promises.rm(originalArtifactPath);
+  });
+
+  it('can upload the application archive', async () => {
+    const ctx = createMockContext();
+    const artifactPath = await saveArtifactToTemporaryDirectoryAsync(
+      ctx,
+      BuildArtifactType.APPLICATION_ARCHIVE,
+      originalArtifactPath
+    );
+    expect(artifactPath).not.toBe(originalArtifactPath);
+    await expect(fs.promises.readFile(artifactPath, 'utf-8')).resolves.toBe('abc123');
+    expect(artifactPath.startsWith(os.tmpdir())).toBe(true);
+  });
+  it('can upload a build artifact', async () => {
+    const ctx = createMockContext();
+    const artifactPath = await saveArtifactToTemporaryDirectoryAsync(
+      ctx,
+      BuildArtifactType.BUILD_ARTIFACT,
+      originalArtifactPath
+    );
+    expect(artifactPath).not.toBe(originalArtifactPath);
+    await expect(fs.promises.readFile(artifactPath, 'utf-8')).resolves.toBe('abc123');
+    expect(artifactPath.startsWith(os.tmpdir())).toBe(true);
+  });
+  it('throws when trying to upload unsupported artifact type', async () => {
+    const ctx = createMockContext();
+    const error = await getErrorAsync<BuildInternalError>(async () =>
+      saveArtifactToTemporaryDirectoryAsync(
+        ctx,
+        'unknown' as BuildArtifactType,
+        originalArtifactPath
+      )
+    );
+    expect(error).toBeInstanceOf(BuildInternalError);
+    expect(error.message).toMatch(/Uploading artifacts of type "unknown" is not implemented/);
   });
 });
 
@@ -36,6 +89,60 @@ describe(createTemporaryOutputsDirectoryAsync, () => {
   });
 });
 
+describe(findArtifactsByTypeAsync, () => {
+  const originalArtifactPath1 = path.join(os.tmpdir(), 'app1.ipa');
+  const originalArtifactPath2 = path.join(os.tmpdir(), 'app2.ipa');
+
+  beforeEach(async () => {
+    await fs.promises.writeFile(originalArtifactPath1, 'abc123');
+    await fs.promises.writeFile(originalArtifactPath2, 'def456');
+  });
+  afterEach(async () => {
+    await fs.promises.rm(originalArtifactPath1);
+    await fs.promises.rm(originalArtifactPath2);
+  });
+
+  it('can find artifacts of type "application-archive"', async () => {
+    const ctx = createMockContext();
+    const artifactPath1 = await saveArtifactToTemporaryDirectoryAsync(
+      ctx,
+      BuildArtifactType.APPLICATION_ARCHIVE,
+      originalArtifactPath1
+    );
+    const artifactPath2 = await saveArtifactToTemporaryDirectoryAsync(
+      ctx,
+      BuildArtifactType.APPLICATION_ARCHIVE,
+      originalArtifactPath2
+    );
+    const result = await findArtifactsByTypeAsync(ctx, BuildArtifactType.APPLICATION_ARCHIVE);
+    expect(result.length).toBe(2);
+    expect(result[0]).toBe(artifactPath1);
+    expect(result[1]).toBe(artifactPath2);
+  });
+  it('can find artifacts of type "build-artifact"', async () => {
+    const ctx = createMockContext();
+    await saveArtifactToTemporaryDirectoryAsync(
+      ctx,
+      BuildArtifactType.APPLICATION_ARCHIVE,
+      originalArtifactPath1
+    );
+    const artifactPath2 = await saveArtifactToTemporaryDirectoryAsync(
+      ctx,
+      BuildArtifactType.BUILD_ARTIFACT,
+      originalArtifactPath2
+    );
+    const result = await findArtifactsByTypeAsync(ctx, BuildArtifactType.BUILD_ARTIFACT);
+    expect(result.length).toBe(1);
+    expect(result[0]).toBe(artifactPath2);
+  });
+  it('throws when trying to find unsupported artifact type', async () => {
+    const ctx = createMockContext();
+    await expect(findArtifactsByTypeAsync(ctx, 'unknown' as BuildArtifactType)).rejects.toThrow(
+      BuildInternalError
+    );
+  });
+});
+
 describe(cleanUpStepTemporaryDirectoriesAsync, () => {
   it('removes the step temporary directories', async () => {
     const ctx = createMockContext();
@@ -46,5 +153,28 @@ describe(cleanUpStepTemporaryDirectoriesAsync, () => {
     await cleanUpStepTemporaryDirectoriesAsync(ctx, 'foo');
     await expect(fs.promises.stat(scriptPath)).rejects.toThrow(/no such file or directory/);
     await expect(fs.promises.stat(outputsPath)).rejects.toThrow(/no such file or directory/);
+  });
+});
+
+describe(cleanUpWorkflowTemporaryDirectoriesAsync, () => {
+  const originalArtifactPath = path.join(os.tmpdir(), 'app.ipa');
+
+  beforeEach(async () => {
+    await fs.promises.writeFile(originalArtifactPath, 'abc123');
+  });
+  afterEach(async () => {
+    await fs.promises.rm(originalArtifactPath);
+  });
+
+  it('removes the workflow temporary directories', async () => {
+    const ctx = createMockContext();
+    const artifactPath = await saveArtifactToTemporaryDirectoryAsync(
+      ctx,
+      BuildArtifactType.APPLICATION_ARCHIVE,
+      originalArtifactPath
+    );
+    await expect(fs.promises.stat(artifactPath)).resolves.toBeTruthy();
+    await cleanUpWorkflowTemporaryDirectoriesAsync(ctx);
+    await expect(fs.promises.stat(artifactPath)).rejects.toThrow(/no such file or directory/);
   });
 });

--- a/packages/steps/src/__tests__/BuildTemporaryFiles-test.ts
+++ b/packages/steps/src/__tests__/BuildTemporaryFiles-test.ts
@@ -1,4 +1,4 @@
-import fs from 'fs';
+import fs from 'fs/promises';
 import os from 'os';
 import path from 'path';
 
@@ -26,7 +26,7 @@ describe(saveScriptToTemporaryFileAsync, () => {
     const ctx = createMockContext();
     const contents = 'echo 123\necho 456';
     const scriptPath = await saveScriptToTemporaryFileAsync(ctx, 'foo', contents);
-    await expect(fs.promises.readFile(scriptPath, 'utf-8')).resolves.toBe(contents);
+    await expect(fs.readFile(scriptPath, 'utf-8')).resolves.toBe(contents);
   });
 });
 
@@ -34,10 +34,10 @@ describe(saveArtifactToTemporaryDirectoryAsync, () => {
   const originalArtifactPath = path.join(os.tmpdir(), 'app.ipa');
 
   beforeEach(async () => {
-    await fs.promises.writeFile(originalArtifactPath, 'abc123');
+    await fs.writeFile(originalArtifactPath, 'abc123');
   });
   afterEach(async () => {
-    await fs.promises.rm(originalArtifactPath);
+    await fs.rm(originalArtifactPath);
   });
 
   it('can upload the application archive', async () => {
@@ -48,7 +48,7 @@ describe(saveArtifactToTemporaryDirectoryAsync, () => {
       originalArtifactPath
     );
     expect(artifactPath).not.toBe(originalArtifactPath);
-    await expect(fs.promises.readFile(artifactPath, 'utf-8')).resolves.toBe('abc123');
+    await expect(fs.readFile(artifactPath, 'utf-8')).resolves.toBe('abc123');
     expect(artifactPath.startsWith(os.tmpdir())).toBe(true);
   });
   it('can upload a build artifact', async () => {
@@ -59,7 +59,7 @@ describe(saveArtifactToTemporaryDirectoryAsync, () => {
       originalArtifactPath
     );
     expect(artifactPath).not.toBe(originalArtifactPath);
-    await expect(fs.promises.readFile(artifactPath, 'utf-8')).resolves.toBe('abc123');
+    await expect(fs.readFile(artifactPath, 'utf-8')).resolves.toBe('abc123');
     expect(artifactPath.startsWith(os.tmpdir())).toBe(true);
   });
   it('throws when trying to upload unsupported artifact type', async () => {
@@ -80,7 +80,7 @@ describe(createTemporaryOutputsDirectoryAsync, () => {
   it('creates a temporary directory for output values', async () => {
     const ctx = createMockContext();
     const outputsPath = await createTemporaryOutputsDirectoryAsync(ctx, 'foo');
-    await expect(fs.promises.stat(outputsPath)).resolves.not.toThrow();
+    await expect(fs.stat(outputsPath)).resolves.not.toThrow();
   });
   it('creates a temporary directory inside os.tmpdir()', async () => {
     const ctx = createMockContext();
@@ -94,12 +94,12 @@ describe(findArtifactsByTypeAsync, () => {
   const originalArtifactPath2 = path.join(os.tmpdir(), 'app2.ipa');
 
   beforeEach(async () => {
-    await fs.promises.writeFile(originalArtifactPath1, 'abc123');
-    await fs.promises.writeFile(originalArtifactPath2, 'def456');
+    await fs.writeFile(originalArtifactPath1, 'abc123');
+    await fs.writeFile(originalArtifactPath2, 'def456');
   });
   afterEach(async () => {
-    await fs.promises.rm(originalArtifactPath1);
-    await fs.promises.rm(originalArtifactPath2);
+    await fs.rm(originalArtifactPath1);
+    await fs.rm(originalArtifactPath2);
   });
 
   it('can find artifacts of type "application-archive"', async () => {
@@ -148,11 +148,11 @@ describe(cleanUpStepTemporaryDirectoriesAsync, () => {
     const ctx = createMockContext();
     const scriptPath = await saveScriptToTemporaryFileAsync(ctx, 'foo', 'echo 123');
     const outputsPath = await createTemporaryOutputsDirectoryAsync(ctx, 'foo');
-    await expect(fs.promises.stat(scriptPath)).resolves.toBeTruthy();
-    await expect(fs.promises.stat(outputsPath)).resolves.toBeTruthy();
+    await expect(fs.stat(scriptPath)).resolves.toBeTruthy();
+    await expect(fs.stat(outputsPath)).resolves.toBeTruthy();
     await cleanUpStepTemporaryDirectoriesAsync(ctx, 'foo');
-    await expect(fs.promises.stat(scriptPath)).rejects.toThrow(/no such file or directory/);
-    await expect(fs.promises.stat(outputsPath)).rejects.toThrow(/no such file or directory/);
+    await expect(fs.stat(scriptPath)).rejects.toThrow(/no such file or directory/);
+    await expect(fs.stat(outputsPath)).rejects.toThrow(/no such file or directory/);
   });
 });
 
@@ -160,10 +160,10 @@ describe(cleanUpWorkflowTemporaryDirectoriesAsync, () => {
   const originalArtifactPath = path.join(os.tmpdir(), 'app.ipa');
 
   beforeEach(async () => {
-    await fs.promises.writeFile(originalArtifactPath, 'abc123');
+    await fs.writeFile(originalArtifactPath, 'abc123');
   });
   afterEach(async () => {
-    await fs.promises.rm(originalArtifactPath);
+    await fs.rm(originalArtifactPath);
   });
 
   it('removes the workflow temporary directories', async () => {
@@ -173,8 +173,8 @@ describe(cleanUpWorkflowTemporaryDirectoriesAsync, () => {
       BuildArtifactType.APPLICATION_ARCHIVE,
       originalArtifactPath
     );
-    await expect(fs.promises.stat(artifactPath)).resolves.toBeTruthy();
+    await expect(fs.stat(artifactPath)).resolves.toBeTruthy();
     await cleanUpWorkflowTemporaryDirectoriesAsync(ctx);
-    await expect(fs.promises.stat(artifactPath)).rejects.toThrow(/no such file or directory/);
+    await expect(fs.stat(artifactPath)).rejects.toThrow(/no such file or directory/);
   });
 });

--- a/packages/steps/src/__tests__/BuildTemporaryFiles-test.ts
+++ b/packages/steps/src/__tests__/BuildTemporaryFiles-test.ts
@@ -1,12 +1,13 @@
 import fs from 'fs';
 import os from 'os';
 
-import { createMockContext } from '../../../__tests__/utils/context.js';
 import {
-  cleanUpTemporaryDirectoriesAsync,
+  cleanUpStepTemporaryDirectoriesAsync,
   createTemporaryOutputsDirectoryAsync,
   saveScriptToTemporaryFileAsync,
-} from '../temporaryFiles.js';
+} from '../BuildTemporaryFiles.js';
+
+import { createMockContext } from './utils/context.js';
 
 describe(saveScriptToTemporaryFileAsync, () => {
   it('saves the script in a directory inside os.tmpdir()', async () => {
@@ -35,14 +36,14 @@ describe(createTemporaryOutputsDirectoryAsync, () => {
   });
 });
 
-describe(cleanUpTemporaryDirectoriesAsync, () => {
-  it('removes the temporary directories', async () => {
+describe(cleanUpStepTemporaryDirectoriesAsync, () => {
+  it('removes the step temporary directories', async () => {
     const ctx = createMockContext();
     const scriptPath = await saveScriptToTemporaryFileAsync(ctx, 'foo', 'echo 123');
     const outputsPath = await createTemporaryOutputsDirectoryAsync(ctx, 'foo');
     await expect(fs.promises.stat(scriptPath)).resolves.toBeTruthy();
     await expect(fs.promises.stat(outputsPath)).resolves.toBeTruthy();
-    await cleanUpTemporaryDirectoriesAsync(ctx, 'foo');
+    await cleanUpStepTemporaryDirectoriesAsync(ctx, 'foo');
     await expect(fs.promises.stat(scriptPath)).rejects.toThrow(/no such file or directory/);
     await expect(fs.promises.stat(outputsPath)).rejects.toThrow(/no such file or directory/);
   });

--- a/packages/steps/src/__tests__/BuildWorkflow-test.ts
+++ b/packages/steps/src/__tests__/BuildWorkflow-test.ts
@@ -79,7 +79,8 @@ describe(BuildWorkflow, () => {
       verify(mockBuildStep2.executeAsync(mockEnv));
       verify(mockBuildStep3.executeAsync(mockEnv));
     });
-
+  });
+  describe(BuildWorkflow.prototype.collectArtifactsAsync, () => {
     it('returns build artifacts', async () => {
       const ctx = createMockContext();
       const originalApplicationArchivePath = path.join(os.tmpdir(), 'app.ipa');
@@ -111,7 +112,9 @@ describe(BuildWorkflow, () => {
         ];
 
         const workflow = new BuildWorkflow(ctx, { buildSteps });
-        const artifacts = await workflow.executeAsync();
+        await workflow.executeAsync();
+
+        const artifacts = await workflow.collectArtifactsAsync();
         expect(artifacts['application-archive']?.length).toBe(1);
         expect(artifacts['build-artifact']?.length).toBe(2);
         expect(artifacts['application-archive']?.[0].endsWith('app.ipa')).toBeTruthy();

--- a/packages/steps/src/__tests__/BuildWorkflow-test.ts
+++ b/packages/steps/src/__tests__/BuildWorkflow-test.ts
@@ -1,4 +1,4 @@
-import fs from 'fs';
+import fs from 'fs/promises';
 import os from 'os';
 import path from 'path';
 
@@ -88,10 +88,10 @@ describe(BuildWorkflow, () => {
       const originalBuildArtifactPath2 = path.join(os.tmpdir(), 'screenshot2.png');
 
       try {
-        await fs.promises.mkdir(ctx.workingDirectory, { recursive: true });
-        await fs.promises.writeFile(originalApplicationArchivePath, 'abc123');
-        await fs.promises.writeFile(originalBuildArtifactPath1, 'def456');
-        await fs.promises.writeFile(originalBuildArtifactPath2, 'ghi789');
+        await fs.mkdir(ctx.workingDirectory, { recursive: true });
+        await fs.writeFile(originalApplicationArchivePath, 'abc123');
+        await fs.writeFile(originalBuildArtifactPath1, 'def456');
+        await fs.writeFile(originalBuildArtifactPath2, 'ghi789');
 
         const buildSteps: BuildStep[] = [
           new BuildStep(ctx, {
@@ -122,10 +122,10 @@ describe(BuildWorkflow, () => {
         expect(artifacts['build-artifact']?.[1].endsWith('screenshot2.png')).toBeTruthy();
       } finally {
         await Promise.all([
-          fs.promises.rm(ctx.baseWorkingDirectory, { recursive: true }),
-          fs.promises.rm(originalApplicationArchivePath),
-          fs.promises.rm(originalBuildArtifactPath1),
-          fs.promises.rm(originalBuildArtifactPath2),
+          fs.rm(ctx.baseWorkingDirectory, { recursive: true }),
+          fs.rm(originalApplicationArchivePath),
+          fs.rm(originalBuildArtifactPath1),
+          fs.rm(originalBuildArtifactPath2),
         ]);
       }
     });

--- a/packages/steps/src/__tests__/BuildWorkflow-test.ts
+++ b/packages/steps/src/__tests__/BuildWorkflow-test.ts
@@ -1,8 +1,14 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
 import { anything, instance, mock, verify } from 'ts-mockito';
 
 import { BuildStep } from '../BuildStep.js';
 import { BuildStepEnv } from '../BuildStepEnv.js';
 import { BuildWorkflow } from '../BuildWorkflow.js';
+
+import { createMockContext } from './utils/context.js';
 
 describe(BuildWorkflow, () => {
   describe(BuildWorkflow.prototype.executeAsync, () => {
@@ -18,8 +24,10 @@ describe(BuildWorkflow, () => {
         instance(mockBuildStep3),
       ];
 
-      const workflow = new BuildWorkflow({ buildSteps });
+      const ctx = createMockContext();
+      const workflow = new BuildWorkflow(ctx, { buildSteps });
       await workflow.executeAsync();
+
       verify(mockBuildStep1.executeAsync(anything())).once();
       verify(mockBuildStep2.executeAsync(anything())).once();
       verify(mockBuildStep3.executeAsync(anything())).once();
@@ -37,8 +45,10 @@ describe(BuildWorkflow, () => {
         instance(mockBuildStep2),
       ];
 
-      const workflow = new BuildWorkflow({ buildSteps });
+      const ctx = createMockContext();
+      const workflow = new BuildWorkflow(ctx, { buildSteps });
       await workflow.executeAsync();
+
       verify(mockBuildStep1.executeAsync(anything())).calledBefore(
         mockBuildStep3.executeAsync(anything())
       );
@@ -61,11 +71,60 @@ describe(BuildWorkflow, () => {
 
       const mockEnv: BuildStepEnv = { ABC: '123' };
 
-      const workflow = new BuildWorkflow({ buildSteps });
+      const ctx = createMockContext();
+      const workflow = new BuildWorkflow(ctx, { buildSteps });
       await workflow.executeAsync(mockEnv);
+
       verify(mockBuildStep1.executeAsync(mockEnv));
       verify(mockBuildStep2.executeAsync(mockEnv));
       verify(mockBuildStep3.executeAsync(mockEnv));
+    });
+
+    it('returns build artifacts', async () => {
+      const ctx = createMockContext();
+      const originalApplicationArchivePath = path.join(os.tmpdir(), 'app.ipa');
+      const originalBuildArtifactPath1 = path.join(os.tmpdir(), 'screenshot1.png');
+      const originalBuildArtifactPath2 = path.join(os.tmpdir(), 'screenshot2.png');
+
+      try {
+        await fs.promises.mkdir(ctx.workingDirectory, { recursive: true });
+        await fs.promises.writeFile(originalApplicationArchivePath, 'abc123');
+        await fs.promises.writeFile(originalBuildArtifactPath1, 'def456');
+        await fs.promises.writeFile(originalBuildArtifactPath2, 'ghi789');
+
+        const buildSteps: BuildStep[] = [
+          new BuildStep(ctx, {
+            id: 'test1',
+            command: `upload-artifact --type application-archive ${originalApplicationArchivePath}`,
+            workingDirectory: ctx.workingDirectory,
+          }),
+          new BuildStep(ctx, {
+            id: 'test2',
+            command: `upload-artifact --type build-artifact ${originalBuildArtifactPath1}`,
+            workingDirectory: ctx.workingDirectory,
+          }),
+          new BuildStep(ctx, {
+            id: 'test3',
+            command: `upload-artifact --type build-artifact ${originalBuildArtifactPath2}`,
+            workingDirectory: ctx.workingDirectory,
+          }),
+        ];
+
+        const workflow = new BuildWorkflow(ctx, { buildSteps });
+        const artifacts = await workflow.executeAsync();
+        expect(artifacts['application-archive']?.length).toBe(1);
+        expect(artifacts['build-artifact']?.length).toBe(2);
+        expect(artifacts['application-archive']?.[0].endsWith('app.ipa')).toBeTruthy();
+        expect(artifacts['build-artifact']?.[0].endsWith('screenshot1.png')).toBeTruthy();
+        expect(artifacts['build-artifact']?.[1].endsWith('screenshot2.png')).toBeTruthy();
+      } finally {
+        await Promise.all([
+          fs.promises.rm(ctx.baseWorkingDirectory, { recursive: true }),
+          fs.promises.rm(originalApplicationArchivePath),
+          fs.promises.rm(originalBuildArtifactPath1),
+          fs.promises.rm(originalBuildArtifactPath2),
+        ]);
+      }
     });
   });
 });

--- a/packages/steps/src/__tests__/BuildWorkflowValidator-test.ts
+++ b/packages/steps/src/__tests__/BuildWorkflowValidator-test.ts
@@ -14,7 +14,7 @@ import { getError } from './utils/error.js';
 describe(BuildWorkflowValidator, () => {
   test('non unique step ids', async () => {
     const ctx = createMockContext();
-    const workflow = new BuildWorkflow({
+    const workflow = new BuildWorkflow(ctx, {
       buildSteps: [
         new BuildStep(ctx, {
           id: 'test1',
@@ -56,7 +56,7 @@ describe(BuildWorkflowValidator, () => {
   });
   test('output from future step', async () => {
     const ctx = createMockContext();
-    const workflow = new BuildWorkflow({
+    const workflow = new BuildWorkflow(ctx, {
       buildSteps: [
         new BuildStep(ctx, {
           id: 'test1',
@@ -94,7 +94,7 @@ describe(BuildWorkflowValidator, () => {
   });
   test('output from non-existent step', async () => {
     const ctx = createMockContext();
-    const workflow = new BuildWorkflow({
+    const workflow = new BuildWorkflow(ctx, {
       buildSteps: [
         new BuildStep(ctx, {
           id: 'test2',
@@ -126,7 +126,7 @@ describe(BuildWorkflowValidator, () => {
   });
   test('undefined output', async () => {
     const ctx = createMockContext();
-    const workflow = new BuildWorkflow({
+    const workflow = new BuildWorkflow(ctx, {
       buildSteps: [
         new BuildStep(ctx, {
           id: 'test1',
@@ -177,7 +177,7 @@ describe(BuildWorkflowValidator, () => {
   });
   test('multiple config errors', () => {
     const ctx = createMockContext();
-    const workflow = new BuildWorkflow({
+    const workflow = new BuildWorkflow(ctx, {
       buildSteps: [
         new BuildStep(ctx, {
           id: 'test1',

--- a/packages/steps/src/bin/uploadArtifact.ts
+++ b/packages/steps/src/bin/uploadArtifact.ts
@@ -1,0 +1,39 @@
+import path from 'path';
+
+import { createLogger } from '@expo/logger';
+import arg from 'arg';
+
+import { nullthrows } from '../utils/nullthrows.js';
+import { BuildArtifactType } from '../BuildArtifacts.js';
+import { BuildStepContext } from '../BuildStepContext.js';
+import { saveArtifactToTemporaryDirectoryAsync } from '../BuildTemporaryFiles.js';
+
+const args = arg({
+  '--type': String,
+});
+
+const artifactPathArg = nullthrows(
+  args._?.[0],
+  'upload-artifact must be run with the artifact path, e.g. "upload-artifact path/to/app.ipa"'
+);
+const artifactPath = path.resolve(process.cwd(), artifactPathArg);
+
+const logger = createLogger({
+  name: 'eas-build',
+  level: 'info',
+});
+
+const ctx = new BuildStepContext(
+  nullthrows(process.env.__EXPO_STEPS_BUILD_ID, 'Set __EXPO_STEPS_BUILD_ID.'),
+  logger,
+  false,
+  nullthrows(process.env.__EXPO_STEPS_WORKING_DIRECTORY, 'Set __EXPO_STEPS_BUILD_ID.')
+);
+
+const rawType = args['--type'] as BuildArtifactType | undefined;
+const type = rawType ?? BuildArtifactType.APPLICATION_ARCHIVE;
+
+saveArtifactToTemporaryDirectoryAsync(ctx, type, artifactPath).catch((err) => {
+  console.error(`Failed preparing "${artifactPath}" for upload.`, err);
+  process.exit(2);
+});

--- a/packages/steps/src/cli/cli.ts
+++ b/packages/steps/src/cli/cli.ts
@@ -17,6 +17,10 @@ async function runAsync(configPath: string, workingDirectory: string): Promise<v
   const parser = new BuildConfigParser(ctx, { configPath });
   const workflow = await parser.parseAsync();
   await workflow.executeAsync();
+  const artifacts = await workflow.collectArtifactsAsync();
+  if (Object.keys(artifacts).length > 0) {
+    logger.info({ artifacts }, 'The workflow produced artifacts');
+  }
 }
 
 const relativeConfigPath = process.argv[2];

--- a/packages/steps/src/errors/BuildInternalError.ts
+++ b/packages/steps/src/errors/BuildInternalError.ts
@@ -1,0 +1,1 @@
+export class BuildInternalError extends Error {}

--- a/packages/steps/src/index.ts
+++ b/packages/steps/src/index.ts
@@ -1,2 +1,3 @@
+export { BuildArtifactType } from './BuildArtifacts.js';
 export { BuildConfigParser } from './BuildConfigParser.js';
 export { BuildStepContext } from './BuildStepContext.js';

--- a/yarn.lock
+++ b/yarn.lock
@@ -2610,6 +2610,11 @@ are-we-there-yet@^3.0.0:
     delegates "^1.0.0"
     readable-stream "^3.6.0"
 
+arg@^5.0.2:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/arg/-/arg-5.0.2.tgz#c81433cc427c92c4dcf4865142dbca6f15acd59c"
+  integrity sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==
+
 argparse@^1.0.7:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.10.tgz#bcd6791ea5ae09725e17e5ad988134cd40b3d911"


### PR DESCRIPTION
# Why

We want to be able to upload artifacts from custom builds.

# How

- Introduce `upload-artifact [--type application-archive|build-artifact]` binary that could be run from any build step.
- The binary copies the artifact to a temporary directory.
- `@expo/build-tools` is responsible for the actual artifacts upload. Because of that, the artifacts are not uploaded at the time the `upload-artifact` command is run but as the last, additional build step. Why? This was the easiest thing I could implement. `@expo/steps` shouldn't have the file upload implementation. Instead, it should be possible to inject some JS code that knows how to upload files. Unfortunately, the `upload-artifact` is run as a separate process so it can have the JS context provided in runtime. The artifact upload feature is going to change in the future. When the "reusable steps" feature is implemented, I want to add the first built-in EAS step that could be used for artifact upload. The reusable steps will have support for running JS code so it'll be possible to use the context from a service using the `@expo/steps` library.

# Test Plan

- Tests.
- Tested locally.

# Future work

Reimplement artifact uploads to use reusable steps.
