### PR TITLE
[eas-build] [ENG-8120] Add `paths` to `Cache` definition

### DIFF
--- a/packages/build-tools/src/ios/credentials/__tests__/manager.test.ios.ts
+++ b/packages/build-tools/src/ios/credentials/__tests__/manager.test.ios.ts
@@ -43,8 +43,7 @@ function createTestIosJob({
     cache: {
       clear: false,
       disabled: false,
-      cacheDefaultPaths: true,
-      customPaths: [],
+      paths: [],
     },
     secrets: {
       buildCredentials,

--- a/packages/eas-build-job/src/common.ts
+++ b/packages/eas-build-job/src/common.ts
@@ -119,7 +119,11 @@ export interface Cache {
    * @deprecated We don't cache anything by default anymore.
    */
   cacheDefaultPaths?: boolean;
-  customPaths: string[];
+  /**
+   * @deprecated We use paths now since there is no default caching anymore.
+   */
+  customPaths?: string[];
+  paths: string[];
 }
 
 export const CacheSchema = Joi.object({
@@ -128,6 +132,7 @@ export const CacheSchema = Joi.object({
   key: Joi.string().allow('').max(128),
   cacheDefaultPaths: Joi.boolean(),
   customPaths: Joi.array().items(Joi.string()).default([]),
+  paths: Joi.array().items(Joi.string()).default([]),
 });
 
 export interface BuildPhaseStats {


### PR DESCRIPTION
Deprecated the old `customPaths` fields and added an analogous `paths` field to `Cache` definition and schema

# Why

As per [ENG-8120](https://linear.app/expo/issue/ENG-8120/rename-cachecustompaths-to-cachepaths-in-easjson-and-job-schema) after disabling the default caching paths it doesn't make much sense to have a `customPaths` field so it was decided to simply use `paths` instead

# How

Added a new field `paths` with the same definition as `customPaths`, while keeping the old field but marking it as deprecated for backwards compatibility.

# Test Plan

Tests will be conducted within the scope of `eas-cli` and `turtle-v2` once updated `eas-build` is utilised.
