### PR TITLE
[steps] use ts-node in upload-artifact script when running tests

### DIFF
--- a/packages/steps/bin/upload-artifact
+++ b/packages/steps/bin/upload-artifact
@@ -9,4 +9,8 @@ fi
 
 STEPS_ROOT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )"/.. && pwd )"
 
-node $STEPS_ROOT_DIR/dist_commonjs/bin/uploadArtifact.cjs $@
+if [[ "$NODE_ENV" == "test" ]]; then
+  ts-node-esm $STEPS_ROOT_DIR/src/bin/uploadArtifact.ts $@
+else
+  node $STEPS_ROOT_DIR/dist_commonjs/bin/uploadArtifact.cjs $@
+fi

--- a/packages/steps/package.json
+++ b/packages/steps/package.json
@@ -39,6 +39,7 @@
     "jest": "^29.4.1",
     "ts-jest": "^29.0.5",
     "ts-mockito": "^2.6.1",
+    "ts-node": "^10.9.1",
     "typescript": "^4.9.5"
   },
   "engines": {

--- a/packages/steps/src/__tests__/BuildWorkflow-test.ts
+++ b/packages/steps/src/__tests__/BuildWorkflow-test.ts
@@ -81,58 +81,63 @@ describe(BuildWorkflow, () => {
     });
   });
   describe(BuildWorkflow.prototype.collectArtifactsAsync, () => {
-    it('returns build artifacts', async () => {
-      const ctx = createMockContext();
-      const originalFilesDirectoryPath = path.join(os.tmpdir(), 'eas-steps-test-fixtures');
-      const originalApplicationArchivePath = path.join(originalFilesDirectoryPath, 'app.ipa');
-      const originalBuildArtifactPath1 = path.join(originalFilesDirectoryPath, 'screenshot1.png');
-      const originalBuildArtifactPath2 = path.join(originalFilesDirectoryPath, 'screenshot2.png');
+    it(
+      'returns build artifacts',
+      async () => {
+        const ctx = createMockContext();
+        const originalFilesDirectoryPath = path.join(os.tmpdir(), 'eas-steps-test-fixtures');
+        const originalApplicationArchivePath = path.join(originalFilesDirectoryPath, 'app.ipa');
+        const originalBuildArtifactPath1 = path.join(originalFilesDirectoryPath, 'screenshot1.png');
+        const originalBuildArtifactPath2 = path.join(originalFilesDirectoryPath, 'screenshot2.png');
 
-      try {
-        await Promise.all([
-          fs.mkdir(ctx.workingDirectory, { recursive: true }),
-          fs.mkdir(originalFilesDirectoryPath, { recursive: true }),
-        ]);
-        await Promise.all([
-          fs.writeFile(originalApplicationArchivePath, 'abc123'),
-          fs.writeFile(originalBuildArtifactPath1, 'def456'),
-          fs.writeFile(originalBuildArtifactPath2, 'ghi789'),
-        ]);
+        try {
+          await Promise.all([
+            fs.mkdir(ctx.workingDirectory, { recursive: true }),
+            fs.mkdir(originalFilesDirectoryPath, { recursive: true }),
+          ]);
+          await Promise.all([
+            fs.writeFile(originalApplicationArchivePath, 'abc123'),
+            fs.writeFile(originalBuildArtifactPath1, 'def456'),
+            fs.writeFile(originalBuildArtifactPath2, 'ghi789'),
+          ]);
 
-        const buildSteps: BuildStep[] = [
-          new BuildStep(ctx, {
-            id: 'test1',
-            command: `upload-artifact --type application-archive ${originalApplicationArchivePath}`,
-            workingDirectory: ctx.workingDirectory,
-          }),
-          new BuildStep(ctx, {
-            id: 'test2',
-            command: `upload-artifact --type build-artifact ${originalBuildArtifactPath1}`,
-            workingDirectory: ctx.workingDirectory,
-          }),
-          new BuildStep(ctx, {
-            id: 'test3',
-            command: `upload-artifact --type build-artifact ${originalBuildArtifactPath2}`,
-            workingDirectory: ctx.workingDirectory,
-          }),
-        ];
+          const buildSteps: BuildStep[] = [
+            new BuildStep(ctx, {
+              id: 'test1',
+              command: `upload-artifact --type application-archive ${originalApplicationArchivePath}`,
+              workingDirectory: ctx.workingDirectory,
+            }),
+            new BuildStep(ctx, {
+              id: 'test2',
+              command: `upload-artifact --type build-artifact ${originalBuildArtifactPath1}`,
+              workingDirectory: ctx.workingDirectory,
+            }),
+            new BuildStep(ctx, {
+              id: 'test3',
+              command: `upload-artifact --type build-artifact ${originalBuildArtifactPath2}`,
+              workingDirectory: ctx.workingDirectory,
+            }),
+          ];
 
-        const workflow = new BuildWorkflow(ctx, { buildSteps, buildFunctions: {} });
-        await workflow.executeAsync();
+          const workflow = new BuildWorkflow(ctx, { buildSteps, buildFunctions: {} });
+          await workflow.executeAsync();
 
-        const artifacts = await workflow.collectArtifactsAsync();
-        expect(artifacts['application-archive']?.length).toBe(1);
-        expect(artifacts['build-artifact']?.length).toBe(2);
-        expect(artifacts['application-archive']?.[0].endsWith('app.ipa')).toBeTruthy();
-        expect(artifacts['build-artifact']?.[0].endsWith('screenshot1.png')).toBeTruthy();
-        expect(artifacts['build-artifact']?.[1].endsWith('screenshot2.png')).toBeTruthy();
-      } finally {
-        await Promise.all([
-          fs.rm(ctx.baseWorkingDirectory, { recursive: true, force: true }),
-          fs.rm(originalFilesDirectoryPath, { recursive: true, force: true }),
-        ]);
-      }
-    });
+          const artifacts = await workflow.collectArtifactsAsync();
+          expect(artifacts['application-archive']?.length).toBe(1);
+          expect(artifacts['build-artifact']?.length).toBe(2);
+          expect(artifacts['application-archive']?.[0].endsWith('app.ipa')).toBeTruthy();
+          expect(artifacts['build-artifact']?.[0].endsWith('screenshot1.png')).toBeTruthy();
+          expect(artifacts['build-artifact']?.[1].endsWith('screenshot2.png')).toBeTruthy();
+        } finally {
+          await Promise.all([
+            fs.rm(ctx.baseWorkingDirectory, { recursive: true, force: true }),
+            fs.rm(originalFilesDirectoryPath, { recursive: true, force: true }),
+          ]);
+        }
+      },
+      // use longer timeout because this test spawns ts-node
+      20 * 1000
+    );
 
     it('returns empty object if no artifacts have been uploaded', async () => {
       const ctx = createMockContext();

--- a/packages/steps/src/__tests__/BuildWorkflow-test.ts
+++ b/packages/steps/src/__tests__/BuildWorkflow-test.ts
@@ -83,15 +83,21 @@ describe(BuildWorkflow, () => {
   describe(BuildWorkflow.prototype.collectArtifactsAsync, () => {
     it('returns build artifacts', async () => {
       const ctx = createMockContext();
-      const originalApplicationArchivePath = path.join(os.tmpdir(), 'app.ipa');
-      const originalBuildArtifactPath1 = path.join(os.tmpdir(), 'screenshot1.png');
-      const originalBuildArtifactPath2 = path.join(os.tmpdir(), 'screenshot2.png');
+      const originalFilesDirectoryPath = path.join(os.tmpdir(), 'eas-steps-test-fixtures');
+      const originalApplicationArchivePath = path.join(originalFilesDirectoryPath, 'app.ipa');
+      const originalBuildArtifactPath1 = path.join(originalFilesDirectoryPath, 'screenshot1.png');
+      const originalBuildArtifactPath2 = path.join(originalFilesDirectoryPath, 'screenshot2.png');
 
       try {
-        await fs.mkdir(ctx.workingDirectory, { recursive: true });
-        await fs.writeFile(originalApplicationArchivePath, 'abc123');
-        await fs.writeFile(originalBuildArtifactPath1, 'def456');
-        await fs.writeFile(originalBuildArtifactPath2, 'ghi789');
+        await Promise.all([
+          fs.mkdir(ctx.workingDirectory, { recursive: true }),
+          fs.mkdir(originalFilesDirectoryPath, { recursive: true }),
+        ]);
+        await Promise.all([
+          fs.writeFile(originalApplicationArchivePath, 'abc123'),
+          fs.writeFile(originalBuildArtifactPath1, 'def456'),
+          fs.writeFile(originalBuildArtifactPath2, 'ghi789'),
+        ]);
 
         const buildSteps: BuildStep[] = [
           new BuildStep(ctx, {
@@ -122,10 +128,8 @@ describe(BuildWorkflow, () => {
         expect(artifacts['build-artifact']?.[1].endsWith('screenshot2.png')).toBeTruthy();
       } finally {
         await Promise.all([
-          fs.rm(ctx.baseWorkingDirectory, { recursive: true }),
-          fs.rm(originalApplicationArchivePath),
-          fs.rm(originalBuildArtifactPath1),
-          fs.rm(originalBuildArtifactPath2),
+          fs.rm(ctx.baseWorkingDirectory, { recursive: true, force: true }),
+          fs.rm(originalFilesDirectoryPath, { recursive: true, force: true }),
         ]);
       }
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -546,6 +546,13 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
+"@cspotcode/source-map-support@^0.8.0":
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz#00629c35a688e05a88b1cda684fb9d5e73f000a1"
+  integrity sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==
+  dependencies:
+    "@jridgewell/trace-mapping" "0.3.9"
+
 "@eslint/eslintrc@^1.4.1":
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-1.4.1.tgz#af58772019a2d271b7e2d4c23ff4ddcba3ccfb3e"
@@ -992,6 +999,14 @@
   version "1.4.11"
   resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.11.tgz#771a1d8d744eeb71b6adb35808e1a6c7b9b8c8ec"
   integrity sha512-Fg32GrJo61m+VqYSdRSjRXMjQ06j8YIYfcTqndLYVAaHmroZHLJZCydsWBOTDqXS2v+mjxohBWEMfg97GXmYQg==
+
+"@jridgewell/trace-mapping@0.3.9":
+  version "0.3.9"
+  resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz#6534fd5933a53ba7cbf3a17615e273a0d1273ff9"
+  integrity sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==
+  dependencies:
+    "@jridgewell/resolve-uri" "^3.0.3"
+    "@jridgewell/sourcemap-codec" "^1.4.10"
 
 "@jridgewell/trace-mapping@^0.3.0":
   version "0.3.4"
@@ -2074,6 +2089,26 @@
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-2.0.0.tgz#f544a148d3ab35801c1f633a7441fd87c2e484bf"
   integrity sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==
 
+"@tsconfig/node10@^1.0.7":
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node10/-/node10-1.0.9.tgz#df4907fc07a886922637b15e02d4cebc4c0021b2"
+  integrity sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==
+
+"@tsconfig/node12@^1.0.7":
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node12/-/node12-1.0.11.tgz#ee3def1f27d9ed66dac6e46a295cffb0152e058d"
+  integrity sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==
+
+"@tsconfig/node14@^1.0.0":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node14/-/node14-1.0.3.tgz#e4386316284f00b98435bf40f72f75a09dabf6c1"
+  integrity sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==
+
+"@tsconfig/node16@^1.0.2":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node16/-/node16-1.0.3.tgz#472eaab5f15c1ffdd7f8628bd4c4f753995ec79e"
+  integrity sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==
+
 "@types/babel__core@^7.1.14":
   version "7.1.18"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.18.tgz#1a29abcc411a9c05e2094c98f9a1b7da6cdf49f8"
@@ -2486,7 +2521,12 @@ acorn-jsx@^5.3.2:
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz#7ed5bb55908b3b2f1bc55c6af1653bada7f07937"
   integrity sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==
 
-acorn@^8.8.0:
+acorn-walk@^8.1.1:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.2.0.tgz#741210f2e2426454508853a2f44d0ab83b7f69c1"
+  integrity sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==
+
+acorn@^8.4.1, acorn@^8.8.0:
   version "8.8.2"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.8.2.tgz#1b2f25db02af965399b9776b0c2c391276d37c4a"
   integrity sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==
@@ -2609,6 +2649,11 @@ are-we-there-yet@^3.0.0:
   dependencies:
     delegates "^1.0.0"
     readable-stream "^3.6.0"
+
+arg@^4.1.0:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/arg/-/arg-4.1.3.tgz#269fc7ad5b8e42cb63c896d5666017261c144089"
+  integrity sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==
 
 arg@^5.0.2:
   version "5.0.2"
@@ -3412,6 +3457,11 @@ cosmiconfig@^7.0.0:
     path-type "^4.0.0"
     yaml "^1.10.0"
 
+create-require@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
+  integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
+
 cross-spawn@^6.0.5:
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
@@ -3596,6 +3646,11 @@ diff-sequences@^29.3.1:
   version "29.3.1"
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-29.3.1.tgz#104b5b95fe725932421a9c6e5b4bef84c3f2249e"
   integrity sha512-hlM3QR272NXCi4pq+N4Kok4kOp6EsgOM3ZSpJI7Da3UAs+Ttsi8MRmB6trM/lhyzUxGfOgnpkHtgqm5Q/CTcfQ==
+
+diff@^4.0.1:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
+  integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
 
 dir-glob@^3.0.1:
   version "3.0.1"
@@ -6101,7 +6156,7 @@ make-dir@^3.0.0:
   dependencies:
     semver "^6.0.0"
 
-make-error@1.x:
+make-error@1.x, make-error@^1.1.1:
   version "1.3.6"
   resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.6.tgz#2eb2e37ea9b67c4891f684a1394799af484cf7a2"
   integrity sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
@@ -8247,6 +8302,25 @@ ts-mockito@^2.6.1:
   dependencies:
     lodash "^4.17.5"
 
+ts-node@^10.9.1:
+  version "10.9.1"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-10.9.1.tgz#e73de9102958af9e1f0b168a6ff320e25adcff4b"
+  integrity sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==
+  dependencies:
+    "@cspotcode/source-map-support" "^0.8.0"
+    "@tsconfig/node10" "^1.0.7"
+    "@tsconfig/node12" "^1.0.7"
+    "@tsconfig/node14" "^1.0.0"
+    "@tsconfig/node16" "^1.0.2"
+    acorn "^8.4.1"
+    acorn-walk "^8.1.1"
+    arg "^4.1.0"
+    create-require "^1.1.0"
+    diff "^4.0.1"
+    make-error "^1.1.1"
+    v8-compile-cache-lib "^3.0.1"
+    yn "3.1.1"
+
 tsconfig-paths@^3.14.1:
   version "3.14.1"
   resolved "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-3.14.1.tgz#ba0734599e8ea36c862798e920bcf163277b137a"
@@ -8444,6 +8518,11 @@ uuid@^9.0.0:
   version "9.0.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.0.tgz#592f550650024a38ceb0c562f2f6aa435761efb5"
   integrity sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==
+
+v8-compile-cache-lib@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz#6336e8d71965cb3d35a1bbb7868445a7c05264bf"
+  integrity sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==
 
 v8-compile-cache@2.3.0:
   version "2.3.0"
@@ -8808,6 +8887,11 @@ yargs@^17.3.1, yargs@^17.6.2:
     string-width "^4.2.3"
     y18n "^5.0.5"
     yargs-parser "^21.1.1"
+
+yn@3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"
+  integrity sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==
 
 yocto-queue@^0.1.0:
   version "0.1.0"


### PR DESCRIPTION
# Why

When working on the steps library, I noticed that the "returns build artifacts" test from BuildWorkflow-test.ts fails intermittently. I debugged the problem and the problem was I had `yarn watch` and `yarn test:watch` running at the same time. The `upload-artifact` script runs `dist_commonjs/bin/uploadArtifact.cjs` which state is not deterministic because of the `yarn watch` script.

# How

Conditionally use `ts-node` for running `src/bin/uploadArtifact.ts`.

# Test Plan

I removed `dist_commonjs` and ran tests, they work fine.