### PR TITLE
[ENG-8577][build-tools] implement checkout function for steps

### DIFF
--- a/packages/build-tools/src/android/__tests__/expoUpdates.test.ts
+++ b/packages/build-tools/src/android/__tests__/expoUpdates.test.ts
@@ -37,7 +37,7 @@ describe(androidSetClassicReleaseChannelNativelyAsync, () => {
 
     const releaseChannel = 'blah';
     const ctx = {
-      reactNativeProjectDirectory: '/app',
+      getReactNativeProjectDirectory: () => '/app',
       job: { releaseChannel },
       logger: { info: () => {} },
     };
@@ -53,7 +53,7 @@ describe(androidSetClassicReleaseChannelNativelyAsync, () => {
     ).toBe('@string/release_channel');
 
     const stringResourcePath = await AndroidConfig.Strings.getProjectStringsXMLPathAsync(
-      ctx.reactNativeProjectDirectory
+      ctx.getReactNativeProjectDirectory()
     );
     const stringResourceObject = await AndroidConfig.Resources.readResourcesXMLAsync({
       path: stringResourcePath,
@@ -74,7 +74,7 @@ describe(androidSetChannelNativelyAsync, () => {
       '/app'
     );
     const ctx = {
-      reactNativeProjectDirectory: '/app',
+      getReactNativeProjectDirectory: () => '/app',
       job: { updates: { channel } },
       logger: { info: () => {} },
     };
@@ -103,7 +103,7 @@ describe(androidGetNativelyDefinedChannelAsync, () => {
       '/app'
     );
     const ctx = {
-      reactNativeProjectDirectory: '/app',
+      getReactNativeProjectDirectory: () => '/app',
       logger: { info: () => {} },
     };
 
@@ -123,7 +123,7 @@ describe(androidGetNativelyDefinedClassicReleaseChannelAsync, () => {
       '/app'
     );
     const ctx = {
-      reactNativeProjectDirectory: '/app',
+      getReactNativeProjectDirectory: () => '/app',
       job: {},
       logger: { info: () => {} },
     };
@@ -147,7 +147,7 @@ describe(androidGetNativelyDefinedRuntimeVersionAsync, () => {
       '/app'
     );
     const ctx = {
-      reactNativeProjectDirectory: '/app',
+      getReactNativeProjectDirectory: () => '/app',
       job: {},
       logger: { info: () => {} },
     };
@@ -171,7 +171,7 @@ describe(androidSetRuntimeVersionNativelyAsync, () => {
       '/app'
     );
     const ctx = {
-      reactNativeProjectDirectory: '/app',
+      getReactNativeProjectDirectory: () => '/app',
       job: {},
       logger: { info: () => {} },
     };
@@ -196,7 +196,7 @@ describe(androidSetRuntimeVersionNativelyAsync, () => {
       '/app'
     );
     const ctx = {
-      reactNativeProjectDirectory: '/app',
+      getReactNativeProjectDirectory: () => '/app',
       job: {},
       logger: { info: () => {} },
     };

--- a/packages/build-tools/src/android/expoUpdates.ts
+++ b/packages/build-tools/src/android/expoUpdates.ts
@@ -17,7 +17,7 @@ export async function androidSetRuntimeVersionNativelyAsync(
   runtimeVersion: string
 ): Promise<void> {
   const manifestPath = await AndroidConfig.Paths.getAndroidManifestAsync(
-    ctx.reactNativeProjectDirectory
+    ctx.getReactNativeProjectDirectory()
   );
 
   if (!(await fs.pathExists(manifestPath))) {
@@ -39,7 +39,7 @@ export async function androidSetChannelNativelyAsync(ctx: BuildContext<Job>): Pr
   assert(ctx.job.updates?.channel, 'updates.channel must be defined');
 
   const manifestPath = await AndroidConfig.Paths.getAndroidManifestAsync(
-    ctx.reactNativeProjectDirectory
+    ctx.getReactNativeProjectDirectory()
   );
 
   if (!(await fs.pathExists(manifestPath))) {
@@ -68,7 +68,7 @@ export async function androidGetNativelyDefinedChannelAsync(
   ctx: BuildContext<Job>
 ): Promise<string | null> {
   const manifestPath = await AndroidConfig.Paths.getAndroidManifestAsync(
-    ctx.reactNativeProjectDirectory
+    ctx.getReactNativeProjectDirectory()
   );
 
   if (!(await fs.pathExists(manifestPath))) {
@@ -98,7 +98,7 @@ export async function androidSetClassicReleaseChannelNativelyAsync(
   const escapedReleaseChannel = XML.escapeAndroidString(releaseChannel);
 
   const manifestPath = await AndroidConfig.Paths.getAndroidManifestAsync(
-    ctx.reactNativeProjectDirectory
+    ctx.getReactNativeProjectDirectory()
   );
   if (!(await fs.pathExists(manifestPath))) {
     throw new Error(`Couldn't find Android manifest at ${manifestPath}`);
@@ -106,7 +106,7 @@ export async function androidSetClassicReleaseChannelNativelyAsync(
 
   // Store the release channel in a string resource to ensure it is interpreted as a string
   const stringResourcePath = await AndroidConfig.Strings.getProjectStringsXMLPathAsync(
-    ctx.reactNativeProjectDirectory
+    ctx.getReactNativeProjectDirectory()
   );
   const stringResourceObject = await AndroidConfig.Resources.readResourcesXMLAsync({
     path: stringResourcePath,
@@ -138,7 +138,7 @@ export async function androidGetNativelyDefinedClassicReleaseChannelAsync(
   ctx: BuildContext<Job>
 ): Promise<string | null> {
   const manifestPath = await AndroidConfig.Paths.getAndroidManifestAsync(
-    ctx.reactNativeProjectDirectory
+    ctx.getReactNativeProjectDirectory()
   );
   if (!(await fs.pathExists(manifestPath))) {
     return null;
@@ -155,7 +155,7 @@ export async function androidGetNativelyDefinedRuntimeVersionAsync(
   ctx: BuildContext<Job>
 ): Promise<string | null> {
   const manifestPath = await AndroidConfig.Paths.getAndroidManifestAsync(
-    ctx.reactNativeProjectDirectory
+    ctx.getReactNativeProjectDirectory()
   );
   if (!(await fs.pathExists(manifestPath))) {
     return null;

--- a/packages/build-tools/src/android/gradle.ts
+++ b/packages/build-tools/src/android/gradle.ts
@@ -12,7 +12,7 @@ import { getParentAndDescendantProcessPidsAsync } from '../utils/processes';
 export async function ensureLFLineEndingsInGradlewScript<TJob extends Job>(
   ctx: BuildContext<TJob>
 ): Promise<void> {
-  const gradlewPath = path.join(ctx.reactNativeProjectDirectory, 'android', 'gradlew');
+  const gradlewPath = path.join(ctx.getReactNativeProjectDirectory(), 'android', 'gradlew');
   const gradlewContent = await fs.readFile(gradlewPath, 'utf8');
   if (gradlewContent.includes('\r')) {
     ctx.logger.info('Replacing CRLF line endings with LF in gradlew script');
@@ -24,7 +24,7 @@ export async function runGradleCommand(
   ctx: BuildContext<Android.Job>,
   gradleCommand: string
 ): Promise<void> {
-  const androidDir = path.join(ctx.reactNativeProjectDirectory, 'android');
+  const androidDir = path.join(ctx.getReactNativeProjectDirectory(), 'android');
   ctx.logger.info(`Running 'gradlew ${gradleCommand}' in ${androidDir}`);
   const spawnPromise = spawn('bash', ['-c', `sh gradlew ${gradleCommand}`], {
     cwd: androidDir,

--- a/packages/build-tools/src/android/gradleConfig.ts
+++ b/packages/build-tools/src/android/gradleConfig.ts
@@ -11,13 +11,13 @@ const APPLY_EAS_BUILD_GRADLE_LINE = 'apply from: "./eas-build.gradle"';
 
 export async function configureBuildGradle(ctx: BuildContext<Android.Job>): Promise<void> {
   ctx.logger.info('Injecting signing config into build.gradle');
-  if (await fs.pathExists(getEasBuildGradlePath(ctx.reactNativeProjectDirectory))) {
+  if (await fs.pathExists(getEasBuildGradlePath(ctx.getReactNativeProjectDirectory()))) {
     ctx.markBuildPhaseHasWarnings();
     ctx.logger.warn('eas-build.gradle script is deprecated, please remove it from your project.');
   }
-  await deleteEasBuildGradle(ctx.reactNativeProjectDirectory);
-  await createEasBuildGradle(ctx.reactNativeProjectDirectory);
-  await addApplyToBuildGradle(ctx.reactNativeProjectDirectory);
+  await deleteEasBuildGradle(ctx.getReactNativeProjectDirectory());
+  await createEasBuildGradle(ctx.getReactNativeProjectDirectory());
+  await addApplyToBuildGradle(ctx.getReactNativeProjectDirectory());
 }
 
 async function deleteEasBuildGradle(projectRoot: string): Promise<void> {

--- a/packages/build-tools/src/builders/android.ts
+++ b/packages/build-tools/src/builders/android.ts
@@ -85,7 +85,7 @@ async function buildAsync(ctx: BuildContext<Android.Job>): Promise<void> {
 
   await ctx.runBuildPhase(BuildPhase.UPLOAD_APPLICATION_ARCHIVE, async () => {
     const applicationArchives = await findArtifacts(
-      ctx.reactNativeProjectDirectory,
+      ctx.getReactNativeProjectDirectory(),
       ctx.job.applicationArchivePath ?? 'android/app/build/outputs/**/*.{apk,aab}',
       ctx.logger
     );

--- a/packages/build-tools/src/builders/common.ts
+++ b/packages/build-tools/src/builders/common.ts
@@ -43,7 +43,7 @@ export async function runBuilderWithHooksAsync<T extends Job>(
           const buildArtifacts = (
             await Promise.all(
               ctx.job.buildArtifactPaths.map((path) =>
-                findArtifacts(ctx.reactNativeProjectDirectory, path, ctx.logger)
+                findArtifacts(ctx.getReactNativeProjectDirectory(), path, ctx.logger)
               )
             )
           ).flat();

--- a/packages/build-tools/src/builders/custom.ts
+++ b/packages/build-tools/src/builders/custom.ts
@@ -19,7 +19,7 @@ export async function runCustomBuildAsync<T extends Job>(ctx: BuildContext<T>): 
     ctx.job.customBuildConfig?.path,
     'Custom build config must be defined for custom builds'
   );
-  const configPath = path.join(ctx.reactNativeProjectDirectory, relativeConfigPath);
+  const configPath = path.join(ctx.getReactNativeProjectDirectory(), relativeConfigPath);
 
   const buildStepContext = new BuildStepContext(
     ctx.env.EAS_BUILD_ID,

--- a/packages/build-tools/src/builders/custom.ts
+++ b/packages/build-tools/src/builders/custom.ts
@@ -14,8 +14,7 @@ const platformToBuildRuntimePlatform: Record<Platform, BuildRuntimePlatform> = {
 };
 
 export async function runCustomBuildAsync<T extends Job>(ctx: BuildContext<T>): Promise<Artifacts> {
-  await prepareProjectSourcesAsync(ctx);
-
+  await prepareProjectSourcesAsync(ctx, ctx.temporaryCustomBuildDirectory);
   const relativeConfigPath = nullthrows(
     ctx.job.customBuildConfig?.path,
     'Custom build config must be defined for custom builds'
@@ -27,7 +26,8 @@ export async function runCustomBuildAsync<T extends Job>(ctx: BuildContext<T>): 
     ctx.logger.child({ phase: BuildPhase.CUSTOM }),
     false,
     platformToBuildRuntimePlatform[ctx.job.platform],
-    ctx.reactNativeProjectDirectory
+    ctx.temporaryCustomBuildDirectory,
+    ctx.buildDirectory
   );
   const easFunctions = getEasFunctions(ctx);
   const parser = new BuildConfigParser(buildStepContext, {

--- a/packages/build-tools/src/builders/ios.ts
+++ b/packages/build-tools/src/builders/ios.ts
@@ -105,7 +105,7 @@ async function buildAsync(ctx: BuildContext<Ios.Job>): Promise<void> {
 
   await ctx.runBuildPhase(BuildPhase.UPLOAD_APPLICATION_ARCHIVE, async () => {
     const applicationArchives = await findArtifacts(
-      ctx.reactNativeProjectDirectory,
+      ctx.getReactNativeProjectDirectory(),
       resolveArtifactPath(ctx),
       ctx.logger
     );
@@ -121,11 +121,11 @@ async function readEntitlementsAsync(
   try {
     const applicationTargetName =
       await IOSConfig.BuildScheme.getApplicationTargetNameForSchemeAsync(
-        ctx.reactNativeProjectDirectory,
+        ctx.getReactNativeProjectDirectory(),
         scheme
       );
     const entitlementsPath = IOSConfig.Entitlements.getEntitlementsPath(
-      ctx.reactNativeProjectDirectory,
+      ctx.getReactNativeProjectDirectory(),
       {
         buildConfiguration,
         targetName: applicationTargetName,

--- a/packages/build-tools/src/common/easBuildInternal.ts
+++ b/packages/build-tools/src/common/easBuildInternal.ts
@@ -27,7 +27,7 @@ export async function runEasBuildInternalAsync<TJob extends Job>(
     cmd,
     [...args, 'build:internal', '--platform', ctx.job.platform, '--profile', buildProfile],
     {
-      cwd: ctx.reactNativeProjectDirectory,
+      cwd: ctx.getReactNativeProjectDirectory(),
       env: {
         ...ctx.env,
         EXPO_TOKEN: nullthrows(ctx.job.secrets, 'Secrets must be defined for non-custom builds')
@@ -66,7 +66,7 @@ export async function configureEnvFromBuildProfileAsync<TJob extends Job>(
         '--eas-json-only',
       ],
       {
-        cwd: ctx.reactNativeProjectDirectory,
+        cwd: ctx.getReactNativeProjectDirectory(),
         env: { ...ctx.env, ...extraEnv },
       }
     );

--- a/packages/build-tools/src/common/installDependencies.ts
+++ b/packages/build-tools/src/common/installDependencies.ts
@@ -10,11 +10,11 @@ import { isUsingYarn2 } from '../utils/project';
 export async function installDependenciesAsync<TJob extends Job>(
   ctx: BuildContext<TJob>
 ): Promise<void> {
-  const packagerRunDir = findPackagerRootDir(ctx.reactNativeProjectDirectory);
-  if (packagerRunDir !== ctx.reactNativeProjectDirectory) {
+  const packagerRunDir = findPackagerRootDir(ctx.getReactNativeProjectDirectory());
+  if (packagerRunDir !== ctx.getReactNativeProjectDirectory()) {
     const relativeReactNativeProjectDirectory = path.relative(
       ctx.buildDirectory,
-      ctx.reactNativeProjectDirectory
+      ctx.getReactNativeProjectDirectory()
     );
     ctx.logger.info(
       `We detected that '${relativeReactNativeProjectDirectory}' is a ${ctx.packageManager} workspace`
@@ -26,7 +26,7 @@ export async function installDependenciesAsync<TJob extends Job>(
   if (ctx.packageManager === PackageManager.PNPM) {
     args = ['install', '--no-frozen-lockfile'];
   } else if (ctx.packageManager === PackageManager.YARN) {
-    const isYarn2 = await isUsingYarn2(ctx.reactNativeProjectDirectory);
+    const isYarn2 = await isUsingYarn2(ctx.getReactNativeProjectDirectory());
     if (isYarn2) {
       args = ['install', '--no-immutable'];
     }

--- a/packages/build-tools/src/common/prebuild.ts
+++ b/packages/build-tools/src/common/prebuild.ts
@@ -21,7 +21,7 @@ export async function prebuildAsync<TJob extends Job>(
     !customExpoCliVersion || semver.satisfies(customExpoCliVersion, '>=5.4.4');
 
   const spawnOptions: SpawnOptions = {
-    cwd: ctx.reactNativeProjectDirectory,
+    cwd: ctx.getReactNativeProjectDirectory(),
     logger: ctx.logger,
     env: {
       ...(shouldDisableSharp ? { EXPO_IMAGE_UTILS_NO_SHARP: '1' } : {}),

--- a/packages/build-tools/src/common/setup.ts
+++ b/packages/build-tools/src/common/setup.ts
@@ -36,7 +36,7 @@ export async function setupAsync<TJob extends Job>(ctx: BuildContext<TJob>): Pro
       await configureEnvFromBuildProfileAsync(ctx);
     }
     // try to read package.json to see if it exists and is valid
-    return readPackageJson(ctx.reactNativeProjectDirectory);
+    return readPackageJson(ctx.getReactNativeProjectDirectory());
   });
 
   await ctx.runBuildPhase(BuildPhase.PRE_INSTALL_HOOK, async () => {
@@ -93,7 +93,7 @@ async function runExpoDoctor<TJob extends Job>(ctx: BuildContext<TJob>): Promise
     if (!shouldUseGlobalExpoCli(ctx)) {
       const argsPrefix = isAtLeastNpm7 ? ['-y'] : [];
       promise = spawn('npx', [...argsPrefix, 'expo-doctor'], {
-        cwd: ctx.reactNativeProjectDirectory,
+        cwd: ctx.getReactNativeProjectDirectory(),
         logger: ctx.logger,
         env: ctx.env,
       });
@@ -101,7 +101,7 @@ async function runExpoDoctor<TJob extends Job>(ctx: BuildContext<TJob>): Promise
       promise = ctx.runGlobalExpoCliCommand(
         ['doctor'],
         {
-          cwd: ctx.reactNativeProjectDirectory,
+          cwd: ctx.getReactNativeProjectDirectory(),
           logger: ctx.logger,
           env: ctx.env,
         },

--- a/packages/build-tools/src/context.ts
+++ b/packages/build-tools/src/context.ts
@@ -139,6 +139,9 @@ export class BuildContext<TJob extends Job> {
   public get buildDirectory(): string {
     return path.join(this.workingdir, 'build');
   }
+  public get temporaryCustomBuildDirectory(): string {
+    return path.join(this.workingdir, 'temporary-custom-build');
+  }
   public get buildLogsDirectory(): string {
     return path.join(this.workingdir, 'logs');
   }
@@ -146,7 +149,7 @@ export class BuildContext<TJob extends Job> {
     return path.join(this.workingdir, 'environment-secrets');
   }
   public get reactNativeProjectDirectory(): string {
-    return path.join(this.buildDirectory, this.job.projectRootDirectory ?? '.');
+    return this.getReactNativeProjectDirectory(this.buildDirectory);
   }
   public get packageManager(): PackageManager {
     return resolvePackageManager(this.reactNativeProjectDirectory);
@@ -248,6 +251,10 @@ export class BuildContext<TJob extends Job> {
       this.logger.error(`Error: ${buildError.userFacingMessage}`);
     }
     return buildError;
+  }
+
+  public getReactNativeProjectDirectory(baseDirectory: string): string {
+    return path.join(baseDirectory, this.job.projectRootDirectory ?? '.');
   }
 
   private setBuildPhase(buildPhase: BuildPhase, { doNotMarkStart = false } = {}): void {

--- a/packages/build-tools/src/context.ts
+++ b/packages/build-tools/src/context.ts
@@ -148,15 +148,16 @@ export class BuildContext<TJob extends Job> {
   public get environmentSecrectsDirectory(): string {
     return path.join(this.workingdir, 'environment-secrets');
   }
-  public get reactNativeProjectDirectory(): string {
-    return this.getReactNativeProjectDirectory(this.buildDirectory);
-  }
   public get packageManager(): PackageManager {
-    return resolvePackageManager(this.reactNativeProjectDirectory);
+    return resolvePackageManager(this.getReactNativeProjectDirectory());
   }
   public get appConfig(): ExpoConfig {
     if (!this._appConfig) {
-      this._appConfig = readAppConfig(this.reactNativeProjectDirectory, this.env, this.logger).exp;
+      this._appConfig = readAppConfig(
+        this.getReactNativeProjectDirectory(),
+        this.env,
+        this.logger
+      ).exp;
     }
     return this._appConfig;
   }
@@ -253,7 +254,7 @@ export class BuildContext<TJob extends Job> {
     return buildError;
   }
 
-  public getReactNativeProjectDirectory(baseDirectory: string): string {
+  public getReactNativeProjectDirectory(baseDirectory = this.buildDirectory): string {
     return path.join(baseDirectory, this.job.projectRootDirectory ?? '.');
   }
 

--- a/packages/build-tools/src/ios/__tests__/configure.test.ts
+++ b/packages/build-tools/src/ios/__tests__/configure.test.ts
@@ -48,7 +48,7 @@ describe(configureXcodeProject, () => {
       buildConfiguration: 'Release',
     };
     const ctx = {
-      reactNativeProjectDirectory: '/app',
+      getReactNativeProjectDirectory: () => '/app',
       logger: { info: jest.fn() },
       job: {},
     };
@@ -102,7 +102,7 @@ describe(configureXcodeProject, () => {
       buildConfiguration: 'Release',
     };
     const ctx = {
-      reactNativeProjectDirectory: '/app',
+      getReactNativeProjectDirectory: () => '/app',
       logger: { info: jest.fn() },
       job: {},
     };
@@ -149,7 +149,7 @@ describe(configureXcodeProject, () => {
       buildConfiguration: 'Release',
     };
     const ctx = {
-      reactNativeProjectDirectory: '/app',
+      getReactNativeProjectDirectory: () => '/app',
       logger: { info: jest.fn() },
       job: {
         version: {
@@ -219,7 +219,7 @@ describe(configureXcodeProject, () => {
       buildConfiguration: 'Release',
     };
     const ctx = {
-      reactNativeProjectDirectory: '/app',
+      getReactNativeProjectDirectory: () => '/app',
       logger: { info: jest.fn() },
       job: {
         version: {

--- a/packages/build-tools/src/ios/__tests__/expoUpdates.test.ts
+++ b/packages/build-tools/src/ios/__tests__/expoUpdates.test.ts
@@ -41,7 +41,7 @@ describe(iosSetClassicReleaseChannelNativelyAsync, () => {
     );
 
     const ctx = {
-      reactNativeProjectDirectory: '/app',
+      getReactNativeProjectDirectory: () => '/app',
       job: { releaseChannel },
       logger: { info: () => {} },
     };
@@ -64,7 +64,7 @@ describe(iosSetChannelNativelyAsync, () => {
     );
 
     const ctx = {
-      reactNativeProjectDirectory: '/app',
+      getReactNativeProjectDirectory: () => '/app',
       job: { updates: { channel } },
       logger: { info: () => {} },
     };
@@ -103,7 +103,7 @@ describe(iosGetNativelyDefinedChannelAsync, () => {
     );
 
     const ctx = {
-      reactNativeProjectDirectory: '/app',
+      getReactNativeProjectDirectory: () => '/app',
       logger: { info: () => {} },
     };
     await expect(iosGetNativelyDefinedChannelAsync(ctx as any)).resolves.toBe('staging-123');
@@ -132,7 +132,7 @@ describe(iosGetNativelyDefinedClassicReleaseChannelAsync, () => {
     );
 
     const ctx = {
-      reactNativeProjectDirectory: '/app',
+      getReactNativeProjectDirectory: () => '/app',
       logger: { info: () => {} },
     };
     const nativelyDefinedReleaseChannel = await iosGetNativelyDefinedClassicReleaseChannelAsync(
@@ -165,7 +165,7 @@ describe(iosGetNativelyDefinedRuntimeVersionAsync, () => {
     );
 
     const ctx = {
-      reactNativeProjectDirectory: '/app',
+      getReactNativeProjectDirectory: () => '/app',
       logger: { info: () => {} },
     };
 
@@ -187,7 +187,7 @@ describe(iosSetRuntimeVersionNativelyAsync, () => {
       '/app'
     );
     const ctx = {
-      reactNativeProjectDirectory: '/app',
+      getReactNativeProjectDirectory: () => '/app',
       logger: { info: () => {} },
     };
 
@@ -216,7 +216,7 @@ describe(iosSetRuntimeVersionNativelyAsync, () => {
       '/app'
     );
     const ctx = {
-      reactNativeProjectDirectory: '/app',
+      getReactNativeProjectDirectory: () => '/app',
       logger: { info: () => {} },
     };
 

--- a/packages/build-tools/src/ios/__tests__/xcodeEnv.test.ts
+++ b/packages/build-tools/src/ios/__tests__/xcodeEnv.test.ts
@@ -24,7 +24,7 @@ describe(deleteXcodeEnvLocalIfExistsAsync, () => {
     );
 
     const mockCtx = mock<BuildContext<Ios.Job>>();
-    when(mockCtx.reactNativeProjectDirectory).thenReturn('/app');
+    when(mockCtx.getReactNativeProjectDirectory()).thenReturn('/app');
     when(mockCtx.logger).thenReturn(instance(mock<bunyan>()));
     const ctx = instance(mockCtx);
 

--- a/packages/build-tools/src/ios/configure.ts
+++ b/packages/build-tools/src/ios/configure.ts
@@ -51,7 +51,7 @@ async function configureCredentialsAsync(
       `Assigning provisioning profile '${profile.name}' (Apple Team ID: ${profile.teamId}) to target '${targetName}'`
     );
     IOSConfig.ProvisioningProfile.setProvisioningProfileForPbxproj(
-      ctx.reactNativeProjectDirectory,
+      ctx.getReactNativeProjectDirectory(),
       {
         targetName,
         profileName: profile.name,
@@ -72,8 +72,8 @@ async function updateVersionsAsync(
     buildConfiguration: string;
   }
 ): Promise<void> {
-  const project = IOSConfig.XcodeUtils.getPbxproj(ctx.reactNativeProjectDirectory);
-  const iosDir = path.join(ctx.reactNativeProjectDirectory, 'ios');
+  const project = IOSConfig.XcodeUtils.getPbxproj(ctx.getReactNativeProjectDirectory());
+  const iosDir = path.join(ctx.getReactNativeProjectDirectory(), 'ios');
 
   const infoPlistPaths: string[] = [];
   for (const targetName of targetNames) {

--- a/packages/build-tools/src/ios/expoUpdates.ts
+++ b/packages/build-tools/src/ios/expoUpdates.ts
@@ -17,7 +17,7 @@ export async function iosSetRuntimeVersionNativelyAsync(
   ctx: BuildContext<Job>,
   runtimeVersion: string
 ): Promise<void> {
-  const expoPlistPath = IOSConfig.Paths.getExpoPlistPath(ctx.reactNativeProjectDirectory);
+  const expoPlistPath = IOSConfig.Paths.getExpoPlistPath(ctx.getReactNativeProjectDirectory());
 
   if (!(await fs.pathExists(expoPlistPath))) {
     throw new Error(`${expoPlistPath} does not exist`);
@@ -34,7 +34,7 @@ export async function iosSetRuntimeVersionNativelyAsync(
 export async function iosSetChannelNativelyAsync(ctx: BuildContext<Job>): Promise<void> {
   assert(ctx.job.updates?.channel, 'updates.channel must be defined');
 
-  const expoPlistPath = IOSConfig.Paths.getExpoPlistPath(ctx.reactNativeProjectDirectory);
+  const expoPlistPath = IOSConfig.Paths.getExpoPlistPath(ctx.getReactNativeProjectDirectory());
 
   if (!(await fs.pathExists(expoPlistPath))) {
     throw new Error(`${expoPlistPath} does not exist`);
@@ -57,7 +57,7 @@ export async function iosSetChannelNativelyAsync(ctx: BuildContext<Job>): Promis
 export async function iosGetNativelyDefinedChannelAsync(
   ctx: BuildContext<Job>
 ): Promise<string | null> {
-  const expoPlistPath = IOSConfig.Paths.getExpoPlistPath(ctx.reactNativeProjectDirectory);
+  const expoPlistPath = IOSConfig.Paths.getExpoPlistPath(ctx.getReactNativeProjectDirectory());
 
   if (!(await fs.pathExists(expoPlistPath))) {
     return null;
@@ -82,7 +82,7 @@ export async function iosSetClassicReleaseChannelNativelyAsync(
 ): Promise<void> {
   assert(ctx.job.releaseChannel, 'releaseChannel must be defined');
 
-  const expoPlistPath = IOSConfig.Paths.getExpoPlistPath(ctx.reactNativeProjectDirectory);
+  const expoPlistPath = IOSConfig.Paths.getExpoPlistPath(ctx.getReactNativeProjectDirectory());
 
   if (!(await fs.pathExists(expoPlistPath))) {
     throw new Error(`${expoPlistPath} does not exist`);
@@ -99,7 +99,7 @@ export async function iosSetClassicReleaseChannelNativelyAsync(
 export async function iosGetNativelyDefinedClassicReleaseChannelAsync(
   ctx: BuildContext<Job>
 ): Promise<string | null> {
-  const expoPlistPath = IOSConfig.Paths.getExpoPlistPath(ctx.reactNativeProjectDirectory);
+  const expoPlistPath = IOSConfig.Paths.getExpoPlistPath(ctx.getReactNativeProjectDirectory());
   if (!(await fs.pathExists(expoPlistPath))) {
     return null;
   }
@@ -114,7 +114,7 @@ export async function iosGetNativelyDefinedClassicReleaseChannelAsync(
 export async function iosGetNativelyDefinedRuntimeVersionAsync(
   ctx: BuildContext<Job>
 ): Promise<string | null> {
-  const expoPlistPath = IOSConfig.Paths.getExpoPlistPath(ctx.reactNativeProjectDirectory);
+  const expoPlistPath = IOSConfig.Paths.getExpoPlistPath(ctx.getReactNativeProjectDirectory());
   if (!(await fs.pathExists(expoPlistPath))) {
     return null;
   }

--- a/packages/build-tools/src/ios/fastlane.ts
+++ b/packages/build-tools/src/ios/fastlane.ts
@@ -38,11 +38,11 @@ export async function runFastlaneGym<TJob extends Ios.Job>(
   if (ctx.skipNativeBuild) {
     throw new SkipNativeBuildError('Skipping fastlane build');
   }
-  const buildLogger = new XcodeBuildLogger(ctx.logger, ctx.reactNativeProjectDirectory);
+  const buildLogger = new XcodeBuildLogger(ctx.logger, ctx.getReactNativeProjectDirectory());
   void buildLogger.watchLogFiles(ctx.buildLogsDirectory);
   try {
     await runFastlane(['gym'], {
-      cwd: path.join(ctx.reactNativeProjectDirectory, 'ios'),
+      cwd: path.join(ctx.getReactNativeProjectDirectory(), 'ios'),
       logger: ctx.logger,
       env: ctx.env,
     });
@@ -118,7 +118,7 @@ async function ensureGymfileExists<TJob extends Ios.Job>(
     entitlements: object | null;
   }
 ): Promise<void> {
-  const gymfilePath = path.join(ctx.reactNativeProjectDirectory, 'ios/Gymfile');
+  const gymfilePath = path.join(ctx.getReactNativeProjectDirectory(), 'ios/Gymfile');
 
   if (await fs.pathExists(gymfilePath)) {
     ctx.logger.info('Gymfile already exists');

--- a/packages/build-tools/src/ios/pod.ts
+++ b/packages/build-tools/src/ios/pod.ts
@@ -6,7 +6,7 @@ import spawn from '@expo/turtle-spawn';
 import { BuildContext } from '../context';
 
 export async function installPods<TJob extends Ios.Job>(ctx: BuildContext<TJob>): Promise<void> {
-  const iosDir = path.join(ctx.reactNativeProjectDirectory, 'ios');
+  const iosDir = path.join(ctx.getReactNativeProjectDirectory(), 'ios');
 
   await spawn('pod', ['install'], {
     cwd: iosDir,

--- a/packages/build-tools/src/ios/resolve.ts
+++ b/packages/build-tools/src/ios/resolve.ts
@@ -9,7 +9,9 @@ export function resolveScheme(ctx: BuildContext<Ios.Job>): string {
   if (ctx.job.scheme) {
     return ctx.job.scheme;
   }
-  const schemes = IOSConfig.BuildScheme.getSchemesFromXcodeproj(ctx.reactNativeProjectDirectory);
+  const schemes = IOSConfig.BuildScheme.getSchemesFromXcodeproj(
+    ctx.getReactNativeProjectDirectory()
+  );
   assert(schemes.length === 1, 'Ejected project should have exactly one scheme');
   return schemes[0];
 }

--- a/packages/build-tools/src/ios/tvos.ts
+++ b/packages/build-tools/src/ios/tvos.ts
@@ -16,10 +16,10 @@ import { resolveBuildConfiguration, resolveScheme } from './resolve';
 export async function isTVOS(ctx: BuildContext<Ios.Job>): Promise<boolean> {
   const scheme = resolveScheme(ctx);
 
-  const project = IOSConfig.XcodeUtils.getPbxproj(ctx.reactNativeProjectDirectory);
+  const project = IOSConfig.XcodeUtils.getPbxproj(ctx.getReactNativeProjectDirectory());
 
   const targetName = await IOSConfig.BuildScheme.getApplicationTargetNameForSchemeAsync(
-    ctx.reactNativeProjectDirectory,
+    ctx.getReactNativeProjectDirectory(),
     scheme
   );
 

--- a/packages/build-tools/src/ios/xcodeEnv.ts
+++ b/packages/build-tools/src/ios/xcodeEnv.ts
@@ -6,7 +6,11 @@ import fs from 'fs-extra';
 import { BuildContext } from '../context';
 
 export async function deleteXcodeEnvLocalIfExistsAsync(ctx: BuildContext<Ios.Job>): Promise<void> {
-  const xcodeEnvLocalPath = path.join(ctx.reactNativeProjectDirectory, 'ios', '.xcode.env.local');
+  const xcodeEnvLocalPath = path.join(
+    ctx.getReactNativeProjectDirectory(),
+    'ios',
+    '.xcode.env.local'
+  );
   if (await fs.pathExists(xcodeEnvLocalPath)) {
     ctx.markBuildPhaseHasWarnings();
     ctx.logger.warn(

--- a/packages/build-tools/src/steps/easFunctions.ts
+++ b/packages/build-tools/src/steps/easFunctions.ts
@@ -3,8 +3,9 @@ import { BuildFunction } from '@expo/steps';
 
 import { BuildContext } from '../context';
 
-import { createUploadArtifactStepsFunction } from './functions/uploadArtifact';
+import { createUploadArtifactBuildFunction } from './functions/uploadArtifact';
+import { createCheckoutBuildFunction } from './functions/checkout';
 
 export function getEasFunctions<T extends Job>(ctx: BuildContext<T>): BuildFunction[] {
-  return [createUploadArtifactStepsFunction(ctx)];
+  return [createCheckoutBuildFunction(), createUploadArtifactBuildFunction(ctx)];
 }

--- a/packages/build-tools/src/steps/functions/checkout.ts
+++ b/packages/build-tools/src/steps/functions/checkout.ts
@@ -1,0 +1,16 @@
+import { BuildFunction } from '@expo/steps';
+import fs from 'fs-extra';
+
+export function createCheckoutBuildFunction(): BuildFunction {
+  return new BuildFunction({
+    namespace: 'eas',
+    id: 'checkout',
+    name: 'Checkout',
+    fn: async (stepsCtx) => {
+      stepsCtx.logger.info('Checking out project directory');
+      await fs.move(stepsCtx.projectSourceDirectory, stepsCtx.workingDirectory, {
+        overwrite: true,
+      });
+    },
+  });
+}

--- a/packages/build-tools/src/steps/functions/uploadArtifact.ts
+++ b/packages/build-tools/src/steps/functions/uploadArtifact.ts
@@ -11,7 +11,7 @@ enum BuildArtifactType {
   BUILD_ARTIFACT = 'build-artifact',
 }
 
-export function createUploadArtifactStepsFunction<T extends Job>(
+export function createUploadArtifactBuildFunction<T extends Job>(
   ctx: BuildContext<T>
 ): BuildFunction {
   return new BuildFunction({

--- a/packages/build-tools/src/utils/__tests__/expoUpdates.test.ts
+++ b/packages/build-tools/src/utils/__tests__/expoUpdates.test.ts
@@ -29,6 +29,7 @@ describe(expoUpdates.configureExpoUpdatesIfInstalledAsync, () => {
 
     await expoUpdates.configureExpoUpdatesIfInstalledAsync({
       job: { Platform: Platform.IOS },
+      getReactNativeProjectDirectory: () => '/app',
     } as any);
 
     expect(androidSetChannelNativelyAsync).not.toBeCalled();
@@ -51,6 +52,7 @@ describe(expoUpdates.configureExpoUpdatesIfInstalledAsync, () => {
         platform: Platform.IOS,
       },
       logger: { info: () => {} },
+      getReactNativeProjectDirectory: () => '/app',
     } as any;
     await expoUpdates.configureExpoUpdatesIfInstalledAsync(managedCtx);
 
@@ -77,6 +79,7 @@ describe(expoUpdates.configureExpoUpdatesIfInstalledAsync, () => {
         platform: Platform.IOS,
       },
       logger: { info: () => {} },
+      getReactNativeProjectDirectory: () => '/app',
     } as any;
     await expoUpdates.configureExpoUpdatesIfInstalledAsync(managedCtx);
 
@@ -98,6 +101,7 @@ describe(expoUpdates.configureExpoUpdatesIfInstalledAsync, () => {
       },
       job: { updates: { channel: 'main' }, releaseChannel: 'default', platform: Platform.IOS },
       logger: { info: () => {} },
+      getReactNativeProjectDirectory: () => '/app',
     } as any;
     await expoUpdates.configureExpoUpdatesIfInstalledAsync(managedCtx);
 
@@ -115,6 +119,7 @@ describe(expoUpdates.configureExpoUpdatesIfInstalledAsync, () => {
       appConfig: { updates: {} },
       job: { platform: Platform.IOS },
       logger: { info: () => {} },
+      getReactNativeProjectDirectory: () => '/app',
     } as any;
     await expoUpdates.configureExpoUpdatesIfInstalledAsync(managedCtx);
 
@@ -133,6 +138,7 @@ describe(expoUpdates.configureExpoUpdatesIfInstalledAsync, () => {
       appConfig: {},
       job: { releaseChannel: 'default', platform: Platform.IOS },
       logger: { info: () => {} },
+      getReactNativeProjectDirectory: () => '/app',
     } as any;
     await expoUpdates.configureExpoUpdatesIfInstalledAsync(managedCtx);
 
@@ -150,6 +156,7 @@ describe(expoUpdates.configureExpoUpdatesIfInstalledAsync, () => {
       appConfig: {},
       job: { platform: Platform.IOS },
       logger: { info: infoLogger, warn: () => {} },
+      getReactNativeProjectDirectory: () => '/app',
     } as any;
     await expoUpdates.configureExpoUpdatesIfInstalledAsync(managedCtx);
 

--- a/packages/build-tools/src/utils/expoUpdates.ts
+++ b/packages/build-tools/src/utils/expoUpdates.ts
@@ -138,7 +138,7 @@ export async function configureEASExpoUpdatesAsync(ctx: BuildContext<Job>): Prom
 }
 
 export async function configureExpoUpdatesIfInstalledAsync(ctx: BuildContext<Job>): Promise<void> {
-  if (!(await isExpoUpdatesInstalledAsync(ctx.reactNativeProjectDirectory))) {
+  if (!(await isExpoUpdatesInstalledAsync(ctx.getReactNativeProjectDirectory()))) {
     return;
   }
 

--- a/packages/build-tools/src/utils/hooks.ts
+++ b/packages/build-tools/src/utils/hooks.ts
@@ -23,7 +23,7 @@ export async function runHookIfPresent<TJob extends Job>(
   hook: Hook,
   { extraEnvs }: { extraEnvs?: Record<string, string> } = {}
 ): Promise<void> {
-  const projectDir = ctx.reactNativeProjectDirectory;
+  const projectDir = ctx.getReactNativeProjectDirectory();
   const packageJson = readPackageJson(projectDir);
   if (packageJson.scripts?.[hook]) {
     ctx.logger.info(`Script '${hook}' is present in package.json, running it...`);

--- a/packages/build-tools/src/utils/npmrc.ts
+++ b/packages/build-tools/src/utils/npmrc.ts
@@ -24,7 +24,7 @@ export async function createNpmrcIfNotExistsAsync(ctx: BuildContext<Job>): Promi
 
 export async function logIfNpmrcExistsAsync(ctx: BuildContext<Job>): Promise<void> {
   const projectNpmrcPath = path.join(
-    findPackagerRootDir(ctx.reactNativeProjectDirectory),
+    findPackagerRootDir(ctx.getReactNativeProjectDirectory()),
     '.npmrc'
   );
   if (await fs.pathExists(projectNpmrcPath)) {

--- a/packages/local-build-plugin/src/workingdir.ts
+++ b/packages/local-build-plugin/src/workingdir.ts
@@ -16,6 +16,7 @@ export async function prepareWorkingdirAsync(): Promise<string> {
   }
   await fs.mkdirp(path.join(workingdir, 'artifacts'));
   await fs.mkdirp(path.join(workingdir, 'build'));
+  await fs.mkdirp(path.join(workingdir, 'custom-build'));
   registerHandler(async () => {
     if (!config.skipCleanup) {
       await fs.remove(workingdir);

--- a/packages/steps/src/BuildStepContext.ts
+++ b/packages/steps/src/BuildStepContext.ts
@@ -19,6 +19,7 @@ export class BuildStepContext {
     public readonly logger: bunyan,
     public readonly skipCleanup: boolean,
     public readonly runtimePlatform: BuildRuntimePlatform,
+    public readonly projectSourceDirectory: string,
     workingDirectory?: string
   ) {
     this.baseWorkingDirectory = path.join(os.tmpdir(), 'eas-build', buildId);
@@ -49,6 +50,7 @@ export class BuildStepContext {
       logger ?? this.logger,
       this.skipCleanup,
       this.runtimePlatform,
+      this.projectSourceDirectory,
       workingDirectory ?? this.workingDirectory
     );
   }

--- a/packages/steps/src/__tests__/BuildStepContext-test.ts
+++ b/packages/steps/src/__tests__/BuildStepContext-test.ts
@@ -20,7 +20,8 @@ describe(BuildStepContext, () => {
         uuidv4(),
         createMockLogger(),
         false,
-        BuildRuntimePlatform.LINUX
+        BuildRuntimePlatform.LINUX,
+        '/non/existent/path'
       );
       expect(ctx.baseWorkingDirectory.startsWith(os.tmpdir())).toBe(true);
     });
@@ -30,7 +31,8 @@ describe(BuildStepContext, () => {
         buildId,
         createMockLogger(),
         false,
-        BuildRuntimePlatform.LINUX
+        BuildRuntimePlatform.LINUX,
+        '/non/existent/path'
       );
       expect(ctx.baseWorkingDirectory).toMatch(buildId);
     });
@@ -41,7 +43,8 @@ describe(BuildStepContext, () => {
         uuidv4(),
         createMockLogger(),
         false,
-        BuildRuntimePlatform.LINUX
+        BuildRuntimePlatform.LINUX,
+        '/non/existent/path'
       );
       expect(ctx.workingDirectory).toBe(path.join(ctx.baseWorkingDirectory, 'project'));
     });
@@ -52,6 +55,7 @@ describe(BuildStepContext, () => {
         createMockLogger(),
         false,
         BuildRuntimePlatform.LINUX,
+        '/non/existent/path',
         workingDirectory
       );
       expect(ctx.workingDirectory).toBe(workingDirectory);

--- a/packages/steps/src/__tests__/utils/context.ts
+++ b/packages/steps/src/__tests__/utils/context.ts
@@ -11,6 +11,7 @@ interface BuildContextParams {
   logger?: bunyan;
   skipCleanup?: boolean;
   runtimePlatform?: BuildRuntimePlatform;
+  projectSourceDirectory?: string;
   workingDirectory?: string;
 }
 
@@ -19,6 +20,7 @@ export function createMockContext({
   logger,
   skipCleanup,
   runtimePlatform,
+  projectSourceDirectory,
   workingDirectory,
 }: BuildContextParams = {}): BuildStepContext {
   return new BuildStepContext(
@@ -26,6 +28,7 @@ export function createMockContext({
     logger ?? createMockLogger(),
     skipCleanup ?? false,
     runtimePlatform ?? BuildRuntimePlatform.LINUX,
+    projectSourceDirectory ?? '/non/existent/dir',
     workingDirectory
   );
 }

--- a/packages/steps/src/cli/cli.ts
+++ b/packages/steps/src/cli/cli.ts
@@ -19,7 +19,14 @@ async function runAsync(
   runtimePlatform: BuildRuntimePlatform
 ): Promise<void> {
   const fakeBuildId = uuidv4();
-  const ctx = new BuildStepContext(fakeBuildId, logger, false, runtimePlatform, workingDirectory);
+  const ctx = new BuildStepContext(
+    fakeBuildId,
+    logger,
+    false,
+    runtimePlatform,
+    workingDirectory,
+    workingDirectory
+  );
   const parser = new BuildConfigParser(ctx, { configPath });
   const workflow = await parser.parseAsync();
   await workflow.executeAsync();


### PR DESCRIPTION
# Why

The first step towards reimplementing `@expo/build-tools` as functions for `@expo/steps`.

# How

Implement `eas/checkout` that prepares the project sources so that next steps can work with the project files.
- In `@expo/build-tools` prepare the project directory the same way as for regular builds.
- When running `checkout`, copy the project directory to a new working directory that `@expo/steps` works with.

# Test Plan

Tested locally.