### PR TITLE
[steps] support platform check for reusable functions

### DIFF
--- a/packages/steps/src/BuildConfig.ts
+++ b/packages/steps/src/BuildConfig.ts
@@ -150,7 +150,7 @@ const BuildStepConfigSchema = Joi.any<BuildStepConfig>()
 
 const BuildFunctionConfigSchema = Joi.object({
   name: Joi.string(),
-  platforms: Joi.string().allow(...Object.values(BuildPlatform)),
+  platforms: Joi.array().allow(...Object.values(BuildPlatform)),
   inputs: BuildFunctionInputsSchema,
   outputs: BuildStepOutputsSchema,
   command: Joi.string().required(),

--- a/packages/steps/src/__tests__/BuildConfig-test.ts
+++ b/packages/steps/src/__tests__/BuildConfig-test.ts
@@ -93,6 +93,14 @@ describe(readAndValidateBuildFunctionsConfigFileAsync, () => {
     expect(config.configFilesToImport?.[0]).toBe('functions-file-2.yml');
     expect(config.functions?.say_hi).toBeDefined();
   });
+
+  test('valid functions with platform property config', async () => {
+    const config = await readAndValidateBuildFunctionsConfigFileAsync(
+      path.join(__dirname, './fixtures/functions-with-platforms-property.yml')
+    );
+    expect(typeof config).toBe('object');
+    expect(config.functions?.say_hi).toBeDefined();
+  });
 });
 
 describe(readRawBuildConfigAsync, () => {

--- a/packages/steps/src/__tests__/fixtures/functions-with-platforms-property.yml
+++ b/packages/steps/src/__tests__/fixtures/functions-with-platforms-property.yml
@@ -1,0 +1,7 @@
+functions:
+  say_hi:
+    name: Hi!
+    inputs:
+      - name
+    command: echo "Hi, ${ inputs.name }!"
+    platforms: ['darwin', 'linux']


### PR DESCRIPTION
# Why

https://linear.app/expo/issue/ENG-7737/support-platform-check-for-reusable-functions

# How

@dsokal already added `platforms` as an accepted parameter for `functions` in our Joi schema etc.

In this PR I wrap a `BuildStepFunction` in another `BuildStepFunction` performing runtime platform assertion before calling the actual underlying function when the `platforms` property is specified.

# Test Plan

Add automated tests
