### PR TITLE
[eas-build-job] [ENG-8120] Remove default from `cache.customPaths`

### DIFF
--- a/packages/eas-build-job/src/common.ts
+++ b/packages/eas-build-job/src/common.ts
@@ -131,7 +131,7 @@ export const CacheSchema = Joi.object({
   clear: Joi.boolean().default(false),
   key: Joi.string().allow('').max(128),
   cacheDefaultPaths: Joi.boolean(),
-  customPaths: Joi.array().items(Joi.string()).default([]),
+  customPaths: Joi.array().items(Joi.string()),
   paths: Joi.array().items(Joi.string()).default([]),
 });
 


### PR DESCRIPTION
Removed the default value from schema definition so that `sanitizeJob` doesn't set the value for the field after it is removed

# Why

For `sanitizeJob` not to set the value for the `customPaths` field after it is removed
See: https://linear.app/expo/issue/ENG-8120/rename-cachecustompaths-to-cachepaths-in-easjson-and-job-schema

# How

Removed the default value from `CacheSchema` definition

# Test Plan

-
