### PR TITLE
[build-tools] Fix timeout on doctor command

### DIFF
--- a/packages/build-tools/src/android/gradle.ts
+++ b/packages/build-tools/src/android/gradle.ts
@@ -7,7 +7,7 @@ import fs from 'fs-extra';
 import { bunyan } from '@expo/logger';
 
 import { BuildContext } from '../context';
-import { getAllChildrenRecursiveAsync } from '../utils/processes';
+import { getParentAndDescendantProcessPidsAsync } from '../utils/processes';
 
 export async function ensureLFLineEndingsInGradlewScript<TJob extends Job>(
   ctx: BuildContext<TJob>
@@ -57,7 +57,7 @@ function adjustOOMScore(spawnPromise: SpawnPromise<SpawnResult>, logger: bunyan)
     async () => {
       try {
         assert(spawnPromise.child.pid);
-        const children = await getAllChildrenRecursiveAsync(spawnPromise.child.pid);
+        const children = await getParentAndDescendantProcessPidsAsync(spawnPromise.child.pid);
         await Promise.all(
           children.map(async (pid: number) => {
             // Value 800 is just a guess here. It's probably higher than most other

--- a/packages/build-tools/src/android/gradle.ts
+++ b/packages/build-tools/src/android/gradle.ts
@@ -57,9 +57,9 @@ function adjustOOMScore(spawnPromise: SpawnPromise<SpawnResult>, logger: bunyan)
     async () => {
       try {
         assert(spawnPromise.child.pid);
-        const children = await getParentAndDescendantProcessPidsAsync(spawnPromise.child.pid);
+        const pids = await getParentAndDescendantProcessPidsAsync(spawnPromise.child.pid);
         await Promise.all(
-          children.map(async (pid: number) => {
+          pids.map(async (pid: number) => {
             // Value 800 is just a guess here. It's probably higher than most other
             // process. I didn't want to set it any higher, because I'm not sure if OOM Killer
             // can start killing processes when there is still enough memory left.

--- a/packages/build-tools/src/common/setup.ts
+++ b/packages/build-tools/src/common/setup.ts
@@ -111,7 +111,8 @@ async function runExpoDoctor<TJob extends Job>(ctx: BuildContext<TJob>): Promise
     timeout = setTimeout(async () => {
       timedOut = true;
       const ppid = nullthrows(promise.child.pid);
-      (await getParentAndDescendantProcessPidsAsync(ppid)).forEach((pid) => {
+      const pids = await getParentAndDescendantProcessPidsAsync(ppid);
+      pids.forEach((pid) => {
         process.kill(pid);
       });
       ctx.reportError?.(`"expo doctor" timed out`, undefined, {

--- a/packages/build-tools/src/common/setup.ts
+++ b/packages/build-tools/src/common/setup.ts
@@ -9,7 +9,7 @@ import { Hook, runHookIfPresent } from '../utils/hooks';
 import { createNpmrcIfNotExistsAsync, logIfNpmrcExistsAsync } from '../utils/npmrc';
 import { isAtLeastNpm7Async } from '../utils/packageManager';
 import { readPackageJson, shouldUseGlobalExpoCli } from '../utils/project';
-import { getAllChildrenRecursiveAsync } from '../utils/processes';
+import { getParentAndDescendantProcessPidsAsync } from '../utils/processes';
 
 import { prepareProjectSourcesAsync } from './projectSources';
 import { installDependenciesAsync } from './installDependencies';
@@ -111,7 +111,7 @@ async function runExpoDoctor<TJob extends Job>(ctx: BuildContext<TJob>): Promise
     timeout = setTimeout(async () => {
       timedOut = true;
       const ppid = nullthrows(promise.child.pid);
-      (await getAllChildrenRecursiveAsync(ppid)).forEach((pid) => {
+      (await getParentAndDescendantProcessPidsAsync(ppid)).forEach((pid) => {
         process.kill(pid);
       });
       ctx.reportError?.(`"expo doctor" timed out`, undefined, {

--- a/packages/build-tools/src/utils/processes.ts
+++ b/packages/build-tools/src/utils/processes.ts
@@ -1,0 +1,28 @@
+import spawn from '@expo/turtle-spawn';
+
+async function getChildrenPidsAsync(parentPids: number[]): Promise<number[]> {
+  const result = await spawn('pgrep', ['-P', parentPids.join(',')], {
+    stdio: 'pipe',
+  });
+  return result.stdout
+    .toString()
+    .split('\n')
+    .map((i) => Number(i.trim()))
+    .filter((i) => i);
+}
+
+export async function getAllChildrenRecursiveAsync(ppid: number): Promise<number[]> {
+  const children: number[] = [ppid];
+  let shouldRetry = true;
+  while (shouldRetry) {
+    const pids = await getChildrenPidsAsync(children);
+    shouldRetry = false;
+    for (const pid of pids) {
+      if (!children.includes(pid)) {
+        shouldRetry = true;
+        children.push(pid);
+      }
+    }
+  }
+  return children;
+}

--- a/packages/build-tools/src/utils/processes.ts
+++ b/packages/build-tools/src/utils/processes.ts
@@ -11,18 +11,18 @@ async function getChildrenPidsAsync(parentPids: number[]): Promise<number[]> {
     .filter((i) => i);
 }
 
-export async function getAllChildrenRecursiveAsync(ppid: number): Promise<number[]> {
-  const children: number[] = [ppid];
-  let shouldRetry = true;
-  while (shouldRetry) {
-    const pids = await getChildrenPidsAsync(children);
-    shouldRetry = false;
+export async function getParentAndDescendantProcessPidsAsync(ppid: number): Promise<number[]> {
+  const children = new Set<number>([ppid]);
+  let shouldCheckAgain = true;
+  while (shouldCheckAgain) {
+    const pids = await getChildrenPidsAsync([...children]);
+    shouldCheckAgain = false;
     for (const pid of pids) {
-      if (!children.includes(pid)) {
-        shouldRetry = true;
-        children.push(pid);
+      if (!children.has(pid)) {
+        shouldCheckAgain = true;
+        children.add(pid);
       }
     }
   }
-  return children;
+  return [...children];
 }


### PR DESCRIPTION
# Why

Fixes for doctor command

# How

- When process is timing out current implementation does not kill it properly, most likely it's sth npx is doing. Even SIGKILL does not work, it only kills npx process, but actual code keeps running. Given that I'm looking for all children of a process recursively and killing them all.
- New doctor does not support sdks <46, so I'm falling back to the old doctor
- Number of timeouts increased very significantly, plus we are using npx now, so there is additional overhead of running a doctor command, so I'm increasing timeout from 20 seconds to 30.

# Test Plan

Tested with local builds for both new sdks and old ones (with timeout small enough to trigger and when command had time to finish)
Did not test on macOS
