### PR TITLE
[ENG-7684][steps] implement reusable functions

### DIFF
--- a/packages/steps/README.md
+++ b/packages/steps/README.md
@@ -9,3 +9,7 @@ If you want to run config examples from the **examples** directory, e.g. **examp
 - Run `yarn` and `yarn build` in the root of the monorepo.
 - Add `alias eas-steps="/REPLACE/WITH/PATH/TO/eas-build/packages/steps/cli.sh"` to your **.zshrc**/**.bashrc**/etc.
 - cd into **examples/simple** and run `eas-steps config.yml project`. The first argument is the config file, and the second is the default working directory for the config file.
+
+### Example project
+
+See the example project using custom builds at https://github.com/expo/eas-custom-builds-example.

--- a/packages/steps/examples/functions/config.yml
+++ b/packages/steps/examples/functions/config.yml
@@ -1,0 +1,33 @@
+build:
+  name: Functions
+  steps:
+    - say_hi_brent
+    - say_hi:
+        inputs:
+          name: Dominik
+    - say_hi:
+        inputs:
+          name: Szymon
+    - random:
+        id: random_number
+    - run:
+        name: Print random number
+        inputs:
+          random_number: ${ steps.random_number.value }
+        command: |
+          echo "Random number: ${ inputs.random_number }"
+
+functions:
+  say_hi:
+    name: Say HI
+    inputs:
+      - name
+    command: echo "Hi, ${ inputs.name }!"
+  say_hi_brent:
+    name: Say HI
+    command: echo "Hi, Brent!"
+  random:
+    name: Generate random number
+    outputs:
+      - value
+    command: set-output value 6

--- a/packages/steps/package.json
+++ b/packages/steps/package.json
@@ -20,7 +20,7 @@
   "scripts": {
     "start": "yarn watch",
     "build": "./build.sh",
-    "watch": "chokidar --initial \"src/**/*.ts\" -c \"./build.sh\"",
+    "watch": "chokidar --initial \"src/**/*.ts\" -i \"src/**/__tests__/**/*\" -c \"./build.sh\"",
     "test": "node --experimental-vm-modules --no-warnings node_modules/.bin/jest -c=jest.config.cjs --no-cache",
     "test:watch": "yarn test --watch",
     "clean": "rm -rf node_modules dist_* coverage"

--- a/packages/steps/src/BuildConfig.ts
+++ b/packages/steps/src/BuildConfig.ts
@@ -1,17 +1,57 @@
+import assert from 'assert';
+
 import Joi from 'joi';
 
 import { BuildConfigError } from './errors/BuildConfigError.js';
+import { BuildPlatform } from './BuildPlatform.js';
 
 export interface BuildConfig {
   build: {
     name?: string;
     steps: BuildStepConfig[];
   };
+  functions?: Record<string, BuildFunctionConfig>;
 }
 
-export type BuildStepInputsConfig = Record<string, string>;
+export type BuildFunctionCallConfig = {
+  id?: string;
+  inputs?: BuildStepInputsConfig;
+  name?: string;
+  workingDirectory?: string;
+  shell?: string;
+};
 
-export type BuildStepOutputsConfig = (
+export type BuildStepConfig =
+  | string
+  | {
+      run:
+        | string
+        | (BuildFunctionCallConfig & {
+            outputs?: BuildStepOutputsConfig;
+            command: string;
+          });
+    }
+  | {
+      [functionId: string]: BuildFunctionCallConfig;
+    };
+
+export type BuildStepInputsConfig = Record<string, string>;
+export type BuildStepOutputsConfig = BuildInputOutputParametersConfig;
+
+export interface BuildFunctionConfig {
+  id?: string;
+  inputs?: BuildFunctionInputsConfig;
+  outputs?: BuildFunctionOutputsConfig;
+  name?: string;
+  platforms?: BuildPlatform[];
+  shell?: string;
+  command: string;
+}
+
+export type BuildFunctionInputsConfig = BuildInputOutputParametersConfig;
+export type BuildFunctionOutputsConfig = BuildInputOutputParametersConfig;
+
+export type BuildInputOutputParametersConfig = (
   | string
   | {
       name: string;
@@ -19,66 +59,108 @@ export type BuildStepOutputsConfig = (
     }
 )[];
 
-export type BuildStepConfig =
-  | string
-  | {
-      run:
-        | string
-        | {
-            id?: string;
-            inputs?: BuildStepInputsConfig;
-            outputs?: BuildStepOutputsConfig;
-            name?: string;
-            workingDirectory?: string;
-            shell?: string;
-            command: string;
-          };
-    };
+const BuildInputOutputParametersConfigSchema = Joi.array().items(
+  Joi.alternatives().try(
+    Joi.string().required(),
+    Joi.object({
+      name: Joi.string().required(),
+      required: Joi.boolean(),
+    }).required()
+  )
+);
 
 export const BuildConfigSchema = Joi.object<BuildConfig>({
   build: Joi.object({
     name: Joi.string(),
     steps: Joi.array()
       .items(
-        Joi.object({
-          run: Joi.alternatives().conditional('run', {
-            is: Joi.string(),
-            then: Joi.string().required(),
-            otherwise: Joi.object({
-              id: Joi.string(),
-              inputs: Joi.object().pattern(Joi.string(), Joi.string()),
-              outputs: Joi.array().items(
-                Joi.alternatives().try(
-                  Joi.string().required(),
-                  Joi.object({
-                    name: Joi.string().required(),
-                    required: Joi.boolean(),
-                  }).required()
-                )
-              ),
-              name: Joi.string(),
-              workingDirectory: Joi.string(),
-              shell: Joi.string(),
-              command: Joi.string().required(),
-            })
-              .rename('working_directory', 'workingDirectory')
+        Joi.alternatives().conditional(Joi.object({ run: Joi.any().required() }).unknown(), {
+          then: Joi.object({
+            run: Joi.alternatives()
+              .conditional(Joi.string(), {
+                then: Joi.string().min(1).required(),
+                otherwise: Joi.object({
+                  id: Joi.string(),
+                  inputs: Joi.object().pattern(Joi.string(), Joi.string()),
+                  outputs: BuildInputOutputParametersConfigSchema,
+                  name: Joi.string(),
+                  workingDirectory: Joi.string(),
+                  shell: Joi.string(),
+                  command: Joi.string().required(),
+                })
+                  .rename('working_directory', 'workingDirectory')
+                  .required(),
+              })
+              .required(),
+          }),
+          otherwise: Joi.alternatives().conditional(Joi.string(), {
+            then: Joi.string().min(1).required(),
+            otherwise: Joi.object()
+              .pattern(
+                Joi.string().min(1).required(),
+                Joi.object({
+                  id: Joi.string(),
+                  inputs: Joi.object().pattern(Joi.string(), Joi.string()),
+                  name: Joi.string(),
+                  workingDirectory: Joi.string(),
+                  shell: Joi.string(),
+                }).required(),
+                { matches: Joi.array().length(1) }
+              )
               .required(),
           }),
         })
       )
       .required(),
   }).required(),
+  functions: Joi.object().pattern(
+    Joi.string().min(1).required(),
+    Joi.object({
+      id: Joi.string(),
+      name: Joi.string(),
+      platforms: Joi.string().allow(...Object.values(BuildPlatform)),
+      inputs: BuildInputOutputParametersConfigSchema,
+      outputs: BuildInputOutputParametersConfigSchema,
+      command: Joi.string().required(),
+      shell: Joi.string(),
+    }).required()
+  ),
 }).required();
 
 export function validateBuildConfig(rawConfig: object): BuildConfig {
-  const { error, value } = BuildConfigSchema.validate(rawConfig, {
+  const { error, value: buildConfig } = BuildConfigSchema.validate(rawConfig, {
     allowUnknown: false,
     abortEarly: false,
   });
   if (error) {
     const errorMessage = error.details.map(({ message }) => message).join(', ');
     throw new BuildConfigError(errorMessage, { cause: error });
-  } else {
-    return value;
+  }
+  validateAllFunctionsExist(buildConfig);
+  return buildConfig;
+}
+
+function validateAllFunctionsExist(config: BuildConfig): void {
+  const calledFunctionsSet = new Set<string>();
+  for (const step of config.build.steps) {
+    if (typeof step === 'string') {
+      calledFunctionsSet.add(step);
+    } else if (!('run' in step)) {
+      const keys = Object.keys(step);
+      assert(
+        keys.length === 1,
+        'There must be at most one function call in the step (enforced by joi)'
+      );
+      calledFunctionsSet.add(keys[0]);
+    }
+  }
+  const calledFunctions = Array.from(calledFunctionsSet);
+  const nonExistentFunctions = calledFunctions.filter((calledFunction) => {
+    return !(calledFunction in (config.functions ?? {}));
+  });
+  if (nonExistentFunctions.length > 0) {
+    throw new BuildConfigError(
+      `Calling non-existent functions: ${nonExistentFunctions.join(', ')}`
+    );
   }
 }

--- a/packages/steps/src/BuildConfigParser.ts
+++ b/packages/steps/src/BuildConfigParser.ts
@@ -1,3 +1,4 @@
+import assert from 'assert';
 import fs from 'fs/promises';
 import path from 'path';
 
@@ -5,11 +6,15 @@ import { v4 as uuidv4 } from 'uuid';
 import YAML from 'yaml';
 
 import {
+  BuildConfig,
+  BuildFunctionConfig,
+  BuildFunctionInputsConfig,
   BuildStepConfig,
   BuildStepInputsConfig,
   BuildStepOutputsConfig,
   validateBuildConfig,
 } from './BuildConfig.js';
+import { BuildFunction, BuildFunctionById } from './BuildFunction.js';
 import { BuildStep } from './BuildStep.js';
 import { BuildStepContext } from './BuildStepContext.js';
 import { BuildStepInput } from './BuildStepInput.js';
@@ -27,10 +32,11 @@ export class BuildConfigParser {
   public async parseAsync(): Promise<BuildWorkflow> {
     const rawConfig = await this.readRawConfigAsync();
     const config = validateBuildConfig(rawConfig);
-    const steps = config.build.steps.map((stepConfig) =>
-      this.createBuildStepFromConfig(stepConfig)
+    const buildFunctions = this.createBuildFunctionsFromConfig(config.functions);
+    const buildSteps = config.build.steps.map((stepConfig) =>
+      this.createBuildStepFromConfig(stepConfig, buildFunctions)
     );
-    const workflow = new BuildWorkflow(this.ctx, { buildSteps: steps });
+    const workflow = new BuildWorkflow(this.ctx, { buildSteps, buildFunctions });
     new BuildWorkflowValidator(workflow).validate();
     return workflow;
   }
@@ -40,10 +46,16 @@ export class BuildConfigParser {
     return YAML.parse(contents);
   }
 
-  private createBuildStepFromConfig(buildStepConfig: BuildStepConfig): BuildStep {
+  private createBuildStepFromConfig(
+    buildStepConfig: BuildStepConfig,
+    buildFunctions: BuildFunctionById
+  ): BuildStep {
     if (typeof buildStepConfig === 'string') {
-      // TODO: implement calling functions
-      throw new Error('Not implemented yet');
+      const functionId = buildStepConfig;
+      const buildFunction = buildFunctions[functionId];
+      return buildFunction.toBuildStep({
+        workingDirectory: this.getStepWorkingDirectory(),
+      });
     } else if (typeof buildStepConfig.run === 'string') {
       const command = buildStepConfig.run;
       return new BuildStep(this.ctx, {
@@ -51,7 +63,8 @@ export class BuildConfigParser {
         workingDirectory: this.ctx.workingDirectory,
         command,
       });
-    } else {
+    } else if ('run' in buildStepConfig) {
+      assert('command' in buildStepConfig.run);
       const {
         id,
         inputs: inputsConfig,
@@ -62,24 +75,64 @@ export class BuildConfigParser {
         command,
       } = buildStepConfig.run;
       const stepId = id ?? uuidv4();
-      const inputs = inputsConfig && this.createBuildStepInputsFromConfig(inputsConfig, stepId);
+      const inputs =
+        inputsConfig && this.createBuildStepInputsFromBuildStepInputsConfig(inputsConfig, stepId);
       const outputs = outputsConfig && this.createBuildStepOutputsFromConfig(outputsConfig, stepId);
       return new BuildStep(this.ctx, {
         id: stepId,
         inputs,
         outputs,
         name,
-        workingDirectory:
-          workingDirectory !== undefined
-            ? path.resolve(this.ctx.workingDirectory, workingDirectory)
-            : this.ctx.workingDirectory,
+        workingDirectory: this.getStepWorkingDirectory(workingDirectory),
         shell,
         command,
+      });
+    } else {
+      const keys = Object.keys(buildStepConfig);
+      assert(
+        keys.length === 1,
+        'There must be at most one function call in the step (enforced by joi)'
+      );
+      const functionId = keys[0];
+      const buildFunctionCallConfig = buildStepConfig[functionId];
+      const buildFunction = buildFunctions[functionId];
+      return buildFunction.toBuildStep({
+        id: buildFunctionCallConfig.id,
+        callInputs: buildFunctionCallConfig.inputs,
+        workingDirectory: this.getStepWorkingDirectory(buildFunctionCallConfig.workingDirectory),
+        shell: buildFunctionCallConfig.shell,
       });
     }
   }
 
-  private createBuildStepInputsFromConfig(
+  private createBuildFunctionsFromConfig(
+    buildFunctionsConfig: BuildConfig['functions']
+  ): BuildFunctionById {
+    if (!buildFunctionsConfig) {
+      return {};
+    }
+    const result: BuildFunctionById = {};
+    for (const [functionId, buildFunctionConfig] of Object.entries(buildFunctionsConfig)) {
+      result[functionId] = this.createBuildFunctionFromConfig(buildFunctionConfig);
+    }
+    return result;
+  }
+
+  private createBuildFunctionFromConfig({
+    id,
+    name,
+    inputs: inputsConfig,
+    outputs: outputsConfig,
+    shell,
+    command,
+  }: BuildFunctionConfig): BuildFunction {
+    const inputs =
+      inputsConfig && this.createBuildStepInputsFromBuildFunctionInputsConfig(inputsConfig);
+    const outputs = outputsConfig && this.createBuildStepOutputsFromConfig(outputsConfig);
+    return new BuildFunction(this.ctx, { id, name, inputs, outputs, shell, command });
+  }
+
+  private createBuildStepInputsFromBuildStepInputsConfig(
     buildStepInputsConfig: BuildStepInputsConfig,
     stepId: string
   ): BuildStepInput[] {
@@ -94,9 +147,24 @@ export class BuildConfigParser {
     );
   }
 
+  private createBuildStepInputsFromBuildFunctionInputsConfig(
+    buildFunctionInputsConfig: BuildFunctionInputsConfig
+  ): BuildStepInput[] {
+    return buildFunctionInputsConfig.map((entry) => {
+      if (typeof entry === 'string') {
+        return new BuildStepInput(this.ctx, { id: entry });
+      } else {
+        return new BuildStepInput(this.ctx, {
+          id: entry.name,
+          required: entry.required ?? true,
+        });
+      }
+    });
+  }
+
   private createBuildStepOutputsFromConfig(
     buildStepOutputsConfig: BuildStepOutputsConfig,
-    stepId: string
+    stepId?: string
   ): BuildStepOutput[] {
     return buildStepOutputsConfig.map((entry) =>
       typeof entry === 'string'
@@ -107,5 +175,11 @@ export class BuildConfigParser {
             required: entry.required ?? true,
           })
     );
+  }
+
+  private getStepWorkingDirectory(workingDirectory?: string): string {
+    return workingDirectory !== undefined
+      ? path.resolve(this.ctx.workingDirectory, workingDirectory)
+      : this.ctx.workingDirectory;
   }
 }

--- a/packages/steps/src/BuildFunction.ts
+++ b/packages/steps/src/BuildFunction.ts
@@ -1,0 +1,82 @@
+import { v4 as uuidv4 } from 'uuid';
+
+import { BuildPlatform } from './BuildPlatform.js';
+import { BuildStep } from './BuildStep.js';
+import { BuildStepContext } from './BuildStepContext.js';
+import { BuildStepInput } from './BuildStepInput.js';
+import { BuildStepOutput } from './BuildStepOutput.js';
+
+export type BuildFunctionById = Record<string, BuildFunction>;
+export type BuildFunctionCallInputs = Record<string, string>;
+
+export class BuildFunction {
+  public readonly id?: string;
+  public readonly name?: string;
+  public readonly platforms?: BuildPlatform[];
+  public readonly inputs?: BuildStepInput[];
+  public readonly outputs?: BuildStepOutput[];
+  public readonly command: string;
+  public readonly shell?: string;
+
+  constructor(
+    private readonly ctx: BuildStepContext,
+    {
+      id,
+      name,
+      platforms,
+      inputs,
+      outputs,
+      command,
+      shell,
+    }: {
+      id?: string;
+      name?: string;
+      platforms?: BuildPlatform[];
+      inputs?: BuildStepInput[];
+      outputs?: BuildStepOutput[];
+      command: string;
+      shell?: string;
+    }
+  ) {
+    this.id = id;
+    this.name = name;
+    this.platforms = platforms;
+    this.inputs = inputs;
+    this.outputs = outputs;
+    this.command = command;
+    this.shell = shell;
+  }
+
+  public toBuildStep({
+    id,
+    callInputs = {},
+    workingDirectory,
+    shell,
+  }: {
+    id?: string;
+    callInputs?: BuildFunctionCallInputs;
+    workingDirectory: string;
+    shell?: string;
+  }): BuildStep {
+    const buildStepId = id ?? this.id ?? uuidv4();
+
+    const stepInputs = this.inputs?.map((i) => {
+      const cloned = i.clone(buildStepId);
+      if (cloned.id in callInputs) {
+        cloned.set(callInputs[cloned.id]);
+      }
+      return cloned;
+    });
+    const stepOutputs = this.outputs?.map((o) => o.clone(buildStepId));
+
+    return new BuildStep(this.ctx, {
+      id: buildStepId,
+      name: this.name,
+      command: this.command,
+      workingDirectory,
+      inputs: stepInputs,
+      outputs: stepOutputs,
+      shell,
+    });
+  }
+}

--- a/packages/steps/src/BuildPlatform.ts
+++ b/packages/steps/src/BuildPlatform.ts
@@ -1,0 +1,4 @@
+export enum BuildPlatform {
+  DARWIN = 'darwin',
+  LINUX = 'linux',
+}

--- a/packages/steps/src/BuildStepInput.ts
+++ b/packages/steps/src/BuildStepInput.ts
@@ -1,12 +1,12 @@
-import assert from 'assert';
-
 import { BuildStepContext } from './BuildStepContext.js';
 import { BuildStepRuntimeError } from './errors/BuildStepRuntimeError.js';
 import { interpolateWithOutputs } from './utils/template.js';
 
+export type BuildStepInputCreator = (stepId: string) => BuildStepInput;
+
 export class BuildStepInput {
   public readonly id: string;
-  public readonly stepId?: string;
+  public readonly stepId: string;
   public readonly defaultValue?: string;
   public readonly required: boolean;
 
@@ -21,7 +21,7 @@ export class BuildStepInput {
       required = true,
     }: {
       id: string;
-      stepId?: string;
+      stepId: string;
       defaultValue?: string;
       required?: boolean;
     }
@@ -33,13 +33,10 @@ export class BuildStepInput {
   }
 
   get value(): string | undefined {
-    const { stepId } = this;
-    assert(stepId, `.value can't be used when not in step context`);
-
     const rawValue = this._value ?? this.defaultValue;
     if (this.required && rawValue === undefined) {
       throw new BuildStepRuntimeError(
-        `Input parameter "${this.id}" for step "${stepId}" is required but it was not set.`
+        `Input parameter "${this.id}" for step "${this.stepId}" is required but it was not set.`
       );
     }
 
@@ -51,27 +48,12 @@ export class BuildStepInput {
   }
 
   set(value: string | undefined): BuildStepInput {
-    const { stepId } = this;
-    assert(
-      stepId,
-      `.set(${value === undefined ? '' : `'${value}'`}) can't be used when not in step context`
-    );
-
     if (this.required && value === undefined) {
       throw new BuildStepRuntimeError(
-        `Input parameter "${this.id}" for step "${stepId}" is required.`
+        `Input parameter "${this.id}" for step "${this.stepId}" is required.`
       );
     }
     this._value = value;
     return this;
-  }
-
-  clone(stepId: string): BuildStepInput {
-    return new BuildStepInput(this.ctx, {
-      id: this.id,
-      stepId,
-      defaultValue: this.defaultValue,
-      required: this.required,
-    });
   }
 }

--- a/packages/steps/src/BuildStepOutput.ts
+++ b/packages/steps/src/BuildStepOutput.ts
@@ -1,17 +1,18 @@
+import assert from 'assert';
+
 import { BuildStepContext } from './BuildStepContext.js';
 import { BuildStepRuntimeError } from './errors/BuildStepRuntimeError.js';
 
 export class BuildStepOutput {
   public readonly id: string;
-  public readonly stepId: string;
+  public readonly stepId?: string;
   public readonly required: boolean;
 
   private _value?: string;
 
   constructor(
-    // @ts-expect-error ctx is not used in this class but let's keep it here for consistency
     private readonly ctx: BuildStepContext,
-    { id, stepId, required = true }: { id: string; stepId: string; required?: boolean }
+    { id, stepId, required = true }: { id: string; stepId?: string; required?: boolean }
   ) {
     this.id = id;
     this.stepId = stepId;
@@ -19,21 +20,36 @@ export class BuildStepOutput {
   }
 
   get value(): string | undefined {
+    const { stepId } = this;
+    assert(stepId, `.value can't be used when not in step context`);
     if (this.required && this._value === undefined) {
       throw new BuildStepRuntimeError(
-        `Output parameter "${this.id}" for step "${this.stepId}" is required but it was not set.`
+        `Output parameter "${this.id}" for step "${stepId}" is required but it was not set.`
       );
     }
     return this._value;
   }
 
   set(value: string | undefined): BuildStepOutput {
+    const { stepId } = this;
+    assert(
+      stepId,
+      `.set(${value === undefined ? '' : `'${value}'`}) can't be used when not in step context`
+    );
     if (this.required && value === undefined) {
       throw new BuildStepRuntimeError(
-        `Output parameter "${this.id}" for step "${this.stepId}" is required.`
+        `Output parameter "${this.id}" for step "${stepId}" is required.`
       );
     }
     this._value = value;
     return this;
+  }
+
+  clone(stepId: string): BuildStepOutput {
+    return new BuildStepOutput(this.ctx, {
+      id: this.id,
+      stepId,
+      required: this.required,
+    });
   }
 }

--- a/packages/steps/src/BuildStepOutput.ts
+++ b/packages/steps/src/BuildStepOutput.ts
@@ -1,18 +1,19 @@
-import assert from 'assert';
-
 import { BuildStepContext } from './BuildStepContext.js';
 import { BuildStepRuntimeError } from './errors/BuildStepRuntimeError.js';
 
+export type BuildStepOutputCreator = (stepId: string) => BuildStepOutput;
+
 export class BuildStepOutput {
   public readonly id: string;
-  public readonly stepId?: string;
+  public readonly stepId: string;
   public readonly required: boolean;
 
   private _value?: string;
 
   constructor(
+    // @ts-expect-error ctx is not used in this class but let's keep it here for consistency
     private readonly ctx: BuildStepContext,
-    { id, stepId, required = true }: { id: string; stepId?: string; required?: boolean }
+    { id, stepId, required = true }: { id: string; stepId: string; required?: boolean }
   ) {
     this.id = id;
     this.stepId = stepId;
@@ -20,36 +21,21 @@ export class BuildStepOutput {
   }
 
   get value(): string | undefined {
-    const { stepId } = this;
-    assert(stepId, `.value can't be used when not in step context`);
     if (this.required && this._value === undefined) {
       throw new BuildStepRuntimeError(
-        `Output parameter "${this.id}" for step "${stepId}" is required but it was not set.`
+        `Output parameter "${this.id}" for step "${this.stepId}" is required but it was not set.`
       );
     }
     return this._value;
   }
 
   set(value: string | undefined): BuildStepOutput {
-    const { stepId } = this;
-    assert(
-      stepId,
-      `.set(${value === undefined ? '' : `'${value}'`}) can't be used when not in step context`
-    );
     if (this.required && value === undefined) {
       throw new BuildStepRuntimeError(
-        `Output parameter "${this.id}" for step "${stepId}" is required.`
+        `Output parameter "${this.id}" for step "${this.stepId}" is required.`
       );
     }
     this._value = value;
     return this;
-  }
-
-  clone(stepId: string): BuildStepOutput {
-    return new BuildStepOutput(this.ctx, {
-      id: this.id,
-      stepId,
-      required: this.required,
-    });
   }
 }

--- a/packages/steps/src/BuildWorkflow.ts
+++ b/packages/steps/src/BuildWorkflow.ts
@@ -1,4 +1,5 @@
 import { BuildArtifacts, BuildArtifactType } from './BuildArtifacts.js';
+import { BuildFunctionById } from './BuildFunction.js';
 import { BuildStep } from './BuildStep.js';
 import { BuildStepContext } from './BuildStepContext.js';
 import { BuildStepEnv } from './BuildStepEnv.js';
@@ -9,9 +10,14 @@ import {
 
 export class BuildWorkflow {
   public readonly buildSteps: BuildStep[];
+  public readonly buildFunctions: BuildFunctionById;
 
-  constructor(private readonly ctx: BuildStepContext, { buildSteps }: { buildSteps: BuildStep[] }) {
+  constructor(
+    private readonly ctx: BuildStepContext,
+    { buildSteps, buildFunctions }: { buildSteps: BuildStep[]; buildFunctions: BuildFunctionById }
+  ) {
     this.buildSteps = buildSteps;
+    this.buildFunctions = buildFunctions;
   }
 
   public async executeAsync(env: BuildStepEnv = process.env): Promise<void> {

--- a/packages/steps/src/BuildWorkflow.ts
+++ b/packages/steps/src/BuildWorkflow.ts
@@ -30,8 +30,10 @@ export class BuildWorkflow {
       BuildArtifactType.BUILD_ARTIFACT
     );
     return {
-      [BuildArtifactType.APPLICATION_ARCHIVE]: applicationArchives,
-      [BuildArtifactType.BUILD_ARTIFACT]: buildArtifacts,
+      ...(applicationArchives.length > 0 && {
+        [BuildArtifactType.APPLICATION_ARCHIVE]: applicationArchives,
+      }),
+      ...(buildArtifacts.length > 0 && { [BuildArtifactType.BUILD_ARTIFACT]: buildArtifacts }),
     };
   }
 

--- a/packages/steps/src/__tests__/BuildConfig-test.ts
+++ b/packages/steps/src/__tests__/BuildConfig-test.ts
@@ -11,38 +11,220 @@ describe(validateBuildConfig, () => {
   });
 
   describe('steps', () => {
+    test('inline command', () => {
+      const buildConfig = {
+        build: {
+          steps: [
+            {
+              run: 'echo 123',
+            },
+          ],
+        },
+      };
+
+      expect(() => {
+        validateBuildConfig(buildConfig);
+      }).not.toThrowError();
+    });
+
+    describe('commands', () => {
+      test('command is required', () => {
+        const buildConfig = {
+          build: {
+            steps: [
+              {
+                run: {},
+              },
+            ],
+          },
+        };
+
+        expect(() => {
+          validateBuildConfig(buildConfig);
+        }).toThrowError(/".*\.command" is required/);
+      });
+      test('non-existent fields', () => {
+        const buildConfig = {
+          build: {
+            steps: [
+              {
+                run: {
+                  command: 'echo 123',
+                  blah: '123',
+                },
+              },
+            ],
+          },
+        };
+
+        expect(() => {
+          validateBuildConfig(buildConfig);
+        }).toThrowError(/".*\.blah" is not allowed/);
+      });
+      test('valid command', () => {
+        const buildConfig = {
+          build: {
+            steps: [
+              {
+                run: {
+                  command: 'echo 123',
+                },
+              },
+            ],
+          },
+        };
+
+        expect(() => {
+          validateBuildConfig(buildConfig);
+        }).not.toThrowError();
+      });
+    });
+
+    describe('function calls', () => {
+      test('bare call', () => {
+        const buildConfig = {
+          build: {
+            steps: ['say_hi'],
+          },
+          functions: {
+            say_hi: {
+              command: 'echo Hi!',
+            },
+          },
+        };
+
+        expect(() => {
+          validateBuildConfig(buildConfig);
+        }).not.toThrowError();
+      });
+      test('non-existent fields', () => {
+        const buildConfig = {
+          build: {
+            steps: [
+              {
+                say_hi: {
+                  blah: '123',
+                },
+              },
+            ],
+          },
+          functions: {
+            say_hi: {
+              command: 'echo Hi!',
+            },
+          },
+        };
+
+        expect(() => {
+          validateBuildConfig(buildConfig);
+        }).toThrowError(/".*\.blah" is not allowed/);
+      });
+      test('command is not allowed', () => {
+        const buildConfig = {
+          build: {
+            steps: [
+              {
+                say_hi: {
+                  command: 'echo 123',
+                },
+              },
+            ],
+          },
+          functions: {
+            say_hi: {
+              command: 'echo Hi!',
+            },
+          },
+        };
+
+        expect(() => {
+          validateBuildConfig(buildConfig);
+        }).toThrowError(/".*\.command" is not allowed/);
+      });
+      test('call with inputs', () => {
+        const buildConfig = {
+          build: {
+            steps: [
+              {
+                say_hi: {
+                  inputs: {
+                    name: 'Dominik',
+                  },
+                },
+              },
+            ],
+          },
+          functions: {
+            say_hi: {
+              command: 'echo "Hi, ${ inputs.name }!"',
+            },
+          },
+        };
+
+        expect(() => {
+          validateBuildConfig(buildConfig);
+        }).not.toThrowError();
+      });
+      test('at most one function call per step', () => {
+        const buildConfig = {
+          build: {
+            steps: [
+              {
+                say_hi: {
+                  inputs: {
+                    name: 'Dominik',
+                  },
+                },
+                say_hello: {
+                  inputs: {
+                    name: 'Dominik',
+                  },
+                },
+              },
+            ],
+          },
+          functions: {
+            say_hi: {
+              command: 'echo "Hi, ${ inputs.name }!"',
+            },
+            say_hello: {
+              command: 'echo "Hello, ${ inputs.name }!"',
+            },
+          },
+        };
+
+        expect(() => {
+          validateBuildConfig(buildConfig);
+        }).toThrowError();
+      });
+      test('non-existent functions', () => {
+        const buildConfig = {
+          build: {
+            steps: ['say_hi', 'say_hello'],
+          },
+        };
+
+        expect(() => {
+          validateBuildConfig(buildConfig);
+        }).toThrowError(/Calling non-existent functions: say_hi, say_hello/);
+      });
+    });
+  });
+
+  describe('functions', () => {
     test('command is required', () => {
       const buildConfig = {
         build: {
-          steps: [
-            {
-              run: {},
-            },
-          ],
+          steps: [],
+        },
+        functions: {
+          say_hi: {},
         },
       };
 
       expect(() => {
         validateBuildConfig(buildConfig);
-      }).toThrowError(/".*\.command" is required/);
-    });
-    test('non-existent fields', () => {
-      const buildConfig = {
-        build: {
-          steps: [
-            {
-              run: {
-                command: 'echo 123',
-                blah: '123',
-              },
-            },
-          ],
-        },
-      };
-
-      expect(() => {
-        validateBuildConfig(buildConfig);
-      }).toThrowError(/".*\.blah" is not allowed/);
+      }).toThrowError(/".*\.say_hi\.command" is required/);
     });
   });
 });

--- a/packages/steps/src/__tests__/BuildConfig-test.ts
+++ b/packages/steps/src/__tests__/BuildConfig-test.ts
@@ -1,4 +1,14 @@
-import { validateBuildConfig } from '../BuildConfig.js';
+import {
+  BuildStepBareCommandRun,
+  BuildStepBareFunctionCall,
+  BuildStepCommandRun,
+  BuildStepFunctionCall,
+  isBuildStepBareCommandRun,
+  isBuildStepBareFunctionCall,
+  isBuildStepCommandRun,
+  isBuildStepFunctionCall,
+  validateBuildConfig,
+} from '../BuildConfig.js';
 import { BuildConfigError } from '../errors/BuildConfigError.js';
 
 describe(validateBuildConfig, () => {
@@ -226,5 +236,87 @@ describe(validateBuildConfig, () => {
         validateBuildConfig(buildConfig);
       }).toThrowError(/".*\.say_hi\.command" is required/);
     });
+    test('"run" is not allowed for function name', () => {
+      const buildConfig = {
+        build: {
+          steps: [],
+        },
+        functions: {
+          run: {},
+        },
+      };
+
+      expect(() => {
+        validateBuildConfig(buildConfig);
+      }).toThrowError(/"functions.run" is not allowed/);
+    });
+  });
+});
+
+const buildStepCommandRun: BuildStepCommandRun = {
+  run: {
+    command: 'echo 123',
+  },
+};
+
+const buildStepBareCommandRun: BuildStepBareCommandRun = {
+  run: 'echo 123',
+};
+
+const buildStepFunctionCall: BuildStepFunctionCall = {
+  say_hi: {
+    inputs: {
+      name: 'Dominik',
+    },
+  },
+};
+
+const buildStepBareFunctionCall: BuildStepBareFunctionCall = 'say_hi';
+
+describe(isBuildStepCommandRun, () => {
+  it.each([buildStepBareCommandRun, buildStepFunctionCall, buildStepBareFunctionCall])(
+    'returns false',
+    (i) => {
+      expect(isBuildStepCommandRun(i)).toBe(false);
+    }
+  );
+  it('returns true', () => {
+    expect(isBuildStepCommandRun(buildStepCommandRun)).toBe(true);
+  });
+});
+
+describe(isBuildStepBareCommandRun, () => {
+  it.each([buildStepCommandRun, buildStepFunctionCall, buildStepBareFunctionCall])(
+    'returns false',
+    (i) => {
+      expect(isBuildStepBareCommandRun(i)).toBe(false);
+    }
+  );
+  it('returns true', () => {
+    expect(isBuildStepBareCommandRun(buildStepBareCommandRun)).toBe(true);
+  });
+});
+
+describe(isBuildStepFunctionCall, () => {
+  it.each([buildStepCommandRun, buildStepBareCommandRun, buildStepBareFunctionCall])(
+    'returns false',
+    (i) => {
+      expect(isBuildStepFunctionCall(i)).toBe(false);
+    }
+  );
+  it('returns true', () => {
+    expect(isBuildStepFunctionCall(buildStepFunctionCall)).toBe(true);
+  });
+});
+
+describe(isBuildStepBareFunctionCall, () => {
+  it.each([buildStepCommandRun, buildStepBareCommandRun, buildStepFunctionCall])(
+    'returns false',
+    (i) => {
+      expect(isBuildStepBareFunctionCall(i)).toBe(false);
+    }
+  );
+  it('returns true', () => {
+    expect(isBuildStepBareFunctionCall(buildStepBareFunctionCall)).toBe(true);
   });
 });

--- a/packages/steps/src/__tests__/BuildConfigParser-test.ts
+++ b/packages/steps/src/__tests__/BuildConfigParser-test.ts
@@ -261,9 +261,9 @@ describe(BuildConfigParser, () => {
       const function1 = buildFunctions.say_hi;
       expect(function1.id).toBe(undefined);
       expect(function1.name).toBe('Hi!');
-      expect(function1.inputs?.[0].id).toBe('name');
-      expect(function1.inputs?.[0].defaultValue).toBe(undefined);
-      expect(function1.inputs?.[0].required).toBe(true);
+      expect(function1.inputCreators?.[0]('unknown-step').id).toBe('name');
+      expect(function1.inputCreators?.[0]('unknown-step').defaultValue).toBe(undefined);
+      expect(function1.inputCreators?.[0]('unknown-step').required).toBe(true);
       expect(function1.command).toBe('echo "Hi, ${ inputs.name }!"');
 
       // say_hi_wojtek:
@@ -282,8 +282,8 @@ describe(BuildConfigParser, () => {
       const function3 = buildFunctions.random;
       expect(function3.id).toBe(undefined);
       expect(function3.name).toBe('Generate random number');
-      expect(function3.outputs?.[0].id).toBe('value');
-      expect(function3.outputs?.[0].required).toBe(true);
+      expect(function3.outputCreators?.[0]('unknown-step').id).toBe('value');
+      expect(function3.outputCreators?.[0]('unknown-step').required).toBe(true);
       expect(function3.command).toBe('set-output value 6');
 
       // print:
@@ -292,8 +292,8 @@ describe(BuildConfigParser, () => {
       const function4 = buildFunctions.print;
       expect(function4.id).toBe(undefined);
       expect(function4.name).toBe(undefined);
-      expect(function4.inputs?.[0].id).toBe('value');
-      expect(function4.inputs?.[0].required).toBe(true);
+      expect(function4.inputCreators?.[0]('unknown-step').id).toBe('value');
+      expect(function4.inputCreators?.[0]('unknown-step').required).toBe(true);
       expect(function4.command).toBe('echo "${ inputs.value }"');
     });
   });

--- a/packages/steps/src/__tests__/BuildFunction-test.ts
+++ b/packages/steps/src/__tests__/BuildFunction-test.ts
@@ -1,12 +1,12 @@
 import { BuildFunction } from '../BuildFunction.js';
 import { BuildStep } from '../BuildStep.js';
-import { BuildStepInput } from '../BuildStepInput.js';
-import { BuildStepOutput } from '../BuildStepOutput.js';
+import { BuildStepInput, BuildStepInputCreator } from '../BuildStepInput.js';
+import { BuildStepOutput, BuildStepOutputCreator } from '../BuildStepOutput.js';
 
 import { createMockContext } from './utils/context.js';
 
 describe(BuildFunction, () => {
-  describe(BuildFunction.prototype.toBuildStep, () => {
+  describe(BuildFunction.prototype.createBuildStepFromFunctionCall, () => {
     it('returns a BuildStep object', () => {
       const ctx = createMockContext();
       const func = new BuildFunction(ctx, {
@@ -14,7 +14,7 @@ describe(BuildFunction, () => {
         name: 'Test function',
         command: 'echo 123',
       });
-      const step = func.toBuildStep({ workingDirectory: ctx.workingDirectory });
+      const step = func.createBuildStepFromFunctionCall({ workingDirectory: ctx.workingDirectory });
       expect(step).toBeInstanceOf(BuildStep);
       expect(step.id).toBe('test1');
       expect(step.name).toBe('Test function');
@@ -28,7 +28,7 @@ describe(BuildFunction, () => {
         command: 'echo 123',
         shell: '/bin/bash',
       });
-      const step = func.toBuildStep({
+      const step = func.createBuildStepFromFunctionCall({
         id: 'test2',
         shell: '/bin/zsh',
         workingDirectory: ctx.workingDirectory,
@@ -38,61 +38,53 @@ describe(BuildFunction, () => {
       expect(step.id).toBe('test2');
       expect(step.shell).toBe('/bin/zsh');
     });
-    it('clones function input and output parameters', () => {
+    it('creates function input and output parameters', () => {
       const ctx = createMockContext();
-      const funcInputs: BuildStepInput[] = [
-        new BuildStepInput(ctx, { id: 'input1' }),
-        new BuildStepInput(ctx, { id: 'input2' }),
+      const inputCreators: BuildStepInputCreator[] = [
+        (stepId: string) => new BuildStepInput(ctx, { id: 'input1', stepId }),
+        (stepId: string) => new BuildStepInput(ctx, { id: 'input2', stepId }),
       ];
-      const funcOutputs: BuildStepOutput[] = [
-        new BuildStepOutput(ctx, { id: 'output1' }),
-        new BuildStepOutput(ctx, { id: 'output2' }),
+      const outputCreators: BuildStepOutputCreator[] = [
+        (stepId: string) => new BuildStepOutput(ctx, { id: 'output1', stepId }),
+        (stepId: string) => new BuildStepOutput(ctx, { id: 'output2', stepId }),
       ];
       const func = new BuildFunction(ctx, {
         id: 'test1',
         name: 'Test function',
         command:
           'echo ${ inputs.input1 } ${ inputs.input2 }\nset-output output1 value1\nset-output output2 value2',
-        inputs: funcInputs,
-        outputs: funcOutputs,
+        inputCreators,
+        outputCreators,
       });
-      const step = func.toBuildStep({
+      const step = func.createBuildStepFromFunctionCall({
         callInputs: {
           input1: 'abc',
           input2: 'def',
         },
         workingDirectory: ctx.workingDirectory,
       });
-      expect(func.inputs?.[0]).toBe(funcInputs[0]);
-      expect(func.inputs?.[1]).toBe(funcInputs[1]);
-      expect(func.inputs?.[0].id).toBe('input1');
-      expect(func.inputs?.[1].id).toBe('input2');
-      expect(func.outputs?.[0]).toBe(funcOutputs[0]);
-      expect(func.outputs?.[1]).toBe(funcOutputs[1]);
-      expect(func.outputs?.[0].id).toBe('output1');
-      expect(func.outputs?.[1].id).toBe('output2');
-      expect(step.inputs?.[0]).not.toBe(funcInputs[0]);
-      expect(step.inputs?.[1]).not.toBe(funcInputs[1]);
+      expect(func.inputCreators?.[0]).toBe(inputCreators[0]);
+      expect(func.inputCreators?.[1]).toBe(inputCreators[1]);
+      expect(func.outputCreators?.[0]).toBe(outputCreators[0]);
+      expect(func.outputCreators?.[1]).toBe(outputCreators[1]);
       expect(step.inputs?.[0].id).toBe('input1');
       expect(step.inputs?.[1].id).toBe('input2');
-      expect(step.outputs?.[0]).not.toBe(funcOutputs[0]);
-      expect(step.outputs?.[1]).not.toBe(funcOutputs[1]);
       expect(step.outputs?.[0].id).toBe('output1');
       expect(step.outputs?.[1].id).toBe('output2');
     });
     it('passes values to build inputs', () => {
       const ctx = createMockContext();
-      const funcInputs: BuildStepInput[] = [
-        new BuildStepInput(ctx, { id: 'input1', defaultValue: 'xyz1' }),
-        new BuildStepInput(ctx, { id: 'input2', defaultValue: 'xyz2' }),
+      const inputCreators: BuildStepInputCreator[] = [
+        (stepId: string) => new BuildStepInput(ctx, { id: 'input1', defaultValue: 'xyz1', stepId }),
+        (stepId: string) => new BuildStepInput(ctx, { id: 'input2', defaultValue: 'xyz2', stepId }),
       ];
       const func = new BuildFunction(ctx, {
         id: 'test1',
         name: 'Test function',
         command: 'echo ${ inputs.input1 } ${ inputs.input2 }',
-        inputs: funcInputs,
+        inputCreators,
       });
-      const step = func.toBuildStep({
+      const step = func.createBuildStepFromFunctionCall({
         id: 'buildStep1',
         callInputs: {
           input1: 'abc',
@@ -100,8 +92,6 @@ describe(BuildFunction, () => {
         },
         workingDirectory: ctx.workingDirectory,
       });
-      expect(func.inputs?.[0].defaultValue).toBe('xyz1');
-      expect(func.inputs?.[1].defaultValue).toBe('xyz2');
       expect(step.inputs?.[0].value).toBe('abc');
       expect(step.inputs?.[1].value).toBe('def');
     });

--- a/packages/steps/src/__tests__/BuildFunction-test.ts
+++ b/packages/steps/src/__tests__/BuildFunction-test.ts
@@ -1,0 +1,109 @@
+import { BuildFunction } from '../BuildFunction.js';
+import { BuildStep } from '../BuildStep.js';
+import { BuildStepInput } from '../BuildStepInput.js';
+import { BuildStepOutput } from '../BuildStepOutput.js';
+
+import { createMockContext } from './utils/context.js';
+
+describe(BuildFunction, () => {
+  describe(BuildFunction.prototype.toBuildStep, () => {
+    it('returns a BuildStep object', () => {
+      const ctx = createMockContext();
+      const func = new BuildFunction(ctx, {
+        id: 'test1',
+        name: 'Test function',
+        command: 'echo 123',
+      });
+      const step = func.toBuildStep({ workingDirectory: ctx.workingDirectory });
+      expect(step).toBeInstanceOf(BuildStep);
+      expect(step.id).toBe('test1');
+      expect(step.name).toBe('Test function');
+      expect(step.command).toBe('echo 123');
+    });
+    it('can override id and shell from function definition', () => {
+      const ctx = createMockContext();
+      const func = new BuildFunction(ctx, {
+        id: 'test1',
+        name: 'Test function',
+        command: 'echo 123',
+        shell: '/bin/bash',
+      });
+      const step = func.toBuildStep({
+        id: 'test2',
+        shell: '/bin/zsh',
+        workingDirectory: ctx.workingDirectory,
+      });
+      expect(func.id).toBe('test1');
+      expect(func.shell).toBe('/bin/bash');
+      expect(step.id).toBe('test2');
+      expect(step.shell).toBe('/bin/zsh');
+    });
+    it('clones function input and output parameters', () => {
+      const ctx = createMockContext();
+      const funcInputs: BuildStepInput[] = [
+        new BuildStepInput(ctx, { id: 'input1' }),
+        new BuildStepInput(ctx, { id: 'input2' }),
+      ];
+      const funcOutputs: BuildStepOutput[] = [
+        new BuildStepOutput(ctx, { id: 'output1' }),
+        new BuildStepOutput(ctx, { id: 'output2' }),
+      ];
+      const func = new BuildFunction(ctx, {
+        id: 'test1',
+        name: 'Test function',
+        command:
+          'echo ${ inputs.input1 } ${ inputs.input2 }\nset-output output1 value1\nset-output output2 value2',
+        inputs: funcInputs,
+        outputs: funcOutputs,
+      });
+      const step = func.toBuildStep({
+        callInputs: {
+          input1: 'abc',
+          input2: 'def',
+        },
+        workingDirectory: ctx.workingDirectory,
+      });
+      expect(func.inputs?.[0]).toBe(funcInputs[0]);
+      expect(func.inputs?.[1]).toBe(funcInputs[1]);
+      expect(func.inputs?.[0].id).toBe('input1');
+      expect(func.inputs?.[1].id).toBe('input2');
+      expect(func.outputs?.[0]).toBe(funcOutputs[0]);
+      expect(func.outputs?.[1]).toBe(funcOutputs[1]);
+      expect(func.outputs?.[0].id).toBe('output1');
+      expect(func.outputs?.[1].id).toBe('output2');
+      expect(step.inputs?.[0]).not.toBe(funcInputs[0]);
+      expect(step.inputs?.[1]).not.toBe(funcInputs[1]);
+      expect(step.inputs?.[0].id).toBe('input1');
+      expect(step.inputs?.[1].id).toBe('input2');
+      expect(step.outputs?.[0]).not.toBe(funcOutputs[0]);
+      expect(step.outputs?.[1]).not.toBe(funcOutputs[1]);
+      expect(step.outputs?.[0].id).toBe('output1');
+      expect(step.outputs?.[1].id).toBe('output2');
+    });
+    it('passes values to build inputs', () => {
+      const ctx = createMockContext();
+      const funcInputs: BuildStepInput[] = [
+        new BuildStepInput(ctx, { id: 'input1', defaultValue: 'xyz1' }),
+        new BuildStepInput(ctx, { id: 'input2', defaultValue: 'xyz2' }),
+      ];
+      const func = new BuildFunction(ctx, {
+        id: 'test1',
+        name: 'Test function',
+        command: 'echo ${ inputs.input1 } ${ inputs.input2 }',
+        inputs: funcInputs,
+      });
+      const step = func.toBuildStep({
+        id: 'buildStep1',
+        callInputs: {
+          input1: 'abc',
+          input2: 'def',
+        },
+        workingDirectory: ctx.workingDirectory,
+      });
+      expect(func.inputs?.[0].defaultValue).toBe('xyz1');
+      expect(func.inputs?.[1].defaultValue).toBe('xyz2');
+      expect(step.inputs?.[0].value).toBe('abc');
+      expect(step.inputs?.[1].value).toBe('def');
+    });
+  });
+});

--- a/packages/steps/src/__tests__/BuildStepInput-test.ts
+++ b/packages/steps/src/__tests__/BuildStepInput-test.ts
@@ -14,6 +14,16 @@ describe(BuildStepInput, () => {
     expect(i.value).toBe('bar');
   });
 
+  test('stepId is optional (to use with reusable functions)', () => {
+    const ctx = createMockContext();
+    expect(() => {
+      // eslint-disable-next-line no-new
+      new BuildStepInput(ctx, {
+        id: 'foo',
+      });
+    }).not.toThrow();
+  });
+
   test('default value', () => {
     const ctx = createMockContext();
     const i = new BuildStepInput(ctx, {
@@ -45,5 +55,34 @@ describe(BuildStepInput, () => {
     }).toThrowError(
       new BuildStepRuntimeError('Input parameter "foo" for step "test1" is required.')
     );
+  });
+
+  test('.value and .set(value) throw if stepId is not provided', () => {
+    const ctx = createMockContext();
+    const i = new BuildStepInput(ctx, {
+      id: 'foo',
+    });
+    expect(() => {
+      // eslint-disable-next-line
+      i.value;
+    }).toThrowError(/\.value can't be used when not in step context/);
+    expect(() => {
+      i.set('123');
+    }).toThrowError(/\.set\('123'\) can't be used when not in step context/);
+  });
+
+  test('cloning', () => {
+    const ctx = createMockContext();
+    const input = new BuildStepInput(ctx, {
+      id: 'foo',
+      defaultValue: 'abc123',
+      required: false,
+    });
+    const clonedInput = input.clone('test1');
+    expect(clonedInput.id).toBe('foo');
+    expect(clonedInput.stepId).toBe('test1');
+    expect(clonedInput.defaultValue).toBe('abc123');
+    expect(clonedInput.required).toBe(false);
+    expect(clonedInput.value).toBe('abc123');
   });
 });

--- a/packages/steps/src/__tests__/BuildStepInput-test.ts
+++ b/packages/steps/src/__tests__/BuildStepInput-test.ts
@@ -14,16 +14,6 @@ describe(BuildStepInput, () => {
     expect(i.value).toBe('bar');
   });
 
-  test('stepId is optional (to use with reusable functions)', () => {
-    const ctx = createMockContext();
-    expect(() => {
-      // eslint-disable-next-line no-new
-      new BuildStepInput(ctx, {
-        id: 'foo',
-      });
-    }).not.toThrow();
-  });
-
   test('default value', () => {
     const ctx = createMockContext();
     const i = new BuildStepInput(ctx, {
@@ -55,34 +45,5 @@ describe(BuildStepInput, () => {
     }).toThrowError(
       new BuildStepRuntimeError('Input parameter "foo" for step "test1" is required.')
     );
-  });
-
-  test('.value and .set(value) throw if stepId is not provided', () => {
-    const ctx = createMockContext();
-    const i = new BuildStepInput(ctx, {
-      id: 'foo',
-    });
-    expect(() => {
-      // eslint-disable-next-line
-      i.value;
-    }).toThrowError(/\.value can't be used when not in step context/);
-    expect(() => {
-      i.set('123');
-    }).toThrowError(/\.set\('123'\) can't be used when not in step context/);
-  });
-
-  test('cloning', () => {
-    const ctx = createMockContext();
-    const input = new BuildStepInput(ctx, {
-      id: 'foo',
-      defaultValue: 'abc123',
-      required: false,
-    });
-    const clonedInput = input.clone('test1');
-    expect(clonedInput.id).toBe('foo');
-    expect(clonedInput.stepId).toBe('test1');
-    expect(clonedInput.defaultValue).toBe('abc123');
-    expect(clonedInput.required).toBe(false);
-    expect(clonedInput.value).toBe('abc123');
   });
 });

--- a/packages/steps/src/__tests__/BuildStepOutput-test.ts
+++ b/packages/steps/src/__tests__/BuildStepOutput-test.ts
@@ -14,16 +14,6 @@ describe(BuildStepOutput, () => {
     expect(o.value).toBe('bar');
   });
 
-  test('stepId is optional (to use with reusable functions)', () => {
-    const ctx = createMockContext();
-    expect(() => {
-      // eslint-disable-next-line no-new
-      new BuildStepOutput(ctx, {
-        id: 'foo',
-      });
-    }).not.toThrow();
-  });
-
   test('enforces required policy when reading value', () => {
     const ctx = createMockContext();
     const o = new BuildStepOutput(ctx, { id: 'foo', stepId: 'test1', required: true });
@@ -45,31 +35,5 @@ describe(BuildStepOutput, () => {
     }).toThrowError(
       new BuildStepRuntimeError('Output parameter "foo" for step "test1" is required.')
     );
-  });
-
-  test('.value and .set(value) throw if stepId is not provided', () => {
-    const ctx = createMockContext();
-    const i = new BuildStepOutput(ctx, {
-      id: 'foo',
-    });
-    expect(() => {
-      // eslint-disable-next-line
-      i.value;
-    }).toThrowError(/\.value can't be used when not in step context/);
-    expect(() => {
-      i.set('123');
-    }).toThrowError(/\.set\('123'\) can't be used when not in step context/);
-  });
-
-  test('cloning', () => {
-    const ctx = createMockContext();
-    const input = new BuildStepOutput(ctx, {
-      id: 'foo',
-      required: false,
-    });
-    const clonedInput = input.clone('test1');
-    expect(clonedInput.id).toBe('foo');
-    expect(clonedInput.stepId).toBe('test1');
-    expect(clonedInput.required).toBe(false);
   });
 });

--- a/packages/steps/src/__tests__/BuildStepOutput-test.ts
+++ b/packages/steps/src/__tests__/BuildStepOutput-test.ts
@@ -6,20 +6,30 @@ import { createMockContext } from './utils/context.js';
 describe(BuildStepOutput, () => {
   test('basic case', () => {
     const ctx = createMockContext();
-    const i = new BuildStepOutput(ctx, {
+    const o = new BuildStepOutput(ctx, {
       id: 'foo',
       stepId: 'test1',
     });
-    i.set('bar');
-    expect(i.value).toBe('bar');
+    o.set('bar');
+    expect(o.value).toBe('bar');
+  });
+
+  test('stepId is optional (to use with reusable functions)', () => {
+    const ctx = createMockContext();
+    expect(() => {
+      // eslint-disable-next-line no-new
+      new BuildStepOutput(ctx, {
+        id: 'foo',
+      });
+    }).not.toThrow();
   });
 
   test('enforces required policy when reading value', () => {
     const ctx = createMockContext();
-    const i = new BuildStepOutput(ctx, { id: 'foo', stepId: 'test1', required: true });
+    const o = new BuildStepOutput(ctx, { id: 'foo', stepId: 'test1', required: true });
     expect(() => {
       // eslint-disable-next-line
-      i.value;
+      o.value;
     }).toThrowError(
       new BuildStepRuntimeError(
         'Output parameter "foo" for step "test1" is required but it was not set.'
@@ -35,5 +45,31 @@ describe(BuildStepOutput, () => {
     }).toThrowError(
       new BuildStepRuntimeError('Output parameter "foo" for step "test1" is required.')
     );
+  });
+
+  test('.value and .set(value) throw if stepId is not provided', () => {
+    const ctx = createMockContext();
+    const i = new BuildStepOutput(ctx, {
+      id: 'foo',
+    });
+    expect(() => {
+      // eslint-disable-next-line
+      i.value;
+    }).toThrowError(/\.value can't be used when not in step context/);
+    expect(() => {
+      i.set('123');
+    }).toThrowError(/\.set\('123'\) can't be used when not in step context/);
+  });
+
+  test('cloning', () => {
+    const ctx = createMockContext();
+    const input = new BuildStepOutput(ctx, {
+      id: 'foo',
+      required: false,
+    });
+    const clonedInput = input.clone('test1');
+    expect(clonedInput.id).toBe('foo');
+    expect(clonedInput.stepId).toBe('test1');
+    expect(clonedInput.required).toBe(false);
   });
 });

--- a/packages/steps/src/__tests__/BuildWorkflow-test.ts
+++ b/packages/steps/src/__tests__/BuildWorkflow-test.ts
@@ -129,5 +129,15 @@ describe(BuildWorkflow, () => {
         ]);
       }
     });
+
+    it('returns empty object if no artifacts have been uploaded', async () => {
+      const ctx = createMockContext();
+
+      const workflow = new BuildWorkflow(ctx, { buildSteps: [] });
+      await workflow.executeAsync();
+
+      const artifacts = await workflow.collectArtifactsAsync();
+      expect(Object.keys(artifacts).length).toBe(0);
+    });
   });
 });

--- a/packages/steps/src/__tests__/BuildWorkflow-test.ts
+++ b/packages/steps/src/__tests__/BuildWorkflow-test.ts
@@ -25,7 +25,7 @@ describe(BuildWorkflow, () => {
       ];
 
       const ctx = createMockContext();
-      const workflow = new BuildWorkflow(ctx, { buildSteps });
+      const workflow = new BuildWorkflow(ctx, { buildSteps, buildFunctions: {} });
       await workflow.executeAsync();
 
       verify(mockBuildStep1.executeAsync(anything())).once();
@@ -46,7 +46,7 @@ describe(BuildWorkflow, () => {
       ];
 
       const ctx = createMockContext();
-      const workflow = new BuildWorkflow(ctx, { buildSteps });
+      const workflow = new BuildWorkflow(ctx, { buildSteps, buildFunctions: {} });
       await workflow.executeAsync();
 
       verify(mockBuildStep1.executeAsync(anything())).calledBefore(
@@ -72,7 +72,7 @@ describe(BuildWorkflow, () => {
       const mockEnv: BuildStepEnv = { ABC: '123' };
 
       const ctx = createMockContext();
-      const workflow = new BuildWorkflow(ctx, { buildSteps });
+      const workflow = new BuildWorkflow(ctx, { buildSteps, buildFunctions: {} });
       await workflow.executeAsync(mockEnv);
 
       verify(mockBuildStep1.executeAsync(mockEnv));
@@ -111,7 +111,7 @@ describe(BuildWorkflow, () => {
           }),
         ];
 
-        const workflow = new BuildWorkflow(ctx, { buildSteps });
+        const workflow = new BuildWorkflow(ctx, { buildSteps, buildFunctions: {} });
         await workflow.executeAsync();
 
         const artifacts = await workflow.collectArtifactsAsync();
@@ -133,7 +133,7 @@ describe(BuildWorkflow, () => {
     it('returns empty object if no artifacts have been uploaded', async () => {
       const ctx = createMockContext();
 
-      const workflow = new BuildWorkflow(ctx, { buildSteps: [] });
+      const workflow = new BuildWorkflow(ctx, { buildSteps: [], buildFunctions: {} });
       await workflow.executeAsync();
 
       const artifacts = await workflow.collectArtifactsAsync();

--- a/packages/steps/src/__tests__/BuildWorkflowValidator-test.ts
+++ b/packages/steps/src/__tests__/BuildWorkflowValidator-test.ts
@@ -42,6 +42,7 @@ describe(BuildWorkflowValidator, () => {
           workingDirectory: ctx.workingDirectory,
         }),
       ],
+      buildFunctions: {},
     });
 
     const validator = new BuildWorkflowValidator(workflow);
@@ -78,6 +79,7 @@ describe(BuildWorkflowValidator, () => {
           workingDirectory: ctx.workingDirectory,
         }),
       ],
+      buildFunctions: {},
     });
 
     const validator = new BuildWorkflowValidator(workflow);
@@ -110,6 +112,7 @@ describe(BuildWorkflowValidator, () => {
           workingDirectory: ctx.workingDirectory,
         }),
       ],
+      buildFunctions: {},
     });
 
     const validator = new BuildWorkflowValidator(workflow);
@@ -161,6 +164,7 @@ describe(BuildWorkflowValidator, () => {
           workingDirectory: ctx.workingDirectory,
         }),
       ],
+      buildFunctions: {},
     });
 
     const validator = new BuildWorkflowValidator(workflow);
@@ -212,6 +216,7 @@ describe(BuildWorkflowValidator, () => {
           workingDirectory: ctx.workingDirectory,
         }),
       ],
+      buildFunctions: {},
     });
 
     const validator = new BuildWorkflowValidator(workflow);

--- a/packages/steps/src/__tests__/fixtures/functions.yml
+++ b/packages/steps/src/__tests__/fixtures/functions.yml
@@ -1,0 +1,32 @@
+build:
+  name: Functions
+  steps:
+    - say_hi:
+        inputs:
+          name: Dominik
+    - say_hi:
+        inputs:
+          name: Szymon
+    - say_hi_wojtek
+    - random:
+        id: random_number
+    - print:
+        inputs:
+          value: ${ steps.random_number.value }
+
+functions:
+  say_hi:
+    name: Hi!
+    inputs:
+      - name
+    command: echo "Hi, ${ inputs.name }!"
+  say_hi_wojtek:
+    name: Hi, Wojtek!
+    command: echo "Hi, Wojtek!"
+  random:
+    name: Generate random number
+    outputs: [value]
+    command: set-output value 6
+  print:
+    inputs: [value]
+    command: echo "${ inputs.value }"


### PR DESCRIPTION
# Why

https://www.notion.so/expo/Customizable-builds-ba301def39b94e0ca7a2d813ba7ec36a?pvs=4

For custom builds, we want to enable users to define functions - special named steps that can be run multiple times from a workflow.
This can be used to share logic between different workflows, and in the future, we'll use them to reimplement all build phases from `@expo/build-tools`.

# How

- _[unrelated to the feature]_ https://github.com/expo/eas-build/pull/199/commits/539678143c26cec6128773955290bb35e6025324 changes the `watch` command to ignore changes in test files. The test files were not recompiled anyway.
- https://github.com/expo/eas-build/pull/199/commits/a026d151f02c6a2f86de11fba9ba94567fb0b0fe makes the `BuildWorkflow.collectArtifactsAsync` function return an empty object if no artifacts were uploaded from the workflow. Previously, it'd return an object with empty lists.
- https://github.com/expo/eas-build/pull/199/commits/6b4f8e1ecd7d1ff05b982867bd319a4bd0bef324 implements the reusable functions.
- https://github.com/expo/eas-build/pull/199/commits/a5c82feb48f94a9e4851207b64cc3039f29acdb6 adds usage example of reusable functions.

# Test Plan

Tests + new usage example (`functions`).

# TODO in next PRs

- Add `platforms` list to the function definitions. This will ensure that a function is run only on the supported operating systems (macOS/Linux).
- When defining input parameters for reusable functions, allow for specifying a default value.
- Add support for running JS code instead of a bash script in functions. This will make it possible to implement the artifacts upload feature without hacky logic. This is going to be useful for reimplementing `@expo/build-tools` with `@expo/steps`.
- Add the `require` feature to import functions from other files.