### PR TITLE
[ENG-7739][steps] add support for running js code in functions

### DIFF
--- a/packages/steps/src/BuildConfig.ts
+++ b/packages/steps/src/BuildConfig.ts
@@ -43,7 +43,6 @@ export type BuildStepInputs = Record<string, string>;
 export type BuildStepOutputs = BuildInputOutputParameters;
 
 export interface BuildFunctionConfig {
-  id?: string;
   inputs?: BuildFunctionInputs;
   outputs?: BuildFunctionOutputs;
   name?: string;
@@ -112,8 +111,7 @@ const BuildStepConfigSchema = Joi.any<BuildStepConfig>()
     then: Joi.string().min(1),
   });
 
-const BuildFunctionSchema = Joi.object({
-  id: Joi.string(),
+const BuildFunctionConfigSchema = Joi.object({
   name: Joi.string(),
   platforms: Joi.string().allow(...Object.values(BuildPlatform)),
   inputs: BuildInputOutputParametersSchema,
@@ -129,7 +127,7 @@ export const BuildConfigSchema = Joi.object<BuildConfig>({
   }).required(),
   functions: Joi.object().pattern(
     Joi.string().min(1).required().disallow('run'),
-    BuildFunctionSchema.required()
+    BuildFunctionConfigSchema.required()
   ),
 }).required();
 

--- a/packages/steps/src/BuildConfig.ts
+++ b/packages/steps/src/BuildConfig.ts
@@ -126,7 +126,11 @@ export const BuildConfigSchema = Joi.object<BuildConfig>({
     steps: Joi.array().items(BuildStepConfigSchema.required()).required(),
   }).required(),
   functions: Joi.object().pattern(
-    Joi.string().min(1).required().disallow('run'),
+    Joi.string()
+      .pattern(/^[\w-]+$/, 'function names')
+      .min(1)
+      .required()
+      .disallow('run'),
     BuildFunctionConfigSchema.required()
   ),
 }).required();

--- a/packages/steps/src/BuildConfig.ts
+++ b/packages/steps/src/BuildConfig.ts
@@ -173,7 +173,7 @@ function validateAllFunctionsExist(config: BuildConfig): void {
       const keys = Object.keys(step);
       assert(
         keys.length === 1,
-        'There must be at most one function call in the step (enforced by joi)'
+        'There must be at most one function call in the step (enforced by joi).'
       );
       calledFunctionsSet.add(keys[0]);
     }

--- a/packages/steps/src/BuildConfigParser.ts
+++ b/packages/steps/src/BuildConfigParser.ts
@@ -89,7 +89,7 @@ export class BuildConfigParser {
     } else if (isBuildStepBareFunctionCall(buildStepConfig)) {
       const functionId = buildStepConfig;
       const buildFunction = buildFunctions[functionId];
-      return buildFunction.createBuildStepFromFunctionCall({
+      return buildFunction.createBuildStepFromFunctionCall(this.ctx, {
         workingDirectory: this.getStepWorkingDirectory(),
       });
     } else {
@@ -101,7 +101,7 @@ export class BuildConfigParser {
       const functionId = keys[0];
       const buildFunctionCallConfig = buildStepConfig[functionId];
       const buildFunction = buildFunctions[functionId];
-      return buildFunction.createBuildStepFromFunctionCall({
+      return buildFunction.createBuildStepFromFunctionCall(this.ctx, {
         id: buildFunctionCallConfig.id,
         callInputs: buildFunctionCallConfig.inputs,
         workingDirectory: this.getStepWorkingDirectory(buildFunctionCallConfig.workingDirectory),
@@ -135,7 +135,7 @@ export class BuildConfigParser {
       inputsConfig && this.createBuildStepInputCreatorsFromBuildFunctionInputs(inputsConfig);
     const outputCreators =
       outputsConfig && this.createBuildStepOutputCreatorsFromBuildFunctionOutputs(outputsConfig);
-    return new BuildFunction(this.ctx, { id, name, inputCreators, outputCreators, shell, command });
+    return new BuildFunction({ id, name, inputCreators, outputCreators, shell, command });
   }
 
   private createBuildStepInputsFromBuildStepInputsDefinition(

--- a/packages/steps/src/BuildConfigParser.ts
+++ b/packages/steps/src/BuildConfigParser.ts
@@ -118,10 +118,11 @@ export class BuildConfigParser {
     }
     const result: BuildFunctionById = {};
     for (const [functionId, buildFunctionConfig] of Object.entries(buildFunctionsConfig)) {
-      result[functionId] = this.createBuildFunctionFromConfig({
+      const buildFunction = this.createBuildFunctionFromConfig({
         id: functionId,
         ...buildFunctionConfig,
       });
+      result[buildFunction.getFullId()] = buildFunction;
     }
     return result;
   }

--- a/packages/steps/src/BuildConfigParser.ts
+++ b/packages/steps/src/BuildConfigParser.ts
@@ -118,7 +118,10 @@ export class BuildConfigParser {
     }
     const result: BuildFunctionById = {};
     for (const [functionId, buildFunctionConfig] of Object.entries(buildFunctionsConfig)) {
-      result[functionId] = this.createBuildFunctionFromConfig(buildFunctionConfig);
+      result[functionId] = this.createBuildFunctionFromConfig({
+        id: functionId,
+        ...buildFunctionConfig,
+      });
     }
     return result;
   }
@@ -130,7 +133,7 @@ export class BuildConfigParser {
     outputs: outputsConfig,
     shell,
     command,
-  }: BuildFunctionConfig): BuildFunction {
+  }: BuildFunctionConfig & { id: string }): BuildFunction {
     const inputProviders =
       inputsConfig && this.createBuildStepInputProvidersFromBuildFunctionInputs(inputsConfig);
     const outputProviders =

--- a/packages/steps/src/BuildConfigParser.ts
+++ b/packages/steps/src/BuildConfigParser.ts
@@ -21,8 +21,8 @@ import {
 import { BuildFunction, BuildFunctionById } from './BuildFunction.js';
 import { BuildStep } from './BuildStep.js';
 import { BuildStepContext } from './BuildStepContext.js';
-import { BuildStepInput, BuildStepInputCreator } from './BuildStepInput.js';
-import { BuildStepOutput, BuildStepOutputCreator } from './BuildStepOutput.js';
+import { BuildStepInput, BuildStepInputProvider } from './BuildStepInput.js';
+import { BuildStepOutput, BuildStepOutputProvider } from './BuildStepOutput.js';
 import { BuildWorkflow } from './BuildWorkflow.js';
 import { BuildWorkflowValidator } from './BuildWorkflowValidator.js';
 
@@ -131,11 +131,11 @@ export class BuildConfigParser {
     shell,
     command,
   }: BuildFunctionConfig): BuildFunction {
-    const inputCreators =
-      inputsConfig && this.createBuildStepInputCreatorsFromBuildFunctionInputs(inputsConfig);
-    const outputCreators =
-      outputsConfig && this.createBuildStepOutputCreatorsFromBuildFunctionOutputs(outputsConfig);
-    return new BuildFunction({ id, name, inputCreators, outputCreators, shell, command });
+    const inputProviders =
+      inputsConfig && this.createBuildStepInputProvidersFromBuildFunctionInputs(inputsConfig);
+    const outputProviders =
+      outputsConfig && this.createBuildStepOutputProvidersFromBuildFunctionOutputs(outputsConfig);
+    return new BuildFunction({ id, name, inputProviders, outputProviders, shell, command });
   }
 
   private createBuildStepInputsFromBuildStepInputsDefinition(
@@ -153,9 +153,9 @@ export class BuildConfigParser {
     );
   }
 
-  private createBuildStepInputCreatorsFromBuildFunctionInputs(
+  private createBuildStepInputProvidersFromBuildFunctionInputs(
     buildFunctionInputs: BuildFunctionInputs
-  ): BuildStepInputCreator[] {
+  ): BuildStepInputProvider[] {
     return buildFunctionInputs.map((entry) => {
       if (typeof entry === 'string') {
         return (stepId: string) => new BuildStepInput(this.ctx, { id: entry, stepId });
@@ -185,9 +185,9 @@ export class BuildConfigParser {
     );
   }
 
-  private createBuildStepOutputCreatorsFromBuildFunctionOutputs(
+  private createBuildStepOutputProvidersFromBuildFunctionOutputs(
     buildFunctionOutputs: BuildFunctionOutputs
-  ): BuildStepOutputCreator[] {
+  ): BuildStepOutputProvider[] {
     return buildFunctionOutputs.map((entry) =>
       typeof entry === 'string'
         ? (stepId: string) => new BuildStepOutput(this.ctx, { id: entry, stepId, required: true })

--- a/packages/steps/src/BuildConfigParser.ts
+++ b/packages/steps/src/BuildConfigParser.ts
@@ -157,16 +157,9 @@ export class BuildConfigParser {
     buildFunctionInputs: BuildFunctionInputs
   ): BuildStepInputProvider[] {
     return buildFunctionInputs.map((entry) => {
-      if (typeof entry === 'string') {
-        return (stepId: string) => new BuildStepInput(this.ctx, { id: entry, stepId });
-      } else {
-        return (stepId: string) =>
-          new BuildStepInput(this.ctx, {
-            id: entry.name,
-            required: entry.required ?? true,
-            stepId,
-          });
-      }
+      return typeof entry === 'string'
+        ? BuildStepInput.createProvider({ id: entry })
+        : BuildStepInput.createProvider({ id: entry.name, required: entry.required ?? true });
     });
   }
 
@@ -190,13 +183,8 @@ export class BuildConfigParser {
   ): BuildStepOutputProvider[] {
     return buildFunctionOutputs.map((entry) =>
       typeof entry === 'string'
-        ? (stepId: string) => new BuildStepOutput(this.ctx, { id: entry, stepId, required: true })
-        : (stepId: string) =>
-            new BuildStepOutput(this.ctx, {
-              id: entry.name,
-              stepId,
-              required: entry.required ?? true,
-            })
+        ? BuildStepOutput.createProvider({ id: entry, required: true })
+        : BuildStepOutput.createProvider({ id: entry.name, required: entry.required ?? true })
     );
   }
 

--- a/packages/steps/src/BuildConfigParser.ts
+++ b/packages/steps/src/BuildConfigParser.ts
@@ -96,7 +96,7 @@ export class BuildConfigParser {
       const keys = Object.keys(buildStepConfig);
       assert(
         keys.length === 1,
-        'There must be at most one function call in the step (enforced by joi)'
+        'There must be at most one function call in the step (enforced by joi).'
       );
       const functionId = keys[0];
       const buildFunctionCallConfig = buildStepConfig[functionId];

--- a/packages/steps/src/BuildFunction.ts
+++ b/packages/steps/src/BuildFunction.ts
@@ -18,26 +18,23 @@ export class BuildFunction {
   public readonly command: string;
   public readonly shell?: string;
 
-  constructor(
-    private readonly ctx: BuildStepContext,
-    {
-      id,
-      name,
-      platforms,
-      inputCreators,
-      outputCreators,
-      command,
-      shell,
-    }: {
-      id?: string;
-      name?: string;
-      platforms?: BuildPlatform[];
-      inputCreators?: BuildStepInputCreator[];
-      outputCreators?: BuildStepOutputCreator[];
-      command: string;
-      shell?: string;
-    }
-  ) {
+  constructor({
+    id,
+    name,
+    platforms,
+    inputCreators,
+    outputCreators,
+    command,
+    shell,
+  }: {
+    id?: string;
+    name?: string;
+    platforms?: BuildPlatform[];
+    inputCreators?: BuildStepInputCreator[];
+    outputCreators?: BuildStepOutputCreator[];
+    command: string;
+    shell?: string;
+  }) {
     this.id = id;
     this.name = name;
     this.platforms = platforms;
@@ -47,17 +44,20 @@ export class BuildFunction {
     this.shell = shell;
   }
 
-  public createBuildStepFromFunctionCall({
-    id,
-    callInputs = {},
-    workingDirectory,
-    shell,
-  }: {
-    id?: string;
-    callInputs?: BuildFunctionCallInputs;
-    workingDirectory: string;
-    shell?: string;
-  }): BuildStep {
+  public createBuildStepFromFunctionCall(
+    ctx: BuildStepContext,
+    {
+      id,
+      callInputs = {},
+      workingDirectory,
+      shell,
+    }: {
+      id?: string;
+      callInputs?: BuildFunctionCallInputs;
+      workingDirectory: string;
+      shell?: string;
+    }
+  ): BuildStep {
     const buildStepId = id ?? this.id ?? uuidv4();
 
     const inputs = this.inputCreators?.map((inputCreator) => {
@@ -69,7 +69,7 @@ export class BuildFunction {
     });
     const outputs = this.outputCreators?.map((outputCreator) => outputCreator(buildStepId));
 
-    return new BuildStep(this.ctx, {
+    return new BuildStep(ctx, {
       id: buildStepId,
       name: this.name,
       command: this.command,

--- a/packages/steps/src/BuildFunction.ts
+++ b/packages/steps/src/BuildFunction.ts
@@ -61,13 +61,13 @@ export class BuildFunction {
     const buildStepId = id ?? this.id ?? uuidv4();
 
     const inputs = this.inputProviders?.map((inputProvider) => {
-      const input = inputProvider(buildStepId);
+      const input = inputProvider(ctx, buildStepId);
       if (input.id in callInputs) {
         input.set(callInputs[input.id]);
       }
       return input;
     });
-    const outputs = this.outputProviders?.map((outputProvider) => outputProvider(buildStepId));
+    const outputs = this.outputProviders?.map((outputProvider) => outputProvider(ctx, buildStepId));
 
     return new BuildStep(ctx, {
       id: buildStepId,

--- a/packages/steps/src/BuildFunction.ts
+++ b/packages/steps/src/BuildFunction.ts
@@ -1,7 +1,9 @@
+import assert from 'assert';
+
 import { v4 as uuidv4 } from 'uuid';
 
 import { BuildPlatform } from './BuildPlatform.js';
-import { BuildStep } from './BuildStep.js';
+import { BuildStep, BuildStepFunction } from './BuildStep.js';
 import { BuildStepContext } from './BuildStepContext.js';
 import { BuildStepInputProvider } from './BuildStepInput.js';
 import { BuildStepOutputProvider } from './BuildStepOutput.js';
@@ -15,7 +17,8 @@ export class BuildFunction {
   public readonly platforms?: BuildPlatform[];
   public readonly inputProviders?: BuildStepInputProvider[];
   public readonly outputProviders?: BuildStepOutputProvider[];
-  public readonly command: string;
+  public readonly command?: string;
+  public readonly fn?: BuildStepFunction;
   public readonly shell?: string;
 
   constructor({
@@ -25,6 +28,7 @@ export class BuildFunction {
     inputProviders,
     outputProviders,
     command,
+    fn,
     shell,
   }: {
     id?: string;
@@ -32,15 +36,20 @@ export class BuildFunction {
     platforms?: BuildPlatform[];
     inputProviders?: BuildStepInputProvider[];
     outputProviders?: BuildStepOutputProvider[];
-    command: string;
+    command?: string;
+    fn?: BuildStepFunction;
     shell?: string;
   }) {
+    assert(command !== undefined || fn !== undefined, 'Either command or fn must be defined.');
+    assert(!(command !== undefined && fn !== undefined), 'Command and fn cannot be both set.');
+
     this.id = id;
     this.name = name;
     this.platforms = platforms;
     this.inputProviders = inputProviders;
     this.outputProviders = outputProviders;
     this.command = command;
+    this.fn = fn;
     this.shell = shell;
   }
 
@@ -73,6 +82,7 @@ export class BuildFunction {
       id: buildStepId,
       name: this.name,
       command: this.command,
+      fn: this.fn,
       workingDirectory,
       inputs,
       outputs,

--- a/packages/steps/src/BuildFunction.ts
+++ b/packages/steps/src/BuildFunction.ts
@@ -3,8 +3,8 @@ import { v4 as uuidv4 } from 'uuid';
 import { BuildPlatform } from './BuildPlatform.js';
 import { BuildStep } from './BuildStep.js';
 import { BuildStepContext } from './BuildStepContext.js';
-import { BuildStepInputCreator } from './BuildStepInput.js';
-import { BuildStepOutputCreator } from './BuildStepOutput.js';
+import { BuildStepInputProvider } from './BuildStepInput.js';
+import { BuildStepOutputProvider } from './BuildStepOutput.js';
 
 export type BuildFunctionById = Record<string, BuildFunction>;
 export type BuildFunctionCallInputs = Record<string, string>;
@@ -13,8 +13,8 @@ export class BuildFunction {
   public readonly id?: string;
   public readonly name?: string;
   public readonly platforms?: BuildPlatform[];
-  public readonly inputCreators?: BuildStepInputCreator[];
-  public readonly outputCreators?: BuildStepOutputCreator[];
+  public readonly inputProviders?: BuildStepInputProvider[];
+  public readonly outputProviders?: BuildStepOutputProvider[];
   public readonly command: string;
   public readonly shell?: string;
 
@@ -22,24 +22,24 @@ export class BuildFunction {
     id,
     name,
     platforms,
-    inputCreators,
-    outputCreators,
+    inputProviders,
+    outputProviders,
     command,
     shell,
   }: {
     id?: string;
     name?: string;
     platforms?: BuildPlatform[];
-    inputCreators?: BuildStepInputCreator[];
-    outputCreators?: BuildStepOutputCreator[];
+    inputProviders?: BuildStepInputProvider[];
+    outputProviders?: BuildStepOutputProvider[];
     command: string;
     shell?: string;
   }) {
     this.id = id;
     this.name = name;
     this.platforms = platforms;
-    this.inputCreators = inputCreators;
-    this.outputCreators = outputCreators;
+    this.inputProviders = inputProviders;
+    this.outputProviders = outputProviders;
     this.command = command;
     this.shell = shell;
   }
@@ -60,14 +60,14 @@ export class BuildFunction {
   ): BuildStep {
     const buildStepId = id ?? this.id ?? uuidv4();
 
-    const inputs = this.inputCreators?.map((inputCreator) => {
-      const input = inputCreator(buildStepId);
+    const inputs = this.inputProviders?.map((inputProvider) => {
+      const input = inputProvider(buildStepId);
       if (input.id in callInputs) {
         input.set(callInputs[input.id]);
       }
       return input;
     });
-    const outputs = this.outputCreators?.map((outputCreator) => outputCreator(buildStepId));
+    const outputs = this.outputProviders?.map((outputProvider) => outputProvider(buildStepId));
 
     return new BuildStep(ctx, {
       id: buildStepId,

--- a/packages/steps/src/BuildFunction.ts
+++ b/packages/steps/src/BuildFunction.ts
@@ -12,6 +12,7 @@ export type BuildFunctionById = Record<string, BuildFunction>;
 export type BuildFunctionCallInputs = Record<string, string>;
 
 export class BuildFunction {
+  public readonly namespace?: string;
   public readonly id: string;
   public readonly name?: string;
   public readonly platforms?: BuildPlatform[];
@@ -22,6 +23,7 @@ export class BuildFunction {
   public readonly shell?: string;
 
   constructor({
+    namespace,
     id,
     name,
     platforms,
@@ -31,6 +33,7 @@ export class BuildFunction {
     fn,
     shell,
   }: {
+    namespace?: string;
     id: string;
     name?: string;
     platforms?: BuildPlatform[];
@@ -43,6 +46,7 @@ export class BuildFunction {
     assert(command !== undefined || fn !== undefined, 'Either command or fn must be defined.');
     assert(!(command !== undefined && fn !== undefined), 'Command and fn cannot be both set.');
 
+    this.namespace = namespace;
     this.id = id;
     this.name = name;
     this.platforms = platforms;
@@ -51,6 +55,10 @@ export class BuildFunction {
     this.command = command;
     this.fn = fn;
     this.shell = shell;
+  }
+
+  public getFullId(): string {
+    return this.namespace === undefined ? this.id : `${this.namespace}/${this.id}`;
   }
 
   public createBuildStepFromFunctionCall(

--- a/packages/steps/src/BuildFunction.ts
+++ b/packages/steps/src/BuildFunction.ts
@@ -12,7 +12,7 @@ export type BuildFunctionById = Record<string, BuildFunction>;
 export type BuildFunctionCallInputs = Record<string, string>;
 
 export class BuildFunction {
-  public readonly id?: string;
+  public readonly id: string;
   public readonly name?: string;
   public readonly platforms?: BuildPlatform[];
   public readonly inputProviders?: BuildStepInputProvider[];
@@ -31,7 +31,7 @@ export class BuildFunction {
     fn,
     shell,
   }: {
-    id?: string;
+    id: string;
     name?: string;
     platforms?: BuildPlatform[];
     inputProviders?: BuildStepInputProvider[];
@@ -67,7 +67,7 @@ export class BuildFunction {
       shell?: string;
     }
   ): BuildStep {
-    const buildStepId = id ?? this.id ?? uuidv4();
+    const buildStepId = id ?? uuidv4();
 
     const inputs = this.inputProviders?.map((inputProvider) => {
       const input = inputProvider(ctx, buildStepId);

--- a/packages/steps/src/BuildStep.ts
+++ b/packages/steps/src/BuildStep.ts
@@ -264,7 +264,7 @@ export class BuildStep {
     if (name) {
       return name;
     }
-    if (command !== undefined && command !== '') {
+    if (command) {
       const splits = command.trim().split('\n');
       for (const split of splits) {
         const trimmed = split.trim();

--- a/packages/steps/src/BuildStepInput.ts
+++ b/packages/steps/src/BuildStepInput.ts
@@ -2,6 +2,7 @@ import { BuildStepContext } from './BuildStepContext.js';
 import { BuildStepRuntimeError } from './errors/BuildStepRuntimeError.js';
 import { interpolateWithOutputs } from './utils/template.js';
 
+export type BuildStepInputById = Record<string, BuildStepInput>;
 export type BuildStepInputProvider = (ctx: BuildStepContext, stepId: string) => BuildStepInput;
 
 export class BuildStepInput {
@@ -64,4 +65,14 @@ export class BuildStepInput {
     this._value = value;
     return this;
   }
+}
+
+export function makeBuildStepInputByIdMap(inputs?: BuildStepInput[]): BuildStepInputById {
+  if (inputs === undefined) {
+    return {};
+  }
+  return inputs.reduce((acc, input) => {
+    acc[input.id] = input;
+    return acc;
+  }, {} as BuildStepInputById);
 }

--- a/packages/steps/src/BuildStepInput.ts
+++ b/packages/steps/src/BuildStepInput.ts
@@ -2,7 +2,7 @@ import { BuildStepContext } from './BuildStepContext.js';
 import { BuildStepRuntimeError } from './errors/BuildStepRuntimeError.js';
 import { interpolateWithOutputs } from './utils/template.js';
 
-export type BuildStepInputProvider = (stepId: string) => BuildStepInput;
+export type BuildStepInputProvider = (ctx: BuildStepContext, stepId: string) => BuildStepInput;
 
 export class BuildStepInput {
   public readonly id: string;
@@ -11,6 +11,14 @@ export class BuildStepInput {
   public readonly required: boolean;
 
   private _value?: string;
+
+  public static createProvider(params: {
+    id: string;
+    defaultValue?: string;
+    required?: boolean;
+  }): BuildStepInputProvider {
+    return (ctx, stepId) => new BuildStepInput(ctx, { ...params, stepId });
+  }
 
   constructor(
     private readonly ctx: BuildStepContext,

--- a/packages/steps/src/BuildStepInput.ts
+++ b/packages/steps/src/BuildStepInput.ts
@@ -2,7 +2,7 @@ import { BuildStepContext } from './BuildStepContext.js';
 import { BuildStepRuntimeError } from './errors/BuildStepRuntimeError.js';
 import { interpolateWithOutputs } from './utils/template.js';
 
-export type BuildStepInputCreator = (stepId: string) => BuildStepInput;
+export type BuildStepInputProvider = (stepId: string) => BuildStepInput;
 
 export class BuildStepInput {
   public readonly id: string;

--- a/packages/steps/src/BuildStepOutput.ts
+++ b/packages/steps/src/BuildStepOutput.ts
@@ -1,6 +1,7 @@
 import { BuildStepContext } from './BuildStepContext.js';
 import { BuildStepRuntimeError } from './errors/BuildStepRuntimeError.js';
 
+export type BuildStepOutputById = Record<string, BuildStepOutput>;
 export type BuildStepOutputProvider = (ctx: BuildStepContext, stepId: string) => BuildStepOutput;
 
 export class BuildStepOutput {
@@ -45,4 +46,14 @@ export class BuildStepOutput {
     this._value = value;
     return this;
   }
+}
+
+export function makeBuildStepOutputByIdMap(outputs?: BuildStepOutput[]): BuildStepOutputById {
+  if (outputs === undefined) {
+    return {};
+  }
+  return outputs.reduce((acc, output) => {
+    acc[output.id] = output;
+    return acc;
+  }, {} as BuildStepOutputById);
 }

--- a/packages/steps/src/BuildStepOutput.ts
+++ b/packages/steps/src/BuildStepOutput.ts
@@ -1,7 +1,7 @@
 import { BuildStepContext } from './BuildStepContext.js';
 import { BuildStepRuntimeError } from './errors/BuildStepRuntimeError.js';
 
-export type BuildStepOutputCreator = (stepId: string) => BuildStepOutput;
+export type BuildStepOutputProvider = (stepId: string) => BuildStepOutput;
 
 export class BuildStepOutput {
   public readonly id: string;

--- a/packages/steps/src/BuildStepOutput.ts
+++ b/packages/steps/src/BuildStepOutput.ts
@@ -1,7 +1,7 @@
 import { BuildStepContext } from './BuildStepContext.js';
 import { BuildStepRuntimeError } from './errors/BuildStepRuntimeError.js';
 
-export type BuildStepOutputProvider = (stepId: string) => BuildStepOutput;
+export type BuildStepOutputProvider = (ctx: BuildStepContext, stepId: string) => BuildStepOutput;
 
 export class BuildStepOutput {
   public readonly id: string;
@@ -9,6 +9,13 @@ export class BuildStepOutput {
   public readonly required: boolean;
 
   private _value?: string;
+
+  public static createProvider(params: {
+    id: string;
+    required?: boolean;
+  }): BuildStepOutputProvider {
+    return (ctx, stepId) => new BuildStepOutput(ctx, { ...params, stepId });
+  }
 
   constructor(
     // @ts-expect-error ctx is not used in this class but let's keep it here for consistency

--- a/packages/steps/src/BuildWorkflowValidator.ts
+++ b/packages/steps/src/BuildWorkflowValidator.ts
@@ -2,6 +2,7 @@ import { BuildStep } from './BuildStep.js';
 import { BuildWorkflow } from './BuildWorkflow.js';
 import { BuildConfigError } from './errors/BuildConfigError.js';
 import { BuildWorkflowError } from './errors/BuildWorkflowError.js';
+import { duplicates } from './utils/expodash/duplicates.js';
 import { findOutputPaths } from './utils/template.js';
 
 export class BuildWorkflowValidator {
@@ -18,16 +19,7 @@ export class BuildWorkflowValidator {
 
   private validateUniqueStepIds(): BuildConfigError[] {
     const stepIds = this.workflow.buildSteps.map(({ id }) => id);
-    const visitedStepIdsSet = new Set<string>();
-    const duplicatedStepIdsSet = new Set<string>();
-    for (const stepId of stepIds) {
-      if (visitedStepIdsSet.has(stepId)) {
-        duplicatedStepIdsSet.add(stepId);
-      } else {
-        visitedStepIdsSet.add(stepId);
-      }
-    }
-    const duplicatedStepIds = [...duplicatedStepIdsSet];
+    const duplicatedStepIds = duplicates(stepIds);
     if (duplicatedStepIds.length === 0) {
       return [];
     } else {

--- a/packages/steps/src/__tests__/BuildConfig-test.ts
+++ b/packages/steps/src/__tests__/BuildConfig-test.ts
@@ -10,6 +10,7 @@ import {
   validateBuildConfig,
 } from '../BuildConfig.js';
 import { BuildConfigError } from '../errors/BuildConfigError.js';
+
 import { getError } from './utils/error.js';
 
 describe(validateBuildConfig, () => {

--- a/packages/steps/src/__tests__/BuildConfig-test.ts
+++ b/packages/steps/src/__tests__/BuildConfig-test.ts
@@ -10,6 +10,7 @@ import {
   validateBuildConfig,
 } from '../BuildConfig.js';
 import { BuildConfigError } from '../errors/BuildConfigError.js';
+import { getError } from './utils/error.js';
 
 describe(validateBuildConfig, () => {
   test('can throw BuildConfigError', () => {
@@ -260,6 +261,29 @@ describe(validateBuildConfig, () => {
       expect(() => {
         validateBuildConfig(buildConfig, []);
       }).toThrowError(/"functions.run" is not allowed/);
+    });
+    test('function IDs must be alphanumeric (including underscore and dash)', () => {
+      const buildConfig = {
+        build: {
+          steps: [],
+        },
+        functions: {
+          foo: {},
+          upload_artifact: {},
+          'build-project': {},
+          'eas/download_project': {},
+          '!@#$': {},
+        },
+      };
+
+      const error = getError<Error>(() => {
+        validateBuildConfig(buildConfig, []);
+      });
+      expect(error.message).toMatch(/"functions\.eas\/download_project" is not allowed/);
+      expect(error.message).toMatch(/"functions\.!@#\$" is not allowed/);
+      expect(error.message).not.toMatch(/"functions\.foo" is not allowed/);
+      expect(error.message).not.toMatch(/"functions\.build-project" is not allowed/);
+      expect(error.message).not.toMatch(/"functions\.build-project" is not allowed/);
     });
   });
 });

--- a/packages/steps/src/__tests__/BuildConfig-test.ts
+++ b/packages/steps/src/__tests__/BuildConfig-test.ts
@@ -16,7 +16,7 @@ describe(validateBuildConfig, () => {
     const buildConfig = {};
 
     expect(() => {
-      validateBuildConfig(buildConfig);
+      validateBuildConfig(buildConfig, []);
     }).toThrowError(BuildConfigError);
   });
 
@@ -33,7 +33,7 @@ describe(validateBuildConfig, () => {
       };
 
       expect(() => {
-        validateBuildConfig(buildConfig);
+        validateBuildConfig(buildConfig, []);
       }).not.toThrowError();
     });
 
@@ -50,7 +50,7 @@ describe(validateBuildConfig, () => {
         };
 
         expect(() => {
-          validateBuildConfig(buildConfig);
+          validateBuildConfig(buildConfig, []);
         }).toThrowError(/".*\.command" is required/);
       });
       test('non-existent fields', () => {
@@ -68,7 +68,7 @@ describe(validateBuildConfig, () => {
         };
 
         expect(() => {
-          validateBuildConfig(buildConfig);
+          validateBuildConfig(buildConfig, []);
         }).toThrowError(/".*\.blah" is not allowed/);
       });
       test('valid command', () => {
@@ -85,7 +85,7 @@ describe(validateBuildConfig, () => {
         };
 
         expect(() => {
-          validateBuildConfig(buildConfig);
+          validateBuildConfig(buildConfig, []);
         }).not.toThrowError();
       });
     });
@@ -104,7 +104,7 @@ describe(validateBuildConfig, () => {
         };
 
         expect(() => {
-          validateBuildConfig(buildConfig);
+          validateBuildConfig(buildConfig, []);
         }).not.toThrowError();
       });
       test('non-existent fields', () => {
@@ -126,7 +126,7 @@ describe(validateBuildConfig, () => {
         };
 
         expect(() => {
-          validateBuildConfig(buildConfig);
+          validateBuildConfig(buildConfig, []);
         }).toThrowError(/".*\.blah" is not allowed/);
       });
       test('command is not allowed', () => {
@@ -148,7 +148,7 @@ describe(validateBuildConfig, () => {
         };
 
         expect(() => {
-          validateBuildConfig(buildConfig);
+          validateBuildConfig(buildConfig, []);
         }).toThrowError(/".*\.command" is not allowed/);
       });
       test('call with inputs', () => {
@@ -172,7 +172,7 @@ describe(validateBuildConfig, () => {
         };
 
         expect(() => {
-          validateBuildConfig(buildConfig);
+          validateBuildConfig(buildConfig, []);
         }).not.toThrowError();
       });
       test('at most one function call per step', () => {
@@ -204,7 +204,7 @@ describe(validateBuildConfig, () => {
         };
 
         expect(() => {
-          validateBuildConfig(buildConfig);
+          validateBuildConfig(buildConfig, []);
         }).toThrowError();
       });
       test('non-existent functions', () => {
@@ -215,8 +215,19 @@ describe(validateBuildConfig, () => {
         };
 
         expect(() => {
-          validateBuildConfig(buildConfig);
-        }).toThrowError(/Calling non-existent functions: say_hi, say_hello/);
+          validateBuildConfig(buildConfig, []);
+        }).toThrowError(/Calling non-existent functions: "say_hi", "say_hello"/);
+      });
+      test('works with external functions', () => {
+        const buildConfig = {
+          build: {
+            steps: ['say_hi', 'say_hello'],
+          },
+        };
+
+        expect(() => {
+          validateBuildConfig(buildConfig, ['say_hi', 'say_hello']);
+        }).not.toThrowError();
       });
     });
   });
@@ -233,7 +244,7 @@ describe(validateBuildConfig, () => {
       };
 
       expect(() => {
-        validateBuildConfig(buildConfig);
+        validateBuildConfig(buildConfig, []);
       }).toThrowError(/".*\.say_hi\.command" is required/);
     });
     test('"run" is not allowed for function name', () => {
@@ -247,7 +258,7 @@ describe(validateBuildConfig, () => {
       };
 
       expect(() => {
-        validateBuildConfig(buildConfig);
+        validateBuildConfig(buildConfig, []);
       }).toThrowError(/"functions.run" is not allowed/);
     });
   });

--- a/packages/steps/src/__tests__/BuildConfigParser-test.ts
+++ b/packages/steps/src/__tests__/BuildConfigParser-test.ts
@@ -6,9 +6,7 @@ import { BuildWorkflow } from '../BuildWorkflow.js';
 import { getDefaultShell } from '../utils/shell/command.js';
 
 import { createMockContext } from './utils/context.js';
-
-const UUID_REGEX =
-  /^[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}$/;
+import { UUID_REGEX } from './utils/uuid.js';
 
 const __dirname = url.fileURLToPath(new URL('.', import.meta.url));
 
@@ -259,7 +257,7 @@ describe(BuildConfigParser, () => {
       //     - name
       //   command: echo "Hi, ${ inputs.name }!"
       const function1 = buildFunctions.say_hi;
-      expect(function1.id).toBe(undefined);
+      expect(function1.id).toBe('say_hi');
       expect(function1.name).toBe('Hi!');
       expect(function1.inputProviders?.[0](ctx, 'unknown-step').id).toBe('name');
       expect(function1.inputProviders?.[0](ctx, 'unknown-step').defaultValue).toBe(undefined);
@@ -270,7 +268,7 @@ describe(BuildConfigParser, () => {
       //   name: Hi, Wojtek!
       //   command: echo "Hi, Wojtek!"
       const function2 = buildFunctions.say_hi_wojtek;
-      expect(function2.id).toBe(undefined);
+      expect(function2.id).toBe('say_hi_wojtek');
       expect(function2.name).toBe('Hi, Wojtek!');
       expect(function2.command).toBe('echo "Hi, Wojtek!"');
 
@@ -280,7 +278,7 @@ describe(BuildConfigParser, () => {
       //     - value
       //   command: set-output value 6
       const function3 = buildFunctions.random;
-      expect(function3.id).toBe(undefined);
+      expect(function3.id).toBe('random');
       expect(function3.name).toBe('Generate random number');
       expect(function3.outputProviders?.[0](ctx, 'unknown-step').id).toBe('value');
       expect(function3.outputProviders?.[0](ctx, 'unknown-step').required).toBe(true);
@@ -290,7 +288,7 @@ describe(BuildConfigParser, () => {
       //   inputs: [value]
       //   command: echo "${ inputs.value }"
       const function4 = buildFunctions.print;
-      expect(function4.id).toBe(undefined);
+      expect(function4.id).toBe('print');
       expect(function4.name).toBe(undefined);
       expect(function4.inputProviders?.[0](ctx, 'unknown-step').id).toBe('value');
       expect(function4.inputProviders?.[0](ctx, 'unknown-step').required).toBe(true);

--- a/packages/steps/src/__tests__/BuildConfigParser-test.ts
+++ b/packages/steps/src/__tests__/BuildConfigParser-test.ts
@@ -261,9 +261,9 @@ describe(BuildConfigParser, () => {
       const function1 = buildFunctions.say_hi;
       expect(function1.id).toBe(undefined);
       expect(function1.name).toBe('Hi!');
-      expect(function1.inputCreators?.[0]('unknown-step').id).toBe('name');
-      expect(function1.inputCreators?.[0]('unknown-step').defaultValue).toBe(undefined);
-      expect(function1.inputCreators?.[0]('unknown-step').required).toBe(true);
+      expect(function1.inputProviders?.[0]('unknown-step').id).toBe('name');
+      expect(function1.inputProviders?.[0]('unknown-step').defaultValue).toBe(undefined);
+      expect(function1.inputProviders?.[0]('unknown-step').required).toBe(true);
       expect(function1.command).toBe('echo "Hi, ${ inputs.name }!"');
 
       // say_hi_wojtek:
@@ -282,8 +282,8 @@ describe(BuildConfigParser, () => {
       const function3 = buildFunctions.random;
       expect(function3.id).toBe(undefined);
       expect(function3.name).toBe('Generate random number');
-      expect(function3.outputCreators?.[0]('unknown-step').id).toBe('value');
-      expect(function3.outputCreators?.[0]('unknown-step').required).toBe(true);
+      expect(function3.outputProviders?.[0]('unknown-step').id).toBe('value');
+      expect(function3.outputProviders?.[0]('unknown-step').required).toBe(true);
       expect(function3.command).toBe('set-output value 6');
 
       // print:
@@ -292,8 +292,8 @@ describe(BuildConfigParser, () => {
       const function4 = buildFunctions.print;
       expect(function4.id).toBe(undefined);
       expect(function4.name).toBe(undefined);
-      expect(function4.inputCreators?.[0]('unknown-step').id).toBe('value');
-      expect(function4.inputCreators?.[0]('unknown-step').required).toBe(true);
+      expect(function4.inputProviders?.[0]('unknown-step').id).toBe('value');
+      expect(function4.inputProviders?.[0]('unknown-step').required).toBe(true);
       expect(function4.command).toBe('echo "${ inputs.value }"');
     });
   });

--- a/packages/steps/src/__tests__/BuildConfigParser-test.ts
+++ b/packages/steps/src/__tests__/BuildConfigParser-test.ts
@@ -261,9 +261,9 @@ describe(BuildConfigParser, () => {
       const function1 = buildFunctions.say_hi;
       expect(function1.id).toBe(undefined);
       expect(function1.name).toBe('Hi!');
-      expect(function1.inputProviders?.[0]('unknown-step').id).toBe('name');
-      expect(function1.inputProviders?.[0]('unknown-step').defaultValue).toBe(undefined);
-      expect(function1.inputProviders?.[0]('unknown-step').required).toBe(true);
+      expect(function1.inputProviders?.[0](ctx, 'unknown-step').id).toBe('name');
+      expect(function1.inputProviders?.[0](ctx, 'unknown-step').defaultValue).toBe(undefined);
+      expect(function1.inputProviders?.[0](ctx, 'unknown-step').required).toBe(true);
       expect(function1.command).toBe('echo "Hi, ${ inputs.name }!"');
 
       // say_hi_wojtek:
@@ -282,8 +282,8 @@ describe(BuildConfigParser, () => {
       const function3 = buildFunctions.random;
       expect(function3.id).toBe(undefined);
       expect(function3.name).toBe('Generate random number');
-      expect(function3.outputProviders?.[0]('unknown-step').id).toBe('value');
-      expect(function3.outputProviders?.[0]('unknown-step').required).toBe(true);
+      expect(function3.outputProviders?.[0](ctx, 'unknown-step').id).toBe('value');
+      expect(function3.outputProviders?.[0](ctx, 'unknown-step').required).toBe(true);
       expect(function3.command).toBe('set-output value 6');
 
       // print:
@@ -292,8 +292,8 @@ describe(BuildConfigParser, () => {
       const function4 = buildFunctions.print;
       expect(function4.id).toBe(undefined);
       expect(function4.name).toBe(undefined);
-      expect(function4.inputProviders?.[0]('unknown-step').id).toBe('value');
-      expect(function4.inputProviders?.[0]('unknown-step').required).toBe(true);
+      expect(function4.inputProviders?.[0](ctx, 'unknown-step').id).toBe('value');
+      expect(function4.inputProviders?.[0](ctx, 'unknown-step').required).toBe(true);
       expect(function4.command).toBe('echo "${ inputs.value }"');
     });
   });

--- a/packages/steps/src/__tests__/BuildFunction-test.ts
+++ b/packages/steps/src/__tests__/BuildFunction-test.ts
@@ -9,12 +9,14 @@ describe(BuildFunction, () => {
   describe(BuildFunction.prototype.createBuildStepFromFunctionCall, () => {
     it('returns a BuildStep object', () => {
       const ctx = createMockContext();
-      const func = new BuildFunction(ctx, {
+      const func = new BuildFunction({
         id: 'test1',
         name: 'Test function',
         command: 'echo 123',
       });
-      const step = func.createBuildStepFromFunctionCall({ workingDirectory: ctx.workingDirectory });
+      const step = func.createBuildStepFromFunctionCall(ctx, {
+        workingDirectory: ctx.workingDirectory,
+      });
       expect(step).toBeInstanceOf(BuildStep);
       expect(step.id).toBe('test1');
       expect(step.name).toBe('Test function');
@@ -22,13 +24,13 @@ describe(BuildFunction, () => {
     });
     it('can override id and shell from function definition', () => {
       const ctx = createMockContext();
-      const func = new BuildFunction(ctx, {
+      const func = new BuildFunction({
         id: 'test1',
         name: 'Test function',
         command: 'echo 123',
         shell: '/bin/bash',
       });
-      const step = func.createBuildStepFromFunctionCall({
+      const step = func.createBuildStepFromFunctionCall(ctx, {
         id: 'test2',
         shell: '/bin/zsh',
         workingDirectory: ctx.workingDirectory,
@@ -48,7 +50,7 @@ describe(BuildFunction, () => {
         (stepId: string) => new BuildStepOutput(ctx, { id: 'output1', stepId }),
         (stepId: string) => new BuildStepOutput(ctx, { id: 'output2', stepId }),
       ];
-      const func = new BuildFunction(ctx, {
+      const func = new BuildFunction({
         id: 'test1',
         name: 'Test function',
         command:
@@ -56,7 +58,7 @@ describe(BuildFunction, () => {
         inputCreators,
         outputCreators,
       });
-      const step = func.createBuildStepFromFunctionCall({
+      const step = func.createBuildStepFromFunctionCall(ctx, {
         callInputs: {
           input1: 'abc',
           input2: 'def',
@@ -78,13 +80,13 @@ describe(BuildFunction, () => {
         (stepId: string) => new BuildStepInput(ctx, { id: 'input1', defaultValue: 'xyz1', stepId }),
         (stepId: string) => new BuildStepInput(ctx, { id: 'input2', defaultValue: 'xyz2', stepId }),
       ];
-      const func = new BuildFunction(ctx, {
+      const func = new BuildFunction({
         id: 'test1',
         name: 'Test function',
         command: 'echo ${ inputs.input1 } ${ inputs.input2 }',
         inputCreators,
       });
-      const step = func.createBuildStepFromFunctionCall({
+      const step = func.createBuildStepFromFunctionCall(ctx, {
         id: 'buildStep1',
         callInputs: {
           input1: 'abc',

--- a/packages/steps/src/__tests__/BuildFunction-test.ts
+++ b/packages/steps/src/__tests__/BuildFunction-test.ts
@@ -29,6 +29,26 @@ describe(BuildFunction, () => {
     });
   });
 
+  describe(BuildFunction.prototype.getFullId, () => {
+    test('namespace is not defined', () => {
+      const buildFunction = new BuildFunction({
+        id: 'upload_artifacts',
+        name: 'Test function',
+        command: 'echo 123',
+      });
+      expect(buildFunction.getFullId()).toBe('upload_artifacts');
+    });
+    test('namespace is defined', () => {
+      const buildFunction = new BuildFunction({
+        namespace: 'eas',
+        id: 'upload_artifacts',
+        name: 'Test function',
+        command: 'echo 123',
+      });
+      expect(buildFunction.getFullId()).toBe('eas/upload_artifacts');
+    });
+  });
+
   describe(BuildFunction.prototype.createBuildStepFromFunctionCall, () => {
     it('returns a BuildStep object', () => {
       const ctx = createMockContext();

--- a/packages/steps/src/__tests__/BuildFunction-test.ts
+++ b/packages/steps/src/__tests__/BuildFunction-test.ts
@@ -43,12 +43,12 @@ describe(BuildFunction, () => {
     it('creates function input and output parameters', () => {
       const ctx = createMockContext();
       const inputProviders: BuildStepInputProvider[] = [
-        (stepId: string) => new BuildStepInput(ctx, { id: 'input1', stepId }),
-        (stepId: string) => new BuildStepInput(ctx, { id: 'input2', stepId }),
+        BuildStepInput.createProvider({ id: 'input1' }),
+        BuildStepInput.createProvider({ id: 'input2' }),
       ];
       const outputProviders: BuildStepOutputProvider[] = [
-        (stepId: string) => new BuildStepOutput(ctx, { id: 'output1', stepId }),
-        (stepId: string) => new BuildStepOutput(ctx, { id: 'output2', stepId }),
+        BuildStepOutput.createProvider({ id: 'output1' }),
+        BuildStepOutput.createProvider({ id: 'output2' }),
       ];
       const func = new BuildFunction({
         id: 'test1',
@@ -77,8 +77,8 @@ describe(BuildFunction, () => {
     it('passes values to build inputs', () => {
       const ctx = createMockContext();
       const inputProviders: BuildStepInputProvider[] = [
-        (stepId: string) => new BuildStepInput(ctx, { id: 'input1', defaultValue: 'xyz1', stepId }),
-        (stepId: string) => new BuildStepInput(ctx, { id: 'input2', defaultValue: 'xyz2', stepId }),
+        BuildStepInput.createProvider({ id: 'input1', defaultValue: 'xyz1' }),
+        BuildStepInput.createProvider({ id: 'input2', defaultValue: 'xyz2' }),
       ];
       const func = new BuildFunction({
         id: 'test1',

--- a/packages/steps/src/__tests__/BuildFunction-test.ts
+++ b/packages/steps/src/__tests__/BuildFunction-test.ts
@@ -4,6 +4,7 @@ import { BuildStepInput, BuildStepInputProvider } from '../BuildStepInput.js';
 import { BuildStepOutput, BuildStepOutputProvider } from '../BuildStepOutput.js';
 
 import { createMockContext } from './utils/context.js';
+import { UUID_REGEX } from './utils/uuid.js';
 
 describe(BuildFunction, () => {
   describe('constructor', () => {
@@ -40,7 +41,7 @@ describe(BuildFunction, () => {
         workingDirectory: ctx.workingDirectory,
       });
       expect(step).toBeInstanceOf(BuildStep);
-      expect(step.id).toBe('test1');
+      expect(step.id).toMatch(UUID_REGEX);
       expect(step.name).toBe('Test function');
       expect(step.command).toBe('echo 123');
     });
@@ -56,7 +57,7 @@ describe(BuildFunction, () => {
         workingDirectory: ctx.workingDirectory,
       });
       expect(step).toBeInstanceOf(BuildStep);
-      expect(step.id).toBe('test1');
+      expect(step.id).toMatch(UUID_REGEX);
       expect(step.name).toBe('Test function');
       expect(step.fn).toBe(fn);
     });

--- a/packages/steps/src/__tests__/BuildFunction-test.ts
+++ b/packages/steps/src/__tests__/BuildFunction-test.ts
@@ -1,11 +1,33 @@
 import { BuildFunction } from '../BuildFunction.js';
-import { BuildStep } from '../BuildStep.js';
+import { BuildStep, BuildStepFunction } from '../BuildStep.js';
 import { BuildStepInput, BuildStepInputProvider } from '../BuildStepInput.js';
 import { BuildStepOutput, BuildStepOutputProvider } from '../BuildStepOutput.js';
 
 import { createMockContext } from './utils/context.js';
 
 describe(BuildFunction, () => {
+  describe('constructor', () => {
+    it('throws when neither command nor fn is set', () => {
+      expect(() => {
+        // eslint-disable-next-line no-new
+        new BuildFunction({
+          id: 'test1',
+        });
+      }).toThrowError(/Either command or fn must be defined/);
+    });
+
+    it('throws when neither command nor fn is set', () => {
+      expect(() => {
+        // eslint-disable-next-line no-new
+        new BuildFunction({
+          id: 'test1',
+          command: 'echo 123',
+          fn: () => {},
+        });
+      }).toThrowError(/Command and fn cannot be both set/);
+    });
+  });
+
   describe(BuildFunction.prototype.createBuildStepFromFunctionCall, () => {
     it('returns a BuildStep object', () => {
       const ctx = createMockContext();
@@ -21,6 +43,22 @@ describe(BuildFunction, () => {
       expect(step.id).toBe('test1');
       expect(step.name).toBe('Test function');
       expect(step.command).toBe('echo 123');
+    });
+    it('works with build step function', () => {
+      const ctx = createMockContext();
+      const fn: BuildStepFunction = () => {};
+      const buildFunction = new BuildFunction({
+        id: 'test1',
+        name: 'Test function',
+        fn,
+      });
+      const step = buildFunction.createBuildStepFromFunctionCall(ctx, {
+        workingDirectory: ctx.workingDirectory,
+      });
+      expect(step).toBeInstanceOf(BuildStep);
+      expect(step.id).toBe('test1');
+      expect(step.name).toBe('Test function');
+      expect(step.fn).toBe(fn);
     });
     it('can override id and shell from function definition', () => {
       const ctx = createMockContext();

--- a/packages/steps/src/__tests__/BuildFunction-test.ts
+++ b/packages/steps/src/__tests__/BuildFunction-test.ts
@@ -1,7 +1,7 @@
 import { BuildFunction } from '../BuildFunction.js';
 import { BuildStep } from '../BuildStep.js';
-import { BuildStepInput, BuildStepInputCreator } from '../BuildStepInput.js';
-import { BuildStepOutput, BuildStepOutputCreator } from '../BuildStepOutput.js';
+import { BuildStepInput, BuildStepInputProvider } from '../BuildStepInput.js';
+import { BuildStepOutput, BuildStepOutputProvider } from '../BuildStepOutput.js';
 
 import { createMockContext } from './utils/context.js';
 
@@ -42,11 +42,11 @@ describe(BuildFunction, () => {
     });
     it('creates function input and output parameters', () => {
       const ctx = createMockContext();
-      const inputCreators: BuildStepInputCreator[] = [
+      const inputProviders: BuildStepInputProvider[] = [
         (stepId: string) => new BuildStepInput(ctx, { id: 'input1', stepId }),
         (stepId: string) => new BuildStepInput(ctx, { id: 'input2', stepId }),
       ];
-      const outputCreators: BuildStepOutputCreator[] = [
+      const outputProviders: BuildStepOutputProvider[] = [
         (stepId: string) => new BuildStepOutput(ctx, { id: 'output1', stepId }),
         (stepId: string) => new BuildStepOutput(ctx, { id: 'output2', stepId }),
       ];
@@ -55,8 +55,8 @@ describe(BuildFunction, () => {
         name: 'Test function',
         command:
           'echo ${ inputs.input1 } ${ inputs.input2 }\nset-output output1 value1\nset-output output2 value2',
-        inputCreators,
-        outputCreators,
+        inputProviders,
+        outputProviders,
       });
       const step = func.createBuildStepFromFunctionCall(ctx, {
         callInputs: {
@@ -65,10 +65,10 @@ describe(BuildFunction, () => {
         },
         workingDirectory: ctx.workingDirectory,
       });
-      expect(func.inputCreators?.[0]).toBe(inputCreators[0]);
-      expect(func.inputCreators?.[1]).toBe(inputCreators[1]);
-      expect(func.outputCreators?.[0]).toBe(outputCreators[0]);
-      expect(func.outputCreators?.[1]).toBe(outputCreators[1]);
+      expect(func.inputProviders?.[0]).toBe(inputProviders[0]);
+      expect(func.inputProviders?.[1]).toBe(inputProviders[1]);
+      expect(func.outputProviders?.[0]).toBe(outputProviders[0]);
+      expect(func.outputProviders?.[1]).toBe(outputProviders[1]);
       expect(step.inputs?.[0].id).toBe('input1');
       expect(step.inputs?.[1].id).toBe('input2');
       expect(step.outputs?.[0].id).toBe('output1');
@@ -76,7 +76,7 @@ describe(BuildFunction, () => {
     });
     it('passes values to build inputs', () => {
       const ctx = createMockContext();
-      const inputCreators: BuildStepInputCreator[] = [
+      const inputProviders: BuildStepInputProvider[] = [
         (stepId: string) => new BuildStepInput(ctx, { id: 'input1', defaultValue: 'xyz1', stepId }),
         (stepId: string) => new BuildStepInput(ctx, { id: 'input2', defaultValue: 'xyz2', stepId }),
       ];
@@ -84,7 +84,7 @@ describe(BuildFunction, () => {
         id: 'test1',
         name: 'Test function',
         command: 'echo ${ inputs.input1 } ${ inputs.input2 }',
-        inputCreators,
+        inputProviders,
       });
       const step = func.createBuildStepFromFunctionCall(ctx, {
         id: 'buildStep1',

--- a/packages/steps/src/__tests__/BuildStepInput-test.ts
+++ b/packages/steps/src/__tests__/BuildStepInput-test.ts
@@ -1,5 +1,5 @@
 import { BuildStepRuntimeError } from '../errors/BuildStepRuntimeError.js';
-import { BuildStepInput } from '../BuildStepInput.js';
+import { BuildStepInput, makeBuildStepInputByIdMap } from '../BuildStepInput.js';
 
 import { createMockContext } from './utils/context.js';
 
@@ -45,5 +45,25 @@ describe(BuildStepInput, () => {
     }).toThrowError(
       new BuildStepRuntimeError('Input parameter "foo" for step "test1" is required.')
     );
+  });
+});
+
+describe(makeBuildStepInputByIdMap, () => {
+  it('returns empty object when inputs are undefined', () => {
+    expect(makeBuildStepInputByIdMap(undefined)).toEqual({});
+  });
+
+  it('returns object with inputs indexed by their ids', () => {
+    const ctx = createMockContext();
+    const inputs: BuildStepInput[] = [
+      new BuildStepInput(ctx, { id: 'foo1', stepId: 'test1', defaultValue: 'bar1' }),
+      new BuildStepInput(ctx, { id: 'foo2', stepId: 'test1', defaultValue: 'bar2' }),
+    ];
+    const result = makeBuildStepInputByIdMap(inputs);
+    expect(Object.keys(result).length).toBe(2);
+    expect(result.foo1).toBeDefined();
+    expect(result.foo2).toBeDefined();
+    expect(result.foo1.value).toBe('bar1');
+    expect(result.foo2.value).toBe('bar2');
   });
 });

--- a/packages/steps/src/__tests__/BuildStepOutput-test.ts
+++ b/packages/steps/src/__tests__/BuildStepOutput-test.ts
@@ -1,4 +1,4 @@
-import { BuildStepOutput } from '../BuildStepOutput.js';
+import { BuildStepOutput, makeBuildStepOutputByIdMap } from '../BuildStepOutput.js';
 import { BuildStepRuntimeError } from '../errors/BuildStepRuntimeError.js';
 
 import { createMockContext } from './utils/context.js';
@@ -35,5 +35,23 @@ describe(BuildStepOutput, () => {
     }).toThrowError(
       new BuildStepRuntimeError('Output parameter "foo" for step "test1" is required.')
     );
+  });
+});
+
+describe(makeBuildStepOutputByIdMap, () => {
+  it('returns empty object when inputs are undefined', () => {
+    expect(makeBuildStepOutputByIdMap(undefined)).toEqual({});
+  });
+
+  it('returns object with outputs indexed by their ids', () => {
+    const ctx = createMockContext();
+    const outputs: BuildStepOutput[] = [
+      new BuildStepOutput(ctx, { id: 'abc1', stepId: 'test1', required: true }),
+      new BuildStepOutput(ctx, { id: 'abc2', stepId: 'test1', required: true }),
+    ];
+    const result = makeBuildStepOutputByIdMap(outputs);
+    expect(Object.keys(result).length).toBe(2);
+    expect(result.abc1).toBeDefined();
+    expect(result.abc2).toBeDefined();
   });
 });

--- a/packages/steps/src/__tests__/fixtures/external-functions.yml
+++ b/packages/steps/src/__tests__/fixtures/external-functions.yml
@@ -1,0 +1,5 @@
+build:
+  name: External functions
+  steps:
+    - eas/download_project
+    - eas/build_project

--- a/packages/steps/src/__tests__/utils/uuid.ts
+++ b/packages/steps/src/__tests__/utils/uuid.ts
@@ -1,0 +1,2 @@
+export const UUID_REGEX =
+  /^[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}$/;

--- a/packages/steps/src/utils/expodash/__tests__/duplicates-test.ts
+++ b/packages/steps/src/utils/expodash/__tests__/duplicates-test.ts
@@ -1,0 +1,14 @@
+import { duplicates } from '../duplicates.js';
+
+describe(duplicates, () => {
+  it('returns empty list if there are no duplicates', () => {
+    expect(duplicates([1, 2, 3, 4, 5, 6])).toEqual([]);
+  });
+  it('returns duplicates', () => {
+    expect(duplicates([1, 2, 2, 3, 4, 4, 4, 5])).toEqual([2, 4]);
+  });
+  it('works with other item types too', () => {
+    expect(duplicates(['1', '2', '2', '3', '4', '4', '4', '5'])).toEqual(['2', '4']);
+    expect(duplicates([1, '2', '2', 3, 4, 4, 4, '5'])).toEqual(['2', 4]);
+  });
+});

--- a/packages/steps/src/utils/expodash/duplicates.ts
+++ b/packages/steps/src/utils/expodash/duplicates.ts
@@ -1,11 +1,4 @@
-import { uniq } from './uniq.js';
-
 export function duplicates<T = any>(items: T[]): T[] {
-  const uniqueItems = uniq(items);
-  if (uniqueItems.length === items.length) {
-    return [];
-  }
-
   const visitedItemsSet = new Set<T>();
   const duplicatedItemsSet = new Set<T>();
   for (const item of items) {

--- a/packages/steps/src/utils/expodash/duplicates.ts
+++ b/packages/steps/src/utils/expodash/duplicates.ts
@@ -1,0 +1,19 @@
+import { uniq } from './uniq.js';
+
+export function duplicates<T = any>(items: T[]): T[] {
+  const uniqueItems = uniq(items);
+  if (uniqueItems.length === items.length) {
+    return [];
+  }
+
+  const visitedItemsSet = new Set<T>();
+  const duplicatedItemsSet = new Set<T>();
+  for (const item of items) {
+    if (visitedItemsSet.has(item)) {
+      duplicatedItemsSet.add(item);
+    } else {
+      visitedItemsSet.add(item);
+    }
+  }
+  return [...duplicatedItemsSet];
+}


### PR DESCRIPTION
# Why

Currently, steps and functions use only bash scripts. For implementing functions that share the JS context with the runner, we need to be able to run any arbitrary JS code. This'll let us implement features like artifact upload without hacks. The artifact upload logic (uploading to a particular storage like S3/GCS) shouldn't be part of the library. Instead, it should be injected when creating the workflow object. With the current approach, where there's a bash command upload-artifact  that can be run from the user's script, we can't really share the upload implementation with that script.

# How

- https://github.com/expo/eas-build/pull/201/commits/272edc85a8b0ab9c6a19637691c872a8bcec6ce7 removes the build context object from the `BuildFunction` constructor. `BuildFunction`s are going to be used for defining EAS built-in functions. The context is not available at that time.
- https://github.com/expo/eas-build/pull/201/commits/386edc41f010190d1f45c96c9f16638dd15aad54 renames input / output creators to providers. I wanted to make a function for creating creators but `createInputCreator` sounded a bit funny.
- https://github.com/expo/eas-build/pull/201/commits/4996a465d47ae12e067f8eeb96f92937c8e7ebda introduces the `.createProvider` static methods to `BuildStepInput` and `BuildStepOutput` to streamline provider creation.
- https://github.com/expo/eas-build/pull/201/commits/54c87469a3cd33c4f5f917322f2b692755ed7cc2 changes `BuildStep` to either run the `command` (bash script) or JS function provided to the constructor.
- https://github.com/expo/eas-build/pull/201/commits/c9cbc851fe8a583d9bbef8ace0d1d6dbffcf6129 fixes setting IDs for function and step objects.
- https://github.com/expo/eas-build/pull/201/commits/e30bc631c8175c8cc16ac7694a233d7fe9a13a56 adds namespaces for functions so we can define functions like `eas/upload_artifacts`.
- https://github.com/expo/eas-build/pull/201/commits/dc4ea8a8d849999a03378e96bb3ababb75f398aa makes `BuildConfigParser` accept external functions for building workflow object.

# Test Plan

Tests.