### PR TITLE
[ENG-8721[build-tools] custom builds: add `eas/use_npm_token` and `eas/install_node_modules`

### DIFF
--- a/packages/build-tools/src/common/installDependencies.ts
+++ b/packages/build-tools/src/common/installDependencies.ts
@@ -1,6 +1,7 @@
 import path from 'path';
 
 import { Job } from '@expo/eas-build-job';
+import { bunyan } from '@expo/logger';
 import spawn from '@expo/turtle-spawn';
 
 import { BuildContext } from '../context';
@@ -8,7 +9,8 @@ import { findPackagerRootDir, PackageManager } from '../utils/packageManager';
 import { isUsingYarn2 } from '../utils/project';
 
 export async function installDependenciesAsync<TJob extends Job>(
-  ctx: BuildContext<TJob>
+  ctx: BuildContext<TJob>,
+  logger: bunyan
 ): Promise<void> {
   const packagerRunDir = findPackagerRootDir(ctx.getReactNativeProjectDirectory());
   if (packagerRunDir !== ctx.getReactNativeProjectDirectory()) {
@@ -16,7 +18,7 @@ export async function installDependenciesAsync<TJob extends Job>(
       ctx.buildDirectory,
       ctx.getReactNativeProjectDirectory()
     );
-    ctx.logger.info(
+    logger.info(
       `We detected that '${relativeReactNativeProjectDirectory}' is a ${ctx.packageManager} workspace`
     );
   }
@@ -31,7 +33,7 @@ export async function installDependenciesAsync<TJob extends Job>(
       args = ['install', '--no-immutable'];
     }
   }
-  ctx.logger.info(
+  logger.info(
     `Running "${ctx.packageManager} ${args.join(' ')}" in ${
       relativePackagerRunDir
         ? `directory '${relativePackagerRunDir}'`
@@ -40,7 +42,7 @@ export async function installDependenciesAsync<TJob extends Job>(
   );
   await spawn(ctx.packageManager, args, {
     cwd: packagerRunDir,
-    logger: ctx.logger,
+    logger,
     env: ctx.env,
   });
 }

--- a/packages/build-tools/src/common/prebuild.ts
+++ b/packages/build-tools/src/common/prebuild.ts
@@ -34,7 +34,7 @@ export async function prebuildAsync<TJob extends Job>(
   await runExpoCliCommand(ctx, prebuildCommandArgs, spawnOptions, {
     npmVersionAtLeast7: await isAtLeastNpm7Async(),
   });
-  await installDependenciesAsync(ctx);
+  await installDependenciesAsync(ctx, ctx.logger);
 }
 
 function getPrebuildCommandArgs<TJob extends Job>(ctx: BuildContext<TJob>): string[] {

--- a/packages/build-tools/src/common/setup.ts
+++ b/packages/build-tools/src/common/setup.ts
@@ -6,7 +6,7 @@ import nullthrows from 'nullthrows';
 import { BuildContext } from '../context';
 import { deleteXcodeEnvLocalIfExistsAsync } from '../ios/xcodeEnv';
 import { Hook, runHookIfPresent } from '../utils/hooks';
-import { createNpmrcIfNotExistsAsync, logIfNpmrcExistsAsync } from '../utils/npmrc';
+import { setUpNpmrcAsync } from '../utils/npmrc';
 import { isAtLeastNpm7Async } from '../utils/packageManager';
 import { readPackageJson, shouldUseGlobalExpoCli } from '../utils/project';
 import { getParentAndDescendantProcessPidsAsync } from '../utils/processes';
@@ -22,11 +22,7 @@ class DoctorTimeoutError extends Error {}
 export async function setupAsync<TJob extends Job>(ctx: BuildContext<TJob>): Promise<void> {
   const packageJson = await ctx.runBuildPhase(BuildPhase.PREPARE_PROJECT, async () => {
     await prepareProjectSourcesAsync(ctx);
-    if (ctx.env.NPM_TOKEN) {
-      await createNpmrcIfNotExistsAsync(ctx);
-    } else {
-      await logIfNpmrcExistsAsync(ctx);
-    }
+    await setUpNpmrcAsync(ctx, ctx.logger);
     if (ctx.job.platform === Platform.IOS && ctx.env.EAS_BUILD_RUNNER === 'eas-build') {
       await deleteXcodeEnvLocalIfExistsAsync(ctx as BuildContext<Ios.Job>);
     }

--- a/packages/build-tools/src/common/setup.ts
+++ b/packages/build-tools/src/common/setup.ts
@@ -45,7 +45,7 @@ export async function setupAsync<TJob extends Job>(ctx: BuildContext<TJob>): Pro
   });
 
   await ctx.runBuildPhase(BuildPhase.INSTALL_DEPENDENCIES, async () => {
-    await installDependenciesAsync(ctx);
+    await installDependenciesAsync(ctx, ctx.logger);
   });
 
   if (ctx.job.triggeredBy === BuildTrigger.GIT_BASED_INTEGRATION) {

--- a/packages/build-tools/src/steps/easFunctions.ts
+++ b/packages/build-tools/src/steps/easFunctions.ts
@@ -5,7 +5,12 @@ import { BuildContext } from '../context';
 
 import { createUploadArtifactBuildFunction } from './functions/uploadArtifact';
 import { createCheckoutBuildFunction } from './functions/checkout';
+import { createSetUpNpmrcBuildFunction } from './functions/setUpNpmrc';
 
 export function getEasFunctions<T extends Job>(ctx: BuildContext<T>): BuildFunction[] {
-  return [createCheckoutBuildFunction(), createUploadArtifactBuildFunction(ctx)];
+  return [
+    createCheckoutBuildFunction(),
+    createUploadArtifactBuildFunction(ctx),
+    createSetUpNpmrcBuildFunction(ctx),
+  ];
 }

--- a/packages/build-tools/src/steps/easFunctions.ts
+++ b/packages/build-tools/src/steps/easFunctions.ts
@@ -6,11 +6,13 @@ import { BuildContext } from '../context';
 import { createUploadArtifactBuildFunction } from './functions/uploadArtifact';
 import { createCheckoutBuildFunction } from './functions/checkout';
 import { createSetUpNpmrcBuildFunction } from './functions/setUpNpmrc';
+import { createInstallNodeModulesBuildFunction } from './functions/installNodeModules';
 
 export function getEasFunctions<T extends Job>(ctx: BuildContext<T>): BuildFunction[] {
   return [
     createCheckoutBuildFunction(),
     createUploadArtifactBuildFunction(ctx),
     createSetUpNpmrcBuildFunction(ctx),
+    createInstallNodeModulesBuildFunction(ctx),
   ];
 }

--- a/packages/build-tools/src/steps/functions/installNodeModules.ts
+++ b/packages/build-tools/src/steps/functions/installNodeModules.ts
@@ -1,0 +1,18 @@
+import { Job } from '@expo/eas-build-job';
+import { BuildFunction } from '@expo/steps';
+
+import { BuildContext } from '../../context';
+import { installDependenciesAsync } from '../../common/installDependencies';
+
+export function createInstallNodeModulesBuildFunction<T extends Job>(
+  ctx: BuildContext<T>
+): BuildFunction {
+  return new BuildFunction({
+    namespace: 'eas',
+    id: 'install_node_modules',
+    name: 'Install node modules',
+    fn: async (stepsCtx) => {
+      await installDependenciesAsync(ctx, stepsCtx.logger);
+    },
+  });
+}

--- a/packages/build-tools/src/steps/functions/setUpNpmrc.ts
+++ b/packages/build-tools/src/steps/functions/setUpNpmrc.ts
@@ -1,0 +1,16 @@
+import { Job } from '@expo/eas-build-job';
+import { BuildFunction } from '@expo/steps';
+
+import { BuildContext } from '../../context';
+import { setUpNpmrcAsync } from '../../utils/npmrc';
+
+export function createSetUpNpmrcBuildFunction<T extends Job>(ctx: BuildContext<T>): BuildFunction {
+  return new BuildFunction({
+    namespace: 'eas',
+    id: 'use_npm_token',
+    name: 'Use NPM_TOKEN',
+    fn: async (stepsCtx) => {
+      await setUpNpmrcAsync(ctx, stepsCtx.logger);
+    },
+  });
+}

--- a/packages/build-tools/src/utils/npmrc.ts
+++ b/packages/build-tools/src/utils/npmrc.ts
@@ -1,6 +1,7 @@
 import path from 'path';
 
 import { Job } from '@expo/eas-build-job';
+import { bunyan } from '@expo/logger';
 import fs from 'fs-extra';
 
 import { BuildContext } from '../context';
@@ -9,25 +10,33 @@ import { findPackagerRootDir } from './packageManager';
 
 const NPMRC_TEMPLATE_PATH = path.join(__dirname, '../../templates/npmrc');
 
-export async function createNpmrcIfNotExistsAsync(ctx: BuildContext<Job>): Promise<void> {
-  ctx.logger.info('We detected that you set the NPM_TOKEN environment variable');
+export async function setUpNpmrcAsync(ctx: BuildContext<Job>, logger: bunyan): Promise<void> {
+  if (ctx.env.NPM_TOKEN) {
+    await createNpmrcIfNotExistsAsync(ctx, logger);
+  } else {
+    await logIfNpmrcExistsAsync(ctx, logger);
+  }
+}
+
+async function createNpmrcIfNotExistsAsync(ctx: BuildContext<Job>, logger: bunyan): Promise<void> {
+  logger.info('We detected that you set the NPM_TOKEN environment variable');
   const projectNpmrcPath = path.join(ctx.buildDirectory, '.npmrc');
   if (await fs.pathExists(projectNpmrcPath)) {
-    ctx.logger.info('.npmrc already exists in your project directory, skipping generation');
+    logger.info('.npmrc already exists in your project directory, skipping generation');
   } else {
     const npmrcContents = await fs.readFile(NPMRC_TEMPLATE_PATH, 'utf8');
-    ctx.logger.info('Creating .npmrc in your project directory with the following contents:');
-    ctx.logger.info(npmrcContents);
+    logger.info('Creating .npmrc in your project directory with the following contents:');
+    logger.info(npmrcContents);
     await fs.copy(NPMRC_TEMPLATE_PATH, projectNpmrcPath);
   }
 }
 
-export async function logIfNpmrcExistsAsync(ctx: BuildContext<Job>): Promise<void> {
+async function logIfNpmrcExistsAsync(ctx: BuildContext<Job>, logger: bunyan): Promise<void> {
   const projectNpmrcPath = path.join(
     findPackagerRootDir(ctx.getReactNativeProjectDirectory()),
     '.npmrc'
   );
   if (await fs.pathExists(projectNpmrcPath)) {
-    ctx.logger.info(`.npmrc found at ${path.relative(ctx.buildDirectory, projectNpmrcPath)}`);
+    logger.info(`.npmrc found at ${path.relative(ctx.buildDirectory, projectNpmrcPath)}`);
   }
 }


### PR DESCRIPTION
- Extract creating `.npmrc` (when `NPM_TOKEN` is set) as `eas/use_npm_token`.
- Add `eas/install_node_modules`.

Tested with https://github.com/expo/eas-custom-builds-example