### PR TITLE
[ENG-7819][ENG-7738][steps] add support for default and allowed function input values

### DIFF
--- a/packages/build-tools/src/steps/functions/uploadArtifact.ts
+++ b/packages/build-tools/src/steps/functions/uploadArtifact.ts
@@ -19,11 +19,10 @@ export function createUploadArtifactStepsFunction<T extends Job>(
     id: 'upload_artifact',
     name: 'Upload artifact',
     inputProviders: [
-      // TODO: refactor when BuildStepInput supports "allowedValues" option
-      // either "application-archive" or "build-artifact"
       BuildStepInput.createProvider({
         id: 'type',
         defaultValue: BuildArtifactType.APPLICATION_ARCHIVE,
+        allowedValues: [BuildArtifactType.APPLICATION_ARCHIVE, BuildArtifactType.BUILD_ARTIFACT],
       }),
       BuildStepInput.createProvider({ id: 'path', required: true }),
     ],

--- a/packages/steps/examples/functions/config.yml
+++ b/packages/steps/examples/functions/config.yml
@@ -8,6 +8,9 @@ build:
     - say_hi:
         inputs:
           name: Szymon
+    - say_hi:
+        inputs:
+          greeting: Hello
     - random:
         id: random_number
     - run:
@@ -21,8 +24,12 @@ functions:
   say_hi:
     name: Say HI
     inputs:
-      - name
-    command: echo "Hi, ${ inputs.name }!"
+      - name: name
+        default_value: Brent
+      - name: greeting
+        default_value: Hi
+        allowed_values: [Hi, Hello]
+    command: echo "${ inputs.greeting }, ${ inputs.name }!"
   say_hi_brent:
     name: Say HI
     command: echo "Hi, Brent!"

--- a/packages/steps/src/BuildConfigParser.ts
+++ b/packages/steps/src/BuildConfigParser.ts
@@ -203,7 +203,12 @@ export class BuildConfigParser {
     return buildFunctionInputs.map((entry) => {
       return typeof entry === 'string'
         ? BuildStepInput.createProvider({ id: entry })
-        : BuildStepInput.createProvider({ id: entry.name, required: entry.required ?? true });
+        : BuildStepInput.createProvider({
+            id: entry.name,
+            required: entry.required ?? true,
+            defaultValue: entry.defaultValue,
+            allowedValues: entry.allowedValues,
+          });
     });
   }
 

--- a/packages/steps/src/BuildStep.ts
+++ b/packages/steps/src/BuildStep.ts
@@ -281,10 +281,9 @@ export class BuildStep {
     }
     if (nonSetRequiredOutputIds.length > 0) {
       const idsString = nonSetRequiredOutputIds.map((i) => `"${i}"`).join(', ');
-      throw new BuildStepRuntimeError(
-        `Some required output parameters have not been set: ${idsString}`,
-        { metadata: { ids: nonSetRequiredOutputIds } }
-      );
+      throw new BuildStepRuntimeError(`Some required outputs have not been set: ${idsString}`, {
+        metadata: { ids: nonSetRequiredOutputIds },
+      });
     }
   }
 

--- a/packages/steps/src/BuildStepInput.ts
+++ b/packages/steps/src/BuildStepInput.ts
@@ -63,6 +63,17 @@ export class BuildStepInput {
         `Input parameter "${this.id}" for step "${this.stepDisplayName}" is required.`
       );
     }
+    if (
+      value !== undefined &&
+      this.allowedValues !== undefined &&
+      !this.allowedValues.includes(value)
+    ) {
+      throw new BuildStepRuntimeError(
+        `Value "${value}" for input parameter "${this.id}" for step "${
+          this.stepDisplayName
+        }" is not one of its allowed values: ${this.allowedValues.map((i) => `"${i}"`).join(', ')}.`
+      );
+    }
     this._value = value;
     return this;
   }

--- a/packages/steps/src/BuildStepInput.ts
+++ b/packages/steps/src/BuildStepInput.ts
@@ -33,8 +33,6 @@ export class BuildStepInput {
     private readonly ctx: BuildStepContext,
     { id, stepDisplayName, allowedValues, defaultValue, required = true }: BuildStepInputParams
   ) {
-    this.validateDefaultValue(allowedValues, defaultValue);
-
     this.id = id;
     this.stepDisplayName = stepDisplayName;
     this.allowedValues = allowedValues;
@@ -63,32 +61,16 @@ export class BuildStepInput {
         `Input parameter "${this.id}" for step "${this.stepDisplayName}" is required.`
       );
     }
-    if (
-      value !== undefined &&
-      this.allowedValues !== undefined &&
-      !this.allowedValues.includes(value)
-    ) {
-      throw new BuildStepRuntimeError(
-        `Value "${value}" for input parameter "${this.id}" for step "${
-          this.stepDisplayName
-        }" is not one of its allowed values: ${this.allowedValues.map((i) => `"${i}"`).join(', ')}.`
-      );
-    }
     this._value = value;
     return this;
   }
 
-  private validateDefaultValue(allowedValues?: string[], defaultValue?: string): void {
-    if (allowedValues === undefined || defaultValue === undefined) {
-      return;
+  public isValueOneOfAllowedValues(): boolean {
+    const value = this._value ?? this.defaultValue;
+    if (this.allowedValues === undefined || value === undefined) {
+      return true;
     }
-    if (!allowedValues.includes(defaultValue)) {
-      throw new BuildStepRuntimeError(
-        `Default value "${defaultValue}" for input parameter "${this.id}" for step "${
-          this.stepDisplayName
-        }" is not one of its allowed values: ${allowedValues.map((i) => `"${i}"`).join(', ')}.`
-      );
-    }
+    return this.allowedValues.includes(value);
   }
 }
 

--- a/packages/steps/src/BuildStepOutput.ts
+++ b/packages/steps/src/BuildStepOutput.ts
@@ -7,6 +7,15 @@ export type BuildStepOutputProvider = (
   stepDisplayName: string
 ) => BuildStepOutput;
 
+interface BuildStepOutputProviderParams {
+  id: string;
+  required?: boolean;
+}
+
+interface BuildStepOutputParams extends BuildStepOutputProviderParams {
+  stepDisplayName: string;
+}
+
 export class BuildStepOutput {
   public readonly id: string;
   public readonly stepDisplayName: string;
@@ -14,21 +23,14 @@ export class BuildStepOutput {
 
   private _value?: string;
 
-  public static createProvider(params: {
-    id: string;
-    required?: boolean;
-  }): BuildStepOutputProvider {
+  public static createProvider(params: BuildStepOutputProviderParams): BuildStepOutputProvider {
     return (ctx, stepDisplayName) => new BuildStepOutput(ctx, { ...params, stepDisplayName });
   }
 
   constructor(
     // @ts-expect-error ctx is not used in this class but let's keep it here for consistency
     private readonly ctx: BuildStepContext,
-    {
-      id,
-      stepDisplayName,
-      required = true,
-    }: { id: string; stepDisplayName: string; required?: boolean }
+    { id, stepDisplayName, required = true }: BuildStepOutputParams
   ) {
     this.id = id;
     this.stepDisplayName = stepDisplayName;

--- a/packages/steps/src/BuildStepOutput.ts
+++ b/packages/steps/src/BuildStepOutput.ts
@@ -35,7 +35,7 @@ export class BuildStepOutput {
     this.required = required;
   }
 
-  get value(): string | undefined {
+  public get value(): string | undefined {
     if (this.required && this._value === undefined) {
       throw new BuildStepRuntimeError(
         `Output parameter "${this.id}" for step "${this.stepDisplayName}" is required but it was not set.`
@@ -44,7 +44,7 @@ export class BuildStepOutput {
     return this._value;
   }
 
-  set(value: string | undefined): BuildStepOutput {
+  public set(value: string | undefined): BuildStepOutput {
     if (this.required && value === undefined) {
       throw new BuildStepRuntimeError(
         `Output parameter "${this.id}" for step "${this.stepDisplayName}" is required.`

--- a/packages/steps/src/BuildWorkflowValidator.ts
+++ b/packages/steps/src/BuildWorkflowValidator.ts
@@ -2,6 +2,7 @@ import { BuildStep } from './BuildStep.js';
 import { BuildWorkflow } from './BuildWorkflow.js';
 import { BuildConfigError, BuildWorkflowError } from './errors.js';
 import { duplicates } from './utils/expodash/duplicates.js';
+import { nullthrows } from './utils/nullthrows.js';
 import { findOutputPaths } from './utils/template.js';
 
 export class BuildWorkflowValidator {
@@ -38,6 +39,18 @@ export class BuildWorkflowValidator {
       for (const currentStepInput of currentStep.inputs ?? []) {
         if (currentStepInput.defaultValue === undefined) {
           continue;
+        }
+        if (!currentStepInput.isValueOneOfAllowedValues()) {
+          const error = new BuildConfigError(
+            `Input parameter "${currentStepInput.id}" for step "${
+              currentStep.displayName
+            }" is set to "${
+              currentStepInput.value
+            }" which is not one of the allowed values: ${nullthrows(currentStepInput.allowedValues)
+              .map((i) => `"${i}"`)
+              .join(', ')}.`
+          );
+          errors.push(error);
         }
         const paths = findOutputPaths(currentStepInput.defaultValue);
         for (const { stepId: referencedStepId, outputId: referencedStepOutputId } of paths) {

--- a/packages/steps/src/__tests__/BuildConfig-test.ts
+++ b/packages/steps/src/__tests__/BuildConfig-test.ts
@@ -283,8 +283,66 @@ describe(validateBuildConfig, () => {
       expect(error.message).toMatch(/"functions\.eas\/download_project" is not allowed/);
       expect(error.message).toMatch(/"functions\.!@#\$" is not allowed/);
       expect(error.message).not.toMatch(/"functions\.foo" is not allowed/);
+      expect(error.message).not.toMatch(/"functions\.upload_artifact" is not allowed/);
       expect(error.message).not.toMatch(/"functions\.build-project" is not allowed/);
-      expect(error.message).not.toMatch(/"functions\.build-project" is not allowed/);
+    });
+    test('invalid default and allowed values for function inputs', () => {
+      const buildConfig = {
+        build: {
+          steps: ['abc'],
+        },
+        functions: {
+          abc: {
+            inputs: [
+              {
+                name: 'i1',
+                default_value: 1,
+              },
+              {
+                name: 'i2',
+                default_value: '1',
+                allowed_values: ['2', '3'],
+              },
+            ],
+            command: 'echo "${ inputs.i1 } ${ inputs.i2 }"',
+          },
+        },
+      };
+
+      const error = getError<Error>(() => {
+        validateBuildConfig(buildConfig, []);
+      });
+      expect(error.message).toMatch(/"functions.abc.inputs\[0\].defaultValue" must be a string/);
+      expect(error.message).toMatch(
+        /"functions.abc.inputs\[1\].defaultValue" must be one of allowed values/
+      );
+    });
+    test('valid default and allowed values for function inputs', () => {
+      const buildConfig = {
+        build: {
+          steps: ['abc'],
+        },
+        functions: {
+          abc: {
+            inputs: [
+              {
+                name: 'i1',
+                default_value: '1',
+              },
+              {
+                name: 'i2',
+                default_value: '1',
+                allowed_values: ['1', '2'],
+              },
+            ],
+            command: 'echo "${ inputs.i1 } ${ inputs.i2 }"',
+          },
+        },
+      };
+
+      expect(() => {
+        validateBuildConfig(buildConfig, []);
+      }).not.toThrow();
     });
   });
 });

--- a/packages/steps/src/__tests__/BuildConfigParser-test.ts
+++ b/packages/steps/src/__tests__/BuildConfigParser-test.ts
@@ -227,7 +227,7 @@ describe(BuildConfigParser, () => {
       const workflow = await parser.parseAsync();
 
       const { buildSteps } = workflow;
-      expect(buildSteps.length).toBe(5);
+      expect(buildSteps.length).toBe(6);
 
       // - say_hi:
       //     inputs:
@@ -285,8 +285,26 @@ describe(BuildConfigParser, () => {
       expect(step5.inputs?.[0].id).toBe('value');
       expect(step5.inputs?.[0].required).toBe(true);
 
+      // - say_hi_2:
+      //     inputs:
+      //       greeting: Hello
+      const step6 = buildSteps[5];
+      expect(step6.id).toMatch(UUID_REGEX);
+      expect(step6.name).toBe('Hi!');
+      expect(step6.command).toBe('echo "${ inputs.greeting }, ${ inputs.name }!"');
+      expect(step6.ctx.workingDirectory).toBe(ctx.workingDirectory);
+      expect(step6.shell).toBe(getDefaultShell());
+      expect(step6.inputs?.[0].id).toBe('greeting');
+      expect(step6.inputs?.[0].required).toBe(true);
+      expect(step6.inputs?.[0].defaultValue).toBe('Hi');
+      expect(step6.inputs?.[0].allowedValues).toEqual(['Hi', 'Hello']);
+      expect(step6.inputs?.[1].id).toBe('name');
+      expect(step6.inputs?.[1].required).toBe(true);
+      expect(step6.inputs?.[1].defaultValue).toBe('Brent');
+      expect(step6.inputs?.[1].allowedValues).toEqual(undefined);
+
       const { buildFunctions } = workflow;
-      expect(Object.keys(buildFunctions).length).toBe(4);
+      expect(Object.keys(buildFunctions).length).toBe(5);
 
       // say_hi:
       //   name: Hi!
@@ -330,6 +348,27 @@ describe(BuildConfigParser, () => {
       expect(function4.inputProviders?.[0](ctx, 'unknown-step').id).toBe('value');
       expect(function4.inputProviders?.[0](ctx, 'unknown-step').required).toBe(true);
       expect(function4.command).toBe('echo "${ inputs.value }"');
+
+      // say_hi_2:
+      //   name: Hi!
+      //   inputs:
+      //     - name: greeting
+      //       default_value: Hi
+      //       allowed_values: [Hi, Hello]
+      //     - name: name
+      //       default_value: Brent
+      //   command: echo "${ inputs.greeting }, ${ inputs.name }!"
+      const function5 = buildFunctions.say_hi_2;
+      expect(function5.id).toBe('say_hi_2');
+      expect(function5.name).toBe('Hi!');
+      expect(function5.inputProviders?.[0](ctx, 'unknown-step').id).toBe('greeting');
+      expect(function5.inputProviders?.[0](ctx, 'unknown-step').required).toBe(true);
+      expect(function5.inputProviders?.[0](ctx, 'unknown-step').defaultValue).toBe('Hi');
+      expect(function5.inputProviders?.[0](ctx, 'unknown-step').allowedValues).toEqual([
+        'Hi',
+        'Hello',
+      ]);
+      expect(function5.command).toBe('echo "${ inputs.greeting }, ${ inputs.name }!"');
     });
 
     it('throws if calling non-existent external functions', async () => {

--- a/packages/steps/src/__tests__/BuildFunction-test.ts
+++ b/packages/steps/src/__tests__/BuildFunction-test.ts
@@ -99,7 +99,7 @@ describe(BuildFunction, () => {
       expect(step.id).toBe('test2');
       expect(step.shell).toBe('/bin/zsh');
     });
-    it('creates function input and output parameters', () => {
+    it('creates function inputs and outputs', () => {
       const ctx = createMockContext();
       const inputProviders: BuildStepInputProvider[] = [
         BuildStepInput.createProvider({ id: 'input1' }),

--- a/packages/steps/src/__tests__/BuildStep-test.ts
+++ b/packages/steps/src/__tests__/BuildStep-test.ts
@@ -273,7 +273,7 @@ describe(BuildStep, () => {
         expect(lines.find((line) => line.match('expo-ghi789'))).toBeTruthy();
       });
 
-      it('interpolates the input parameters in command template', async () => {
+      it('interpolates the inputs in command template', async () => {
         const id = 'test1';
         const command = 'set-output foo2 ${ inputs.foo1 }';
         const displayName = BuildStep.getDisplayName({ id, command });
@@ -302,7 +302,7 @@ describe(BuildStep, () => {
         expect(step.getOutputValueByName('foo2')).toBe('bar');
       });
 
-      it('collects the output parameters after calling the script', async () => {
+      it('collects the outputs after calling the script', async () => {
         const id = 'test1';
         const command = 'set-output abc 123';
         const displayName = BuildStep.getDisplayName({ id, command });
@@ -346,7 +346,7 @@ describe(BuildStep, () => {
         expect(abc?.value).toBe('d o m i n i k');
       });
 
-      it('prints a warning if some of the output parameters set with set-output are not defined in step config', async () => {
+      it('prints a warning if some of the outputs set with set-output are not defined in step config', async () => {
         const logger = createMockLogger();
         const warnLines: string[] = [];
         jest.mocked(logger.warn as any).mockImplementation((line: string) => {
@@ -370,7 +370,7 @@ describe(BuildStep, () => {
         expect(found).not.toBeUndefined();
       });
 
-      it('throws an error if some required output parameters have not been set with set-output in script', async () => {
+      it('throws an error if some required outputs have not been set with set-output in script', async () => {
         const id = 'test1';
         const command = 'echo 123';
         const displayName = BuildStep.getDisplayName({ id, command });
@@ -390,7 +390,7 @@ describe(BuildStep, () => {
         });
         const error = await getErrorAsync<BuildStepRuntimeError>(async () => step.executeAsync());
         expect(error).toBeInstanceOf(BuildStepRuntimeError);
-        expect(error.message).toMatch(/Some required output parameters have not been set: "abc"/);
+        expect(error.message).toMatch(/Some required outputs have not been set: "abc"/);
       });
     });
 
@@ -417,7 +417,7 @@ describe(BuildStep, () => {
         );
       });
 
-      it('passes input and output parameters to the function', async () => {
+      it('passes input and outputs to the function', async () => {
         const env = { TEST_VAR_1: 'abc' };
 
         const id = 'test1';

--- a/packages/steps/src/__tests__/BuildStepInput-test.ts
+++ b/packages/steps/src/__tests__/BuildStepInput-test.ts
@@ -55,31 +55,6 @@ describe(BuildStepInput, () => {
       new BuildStepRuntimeError('Input parameter "foo" for step "test1" is required.')
     );
   });
-
-  test('throws an error if default value is not one of the allowed values', () => {
-    const ctx = createMockContext();
-    expect(() => {
-      // eslint-disable-next-line no-new
-      new BuildStepInput(ctx, {
-        id: 'foo',
-        stepDisplayName: BuildStep.getDisplayName({ id: 'test1' }),
-        allowedValues: ['1', '2', '3'],
-        defaultValue: '4',
-      });
-    }).toThrowError(/is not one of its allowed values/);
-  });
-
-  test('setting non-allowed value', () => {
-    const ctx = createMockContext();
-    const input = new BuildStepInput(ctx, {
-      id: 'foo',
-      stepDisplayName: BuildStep.getDisplayName({ id: 'test1' }),
-      allowedValues: ['1', '2', '3'],
-    });
-    expect(() => {
-      input.set('5');
-    }).toThrowError(/is not one of its allowed values/);
-  });
 });
 
 describe(makeBuildStepInputByIdMap, () => {

--- a/packages/steps/src/__tests__/BuildStepInput-test.ts
+++ b/packages/steps/src/__tests__/BuildStepInput-test.ts
@@ -33,7 +33,7 @@ describe(BuildStepInput, () => {
       required: true,
     });
     expect(() => {
-      // eslint-disable-next-line
+      // eslint-disable-next-line @typescript-eslint/no-unused-expressions
       i.value;
     }).toThrowError(
       new BuildStepRuntimeError(
@@ -54,6 +54,19 @@ describe(BuildStepInput, () => {
     }).toThrowError(
       new BuildStepRuntimeError('Input parameter "foo" for step "test1" is required.')
     );
+  });
+
+  test('throws an error if default value is not one of the allowed values', () => {
+    const ctx = createMockContext();
+    expect(() => {
+      // eslint-disable-next-line no-new
+      new BuildStepInput(ctx, {
+        id: 'foo',
+        stepDisplayName: BuildStep.getDisplayName({ id: 'test1' }),
+        allowedValues: ['1', '2', '3'],
+        defaultValue: '4',
+      });
+    }).toThrowError(/is not one of its allowed values/);
   });
 });
 

--- a/packages/steps/src/__tests__/BuildStepInput-test.ts
+++ b/packages/steps/src/__tests__/BuildStepInput-test.ts
@@ -68,6 +68,18 @@ describe(BuildStepInput, () => {
       });
     }).toThrowError(/is not one of its allowed values/);
   });
+
+  test('setting non-allowed value', () => {
+    const ctx = createMockContext();
+    const input = new BuildStepInput(ctx, {
+      id: 'foo',
+      stepDisplayName: BuildStep.getDisplayName({ id: 'test1' }),
+      allowedValues: ['1', '2', '3'],
+    });
+    expect(() => {
+      input.set('5');
+    }).toThrowError(/is not one of its allowed values/);
+  });
 });
 
 describe(makeBuildStepInputByIdMap, () => {

--- a/packages/steps/src/__tests__/fixtures/functions.yml
+++ b/packages/steps/src/__tests__/fixtures/functions.yml
@@ -14,6 +14,9 @@ build:
     - print:
         inputs:
           value: ${ steps.random_number.value }
+    - say_hi_2:
+        inputs:
+          greeting: Hello
 
 functions:
   say_hi:
@@ -31,3 +34,12 @@ functions:
   print:
     inputs: [value]
     command: echo "${ inputs.value }"
+  say_hi_2:
+    name: Hi!
+    inputs:
+      - name: greeting
+        default_value: Hi
+        allowed_values: [Hi, Hello]
+      - name: name
+        default_value: Brent
+    command: echo "${ inputs.greeting }, ${ inputs.name }!"

--- a/packages/steps/src/cli/cli.ts
+++ b/packages/steps/src/cli/cli.ts
@@ -5,6 +5,7 @@ import { v4 as uuidv4 } from 'uuid';
 
 import { BuildConfigParser } from '../BuildConfigParser.js';
 import { BuildStepContext } from '../BuildStepContext.js';
+import { BuildWorkflowError } from '../errors.js';
 
 const logger = createLogger({
   name: 'steps-cli',
@@ -32,4 +33,10 @@ const workingDirectory = path.resolve(process.cwd(), relativeWorkingDirectoryPat
 
 runAsync(configPath, workingDirectory).catch((err) => {
   logger.error({ err }, 'Build failed');
+  if (err instanceof BuildWorkflowError) {
+    logger.error('Failed to parse the custom build config file.');
+    for (const detailedErr of err.errors) {
+      logger.error({ err: detailedErr });
+    }
+  }
 });


### PR DESCRIPTION
Adds support for "default_value" and "allowed_values" in reusable function inputs.

Example:
```
  say_hi:
    name: Say Hi!
    inputs:
      - name: name
        default_value: Brent
      - name: greeting
        default_value: Hi
        allowed_values: [Hi, Hello]
    command: echo "${ inputs.greeting }, ${ inputs.name }!"
```

- `name` defaults to "Brent".
- `greeting` defaults to "Hi".
- `greeting` can be either "Hi" or "Hello".

# Test Plan

- Tests. 
- Tested manually with https://github.com/expo/eas-custom-builds-example/pull/2
- Updated the `functions` example.
