### PR TITLE
[ENG-7968][eas-build-job] deprecate `cache.cacheDefaultPaths` field in `Job` interface

### DIFF
--- a/packages/eas-build-job/src/common.ts
+++ b/packages/eas-build-job/src/common.ts
@@ -115,7 +115,10 @@ export interface Cache {
   disabled: boolean;
   clear: boolean;
   key?: string;
-  cacheDefaultPaths: boolean;
+  /**
+   * @deprecated We don't cache anything by default anymore.
+   */
+  cacheDefaultPaths?: boolean;
   customPaths: string[];
 }
 


### PR DESCRIPTION
# Why

https://linear.app/expo/issue/ENG-7968/do-not-cache-podfilelock-by-default

# How

Deprecate the field.

# Test Plan

Tests