### PR TITLE
[build-tools] Export function to upload XCode logs

### DIFF
--- a/packages/build-tools/src/index.ts
+++ b/packages/build-tools/src/index.ts
@@ -10,3 +10,5 @@ export {
   LogBuffer,
   SkipNativeBuildError,
 } from './context';
+
+export { findAndUploadXcodeBuildLogsAsync } from './ios/xcodeBuildLogs';


### PR DESCRIPTION
In order for the worker to be able to upload XCode logs before it is terminated by the launcher in the case of the build being canceled by the user it needs to import the function to upload the logs from the `build-tools`

# Why

Importing the function in `worker`
See: https://linear.app/expo/issue/ENG-8120/rename-cachecustompaths-to-cachepaths-in-easjson-and-job-schema

# How

Added the function to the exports in `index.ts`

# Test Plan

No tests

Merging order:
1. This PR ➡️ main
2. https://github.com/expo/turtle-v2/pull/1305 ➡️  main
3. <www_pr> ➡️  main
4. https://github.com/expo/turtle-v2/pull/1306 ⬇️ 
5. https://github.com/expo/turtle-v2/pull/1301 ⬇️ 
6. https://github.com/expo/turtle-v2/pull/1299  ⬇️ 
7. https://github.com/expo/turtle-v2/pull/1298 ➡️  main

Deploying order:
1. This PR (build-tools)
2. Migration
3. WWW
4. Worker
5. Launcher
6. Scheduler
7. Turtle API