### PR TITLE
[build-tools] add project id validation

### DIFF
--- a/packages/build-tools/src/common/setup.ts
+++ b/packages/build-tools/src/common/setup.ts
@@ -164,10 +164,10 @@ async function validateAppConfigAsync(
     }
     throw new UserFacingError(
       'EAS_BUILD_PROJECT_ID_MISMATCH',
-      `The value of the "extra.projectId" field in app config does not match current project id. ${extraMessage}Learn more: https://expo.fyi/eas-config-mismatch.`
+      `The value of the "extra.eas.projectId" field (${appConfig.extra.eas.projectId}) in the app config does not match the current project id (${ctx.env.EAS_BUILD_PROJECT_ID}). ${extraMessage}Learn more: https://expo.fyi/eas-config-mismatch.`
     );
   } else if (ctx.env.EAS_BUILD_PROJECT_ID && !appConfig?.extra?.eas?.projectId) {
-    ctx.logger.error(`The "extra.projectId" field is missing from your app config.`);
+    ctx.logger.error(`The "extra.eas.projectId" field is missing from your app config.`);
     ctx.markBuildPhaseHasWarnings();
   }
 }

--- a/packages/build-tools/src/common/setup.ts
+++ b/packages/build-tools/src/common/setup.ts
@@ -144,9 +144,9 @@ async function validateAppConfigAsync(
   appConfig: ExpoConfig
 ): Promise<void> {
   if (
-    appConfig?.extra?.projectId &&
+    appConfig?.extra?.eas?.projectId &&
     ctx.env.EAS_BUILD_PROJECT_ID &&
-    appConfig.extra.projectId !== ctx.env.EAS_BUILD_PROJECT_ID
+    appConfig.extra.eas.projectId !== ctx.env.EAS_BUILD_PROJECT_ID
   ) {
     const isUsingDynamicConfig =
       (await fs.pathExists(path.join(ctx.getReactNativeProjectDirectory(), 'app.config.ts'))) ||
@@ -166,7 +166,7 @@ async function validateAppConfigAsync(
       'EAS_BUILD_PROJECT_ID_MISMATCH',
       `The value of the "extra.projectId" field in app config does not match current project id. ${extraMessage}Learn more: https://expo.fyi/eas-config-mismatch.`
     );
-  } else if (ctx.env.EAS_BUILD_PROJECT_ID && !appConfig?.extra?.projectId) {
+  } else if (ctx.env.EAS_BUILD_PROJECT_ID && !appConfig?.extra?.eas?.projectId) {
     ctx.logger.error(`The "extra.projectId" field is missing from your app config.`);
     ctx.markBuildPhaseHasWarnings();
   }


### PR DESCRIPTION
# Why

On the recent github sync @FiberJW pointed out that it's easy to configure a project where projectId in app config is different than real project id.

The same issue exists for non github build if user have some env variables set only locally but not on the EAS Build worker.

# How

I'm open to suggestions, I see 2 alternatives:
- (currently implemented in this PR) Mark the build phase as a warning and log an error, but do not abort the build process
- Throw an error when this happens.

There are also few other open questions:
- do we want to explain potential scenarios why this might happen or just that there is a mismatch?
- do we want to validate any other fileds like that e.g. slug/owner.
- do we want to limit this validation to managed projects only?

# Test Plan

tested with local builds by setting EAS_BUILD_PROJECT_ID manually