### PR TITLE
[ENG-7650][eas-build-job] add custom workflow name to build metadata

### DIFF
--- a/packages/eas-build-job/src/__tests__/metadata.test.ts
+++ b/packages/eas-build-job/src/__tests__/metadata.test.ts
@@ -21,6 +21,7 @@ describe('MetadataSchema', () => {
       runFromCI: true,
       runWithNoWaitFlag: true,
       buildMode: 'build',
+      customWorkflowName: 'blah blah',
     };
     const { value, error } = MetadataSchema.validate(metadata, {
       stripUnknown: true,
@@ -49,6 +50,7 @@ describe('MetadataSchema', () => {
       runFromCI: true,
       runWithNoWaitFlag: true,
       buildMode: 'resign',
+      customWorkflowName: 'blah blah',
     };
     const { error } = MetadataSchema.validate(metadata, {
       stripUnknown: true,

--- a/packages/eas-build-job/src/metadata.ts
+++ b/packages/eas-build-job/src/metadata.ts
@@ -139,6 +139,11 @@ export type Metadata = {
    * Build mode
    */
   buildMode?: 'build' | 'resign' | 'custom';
+
+  /**
+   * Workflow name available for custom builds.
+   */
+  customWorkflowName?: string;
 };
 
 export const MetadataSchema = Joi.object({
@@ -168,6 +173,7 @@ export const MetadataSchema = Joi.object({
   runFromCI: Joi.boolean(),
   runWithNoWaitFlag: Joi.boolean(),
   buildMode: Joi.string().valid('build', 'resign', 'custom'),
+  customWorkflowName: Joi.string(),
 });
 
 export function sanitizeMetadata(metadata: object): Metadata {


### PR DESCRIPTION
# Why

We want to display the custom build workflow name on the website.

# How

Add `customWorkflowName` to metadata.
It's gonna be set to the value of https://github.com/expo/eas-build/blob/main/packages/steps/examples/simple/config.yml#L2

# Test Plan

Updated test.
