### PR TITLE
[build-tools] ignore pgrep errors

### DIFF
--- a/packages/build-tools/src/utils/processes.ts
+++ b/packages/build-tools/src/utils/processes.ts
@@ -1,14 +1,18 @@
 import spawn from '@expo/turtle-spawn';
 
 async function getChildrenPidsAsync(parentPids: number[]): Promise<number[]> {
-  const result = await spawn('pgrep', ['-P', parentPids.join(',')], {
-    stdio: 'pipe',
-  });
-  return result.stdout
-    .toString()
-    .split('\n')
-    .map((i) => Number(i.trim()))
-    .filter((i) => i);
+  try {
+    const result = await spawn('pgrep', ['-P', parentPids.join(',')], {
+      stdio: 'pipe',
+    });
+    return result.stdout
+      .toString()
+      .split('\n')
+      .map((i) => Number(i.trim()))
+      .filter((i) => i);
+  } catch {
+    return [];
+  }
 }
 
 export async function getParentAndDescendantProcessPidsAsync(ppid: number): Promise<number[]> {


### PR DESCRIPTION
# Why

When e.g. npm registry is down `npx expo-doctor` will hang before spawning any child processes, so the doctor command will hang for 5 minutes. I noticed that only because the npm cache on staging was broken.

# How

Catch any pgrep errors, so in case of any issues, at least parent process receives a kill signal.

# Test Plan

Set npm registry to fake address and run local builds.
