### PR TITLE
[eas-build-job] allow for undefined `cacheDefaultPaths` in Joi schema

### DIFF
--- a/packages/eas-build-job/src/common.ts
+++ b/packages/eas-build-job/src/common.ts
@@ -126,7 +126,7 @@ export const CacheSchema = Joi.object({
   disabled: Joi.boolean().default(false),
   clear: Joi.boolean().default(false),
   key: Joi.string().allow('').max(128),
-  cacheDefaultPaths: Joi.boolean().default(true),
+  cacheDefaultPaths: Joi.boolean(),
   customPaths: Joi.array().items(Joi.string()).default([]),
 });
 


### PR DESCRIPTION
# Why

In https://github.com/expo/eas-build/pull/213 I haven't deleted the default for `cacheDefaultPaths`

# How

Don't apply default in Joi schema

# Test Plan

Tests
