### PR TITLE
[build-tools] Use `npx expo-doctor` instead of `expo doctor`

### DIFF
--- a/packages/build-tools/src/common/easBuildInternal.ts
+++ b/packages/build-tools/src/common/easBuildInternal.ts
@@ -20,7 +20,7 @@ const EasBuildInternalResultSchema = Joi.object<{ job: object; metadata: object 
 export async function runEasBuildInternalAsync<TJob extends Job>(
   ctx: BuildContext<TJob>
 ): Promise<void> {
-  const { cmd, args, extraEnv } = resolveEasCommandPrefixAndEnv(await isAtLeastNpm7Async());
+  const { cmd, args, extraEnv } = await resolveEasCommandPrefixAndEnvAsync();
   const { buildProfile } = ctx.job;
   assert(buildProfile, 'build profile is missing in a build from git-based integration.');
   const result = await spawn(
@@ -47,7 +47,7 @@ export async function runEasBuildInternalAsync<TJob extends Job>(
 export async function configureEnvFromBuildProfileAsync<TJob extends Job>(
   ctx: BuildContext<TJob>
 ): Promise<void> {
-  const { cmd, args, extraEnv } = resolveEasCommandPrefixAndEnv(await isAtLeastNpm7Async());
+  const { cmd, args, extraEnv } = await resolveEasCommandPrefixAndEnvAsync();
   const { buildProfile } = ctx.job;
   assert(buildProfile, 'build profile is missing in a build from git-based integration.');
   let spawnResult;
@@ -81,12 +81,12 @@ export async function configureEnvFromBuildProfileAsync<TJob extends Job>(
   ctx.updateEnv(env);
 }
 
-function resolveEasCommandPrefixAndEnv(isAtLeastNpm7Async: boolean): {
+async function resolveEasCommandPrefixAndEnvAsync(): Promise<{
   cmd: string;
   args: string[];
   extraEnv: Env;
-} {
-  const npxArgsPrefix = isAtLeastNpm7Async ? ['-y'] : [];
+}> {
+  const npxArgsPrefix = (await isAtLeastNpm7Async()) ? ['-y'] : [];
   if (process.env.ENVIRONMENT === 'development') {
     return {
       cmd: process.env.EAS_BUILD_INTERNAL_EXECUTABLE ?? `eas`,


### PR DESCRIPTION
# Why

`expo doctor` often times out, new implementation should be lighter and resolve that issue

# How

- Use npx to run expo-doctor (even if user is using different package manager)
- Unrelated to the main purpose of this PR, but I also notice that github commands did not check which version of npm was used, so on npm < 7 it would fail because `--yes` parameter was not yet supported at that time.

# Test Plan

Run eas build local and build on local turtle server

![20230329_10h45m47s_grim](https://user-images.githubusercontent.com/9753141/228478945-37489564-6b7e-4f77-8e62-124c42cdc542.png)

