### PR TITLE
[ENG-8519] set up test coverage bot for @expo/steps

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -2,23 +2,26 @@ name: Run tests
 on:
   push:
     branches: [main]
+    paths:
+        - 'packages/steps/**'
+        - '.github/workflows/coverage.yml'
   pull_request:
     types: [opened, synchronize]
+    paths:
+        - 'packages/steps/**'
+        - '.github/workflows/coverage.yml'
 
 jobs:
   test:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node: ['14', '16', '18']
-    name: Test with Node ${{ matrix.node }} on Linux
+    name: '@expo/steps code coverage'
     steps:
       - uses: actions/checkout@v2
       - name: Setup node
         uses: actions/setup-node@v1
         with:
-          node-version: ${{ matrix.node }}
+          node-version: 18
       - run: yarn install --frozen-lockfile --check-files
       - run: yarn build
-      - run: yarn test
-      - run: yarn lint --max-warnings=0
+      - run: yarn test:coverage
+      - uses: codecov/codecov-action@v1

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    name: '@expo/steps code coverage'
+    name: '"@expo/steps" code coverage'
     steps:
       - uses: actions/checkout@v2
       - name: Setup node

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,9 @@ jobs:
     strategy:
       matrix:
         node: ['14', '16', '18']
+        include:
+          - node: '18'
+            coverage: true
     name: Test with Node ${{ matrix.node }} on Linux
     steps:
       - uses: actions/checkout@v2
@@ -21,4 +24,10 @@ jobs:
       - run: yarn install --frozen-lockfile --check-files
       - run: yarn build
       - run: yarn test
+        if: ${{ !matrix.coverage }}
       - run: yarn lint --max-warnings=0
+        if: ${{ matrix.coverage }}
+      - uses: codecov/codecov-action@v1
+        if: ${{ matrix.coverage }}
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
       - run: yarn build
       - run: yarn test
       - run: yarn lint --max-warnings=0
-      - run: yarn test --coverage
+      - run: yarn test:coverage
         if: ${{ matrix.coverage }}
       - uses: codecov/codecov-action@v1
         if: ${{ matrix.coverage }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,7 @@ jobs:
       - run: yarn test
         if: ${{ !matrix.coverage }}
       - run: yarn lint --max-warnings=0
+      - run: yarn test --coverage
         if: ${{ matrix.coverage }}
       - uses: codecov/codecov-action@v1
         if: ${{ matrix.coverage }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,6 @@ jobs:
       - run: yarn install --frozen-lockfile --check-files
       - run: yarn build
       - run: yarn test
-        if: ${{ !matrix.coverage }}
       - run: yarn lint --max-warnings=0
       - run: yarn test --coverage
         if: ${{ matrix.coverage }}

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,13 @@
+comment: false
+coverage:
+  round: up
+  precision: 2
+  range: 30..100
+  status:
+    patch: false
+    project:
+      steps:
+        informational: true
+        paths:
+          - packages/steps
+

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "lerna bootstrap && lerna run build",
     "lint": "eslint 'packages/*/src/**/*.ts'",
     "test": "lerna run test",
+    "test:coverage": "lerna run test:coverage",
     "clean": "lerna run clean && rm -rf node_modules",
     "release": "./scripts/release.sh"
   },

--- a/packages/build-tools/jest.config.js
+++ b/packages/build-tools/jest.config.js
@@ -6,9 +6,6 @@ module.exports = {
     '**/__tests__/*.test.ts',
     ...(process.platform === 'darwin' ? ['**/__tests__/*.test.ios.ts'] : []),
   ],
-  collectCoverage: true,
-  coverageReporters: ['json', 'lcov'],
-  coverageDirectory: '../coverage/tests/',
   clearMocks: true,
   setupFilesAfterEnv: ['<rootDir>/../jest/setup-tests.ts'],
 };

--- a/packages/downloader/jest.config.js
+++ b/packages/downloader/jest.config.js
@@ -3,9 +3,6 @@ module.exports = {
   testEnvironment: 'node',
   rootDir: 'src',
   testMatch: ['**/__tests__/*.test.ts'],
-  collectCoverage: true,
-  coverageReporters: ['json', 'lcov'],
-  coverageDirectory: '../coverage/tests/',
   clearMocks: true,
   setupFilesAfterEnv: ['<rootDir>/../jest/setup-tests.ts'],
 };

--- a/packages/eas-build-job/jest.config.js
+++ b/packages/eas-build-job/jest.config.js
@@ -3,9 +3,6 @@ module.exports = {
   testEnvironment: 'node',
   rootDir: 'src',
   testMatch: ['**/__tests__/*.test.ts'],
-  collectCoverage: true,
-  coverageReporters: ['json', 'lcov'],
-  coverageDirectory: '../coverage/tests/',
   clearMocks: true,
   setupFilesAfterEnv: ['<rootDir>/../jest/setup-tests.ts'],
 };

--- a/packages/logger/jest.config.js
+++ b/packages/logger/jest.config.js
@@ -3,9 +3,6 @@ module.exports = {
   testEnvironment: 'node',
   rootDir: 'src',
   testMatch: ['**/__tests__/*.test.ts'],
-  collectCoverage: true,
-  coverageReporters: ['json', 'lcov'],
-  coverageDirectory: '../coverage/tests/',
   clearMocks: true,
   setupFilesAfterEnv: ['<rootDir>/../jest/setup-tests.ts'],
 };

--- a/packages/steps/jest.config.cjs
+++ b/packages/steps/jest.config.cjs
@@ -12,10 +12,9 @@ module.exports = {
   testEnvironment: 'node',
   rootDir: 'src',
   testMatch: ['**/__tests__/*-test.ts'],
-  collectCoverage: true,
   coverageReporters: ['json', 'lcov'],
   coverageDirectory: '../coverage/tests/',
-  collectCoverageFrom: ['<rootDir>/src/**/*.{ts,tsx,js,jsx}'],
+  collectCoverageFrom: ['**/*.ts'],
   moduleNameMapper: {
     '^(\\.\\.?/.*)\\.js$': ['$1.ts', '$0'],
   },

--- a/packages/steps/jest.config.cjs
+++ b/packages/steps/jest.config.cjs
@@ -15,6 +15,7 @@ module.exports = {
   collectCoverage: true,
   coverageReporters: ['json', 'lcov'],
   coverageDirectory: '../coverage/tests/',
+  collectCoverageFrom: ['<rootDir>/src/**/*.{ts,tsx,js,jsx}'],
   moduleNameMapper: {
     '^(\\.\\.?/.*)\\.js$': ['$1.ts', '$0'],
   },

--- a/packages/steps/package.json
+++ b/packages/steps/package.json
@@ -23,6 +23,7 @@
     "prepack": "./build.sh",
     "watch": "chokidar --initial \"src/**/*.ts\" -i \"src/**/__tests__/**/*\" -c \"./build.sh\"",
     "test": "node --experimental-vm-modules --no-warnings node_modules/.bin/jest -c=jest.config.cjs --no-cache",
+    "test:coverage": "node --experimental-vm-modules --no-warnings node_modules/.bin/jest -c=jest.config.cjs --no-cache --coverage",
     "test:watch": "yarn test --watch",
     "clean": "rm -rf node_modules dist_* coverage"
   },

--- a/packages/template-file/jest.config.js
+++ b/packages/template-file/jest.config.js
@@ -3,9 +3,6 @@ module.exports = {
   testEnvironment: 'node',
   rootDir: 'src',
   testMatch: ['**/__tests__/*.test.ts'],
-  collectCoverage: true,
-  coverageReporters: ['json', 'lcov'],
-  coverageDirectory: '../coverage/tests/',
   clearMocks: true,
   setupFilesAfterEnv: ['<rootDir>/../jest/setup-tests.ts'],
 };

--- a/packages/turtle-spawn/jest.config.js
+++ b/packages/turtle-spawn/jest.config.js
@@ -3,9 +3,6 @@ module.exports = {
   testEnvironment: 'node',
   rootDir: 'src',
   testMatch: ['**/__tests__/*.test.ts'],
-  collectCoverage: true,
-  coverageReporters: ['json', 'lcov'],
-  coverageDirectory: '../coverage/tests/',
   clearMocks: true,
   setupFilesAfterEnv: ['<rootDir>/../jest/setup-tests.ts'],
 };


### PR DESCRIPTION
# Why

https://linear.app/expo/issue/ENG-8519/set-up-test-coverage-bot-for-exposteps

# How

Add changes which set up `codecov` fo this repo based on `eas-cli` setup

# Test Plan

Run `test` gh action
