### PR TITLE
[build-tools] change error message for incompatible pods

### DIFF
--- a/packages/build-tools/src/buildErrors/userErrorHandlers.ts
+++ b/packages/build-tools/src/buildErrors/userErrorHandlers.ts
@@ -145,8 +145,8 @@ ${
         'EAS_BUILD_INCOMPATIBLE_PODS_ERROR',
         `Compatible versions of some pods could not be resolved.
 You are seeing this error because either:
-  - Versions in the cached Podfile.lock do not match required values in Podspecs of some installed libraries. To fix this, you can re-run build command with "--clear-cache" option, or select "Clear cache and retry build" on the build page.
   - Some of the pods used in your project depend on different versions of the same pod. See logs for more information.
+  - If you are caching Podfile.lock using "cache" field in eas.json, then versions there might not match required values in Podspecs of some installed libraries. To fix this, you can re-run build command with "--clear-cache" option, or select "Clear cache and retry build" on the build page.
 `
       );
     },


### PR DESCRIPTION
# Why

After we disabled caching Info.plist file this error message might be a bit confusing.

# How

# Test Plan
