### PR TITLE
[ENG-7981] publish eas-cli-local-build-plugin to the latest tag / use the eas-cli tag for EAS CLI

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -8,7 +8,7 @@
 - Run `yarn && yarn start` in root of the repository
 - Test your changes by running build with flag `--local`
 
-You can use the script below to simplify the development process. `./path/to/script build --local` 
+You can use the script below to simplify the development process. `./path/to/script build --local`
 
 ```
 #!/usr/bin/env bash
@@ -26,13 +26,11 @@ eas "$@" # or $HOME/expo/eas-cli/bin/run "$@"
 
 If you want to introduce breaking changes to the `@expo/eas-build-job` package contact one of the [CODEOWNERS](/CODEOWNERS), so we can make sure that legacy cases are still supported on EAS build servers and in GraphQL API. Please describe what changes you want to make and why and we will implement API changes that support both cases. After everything is deployed to production you can introduce PR that relies on the new implementation.
 
-
 Change like that could be e.g. introducing a new required field in the job object. In that case, we would make changes to allow this field and provide default values for legacy requests, but it would be ignored by the build process. After everything is deployed/published, your follow-up PR would introduce logic that is using this new field.
-
 
 ### Updating `local-build-plugin` in EAS CLI
 
-- Run `./scripts/publish.js` (local build plugin will be published as `next`).
+- Run `./scripts/publish.js`.
 - If there are breaking changes, update `eas-build-job` package in EAS CLI and make sure everything works as expected.
-- Tag newly published version as `latest` - `npm dist-tag add eas-cli-local-build-plugin@VERSION latest`.
-- Publish a new EAS CLI version. EAS CLI uses a fixed version of the `eas-cli-local-build-plugin` package, the version is set based on `latest` tag at the publish time.
+- Tag the newly published version as `eas-cli` - `npm dist-tag add eas-cli-local-build-plugin@VERSION eas-cli`.
+- Publish a new EAS CLI version. EAS CLI uses a fixed version of the `eas-cli-local-build-plugin` package, the version is set based on `eas-cli` tag at the publish time.

--- a/scripts/publish.js
+++ b/scripts/publish.js
@@ -70,10 +70,9 @@ async function run() {
     if (shouldPrerelease) {
       args.push('--tag', 'alpha');
     } else if (name === 'eas-cli-local-build-plugin') {
-      args.push('--tag', 'next');
-      console.log(`  using dist-tag 'next', run 'npm dist-tag add ${name}@${version} latest'`);
-      console.log(`  after testing the release to promote it to the latest tag`);
-      console.log(`  in case of breaking changes new eas-cli needs to be released`);
+      console.log(`  Run "npm dist-tag add eas-cli-local-build-plugin@${version} eas-cli"`);
+      console.log(`  to update eas-cli-local-build-plugin in EAS CLI. The version will be`);
+      console.log(`  updated automatically on the next EAS CLI release.`);
     }
 
     await spawnAsync('npm', args, {


### PR DESCRIPTION
# Why

Streamlines eas-cli / eas-build releases.

Currently, the publish script conditionally publishes the local build plugin to the next tag. Instead, we can publish it to latest and tag it with `eas-cli` when we want to update it in EAS CLI.

Companion PR to https://github.com/expo/eas-cli/pull/1759

# How

- Don't tag the local build plugin with `next`. Use `latest` instead.
- Update docs.
- I tagged 0.0.128 with `eas-cli`

<img width="759" alt="Screenshot 2023-03-28 at 10 19 07" src="https://user-images.githubusercontent.com/5256730/228177706-108ce360-5d60-4c52-92da-3353c3262d06.png">


# Test Plan

None.