### PR TITLE
[build-tools][steps] fix building custom builds in non root dir

### DIFF
--- a/packages/build-tools/src/builders/custom.ts
+++ b/packages/build-tools/src/builders/custom.ts
@@ -30,7 +30,8 @@ export async function runCustomBuildAsync<T extends Job>(ctx: BuildContext<T>): 
     false,
     platformToBuildRuntimePlatform[ctx.job.platform],
     ctx.temporaryCustomBuildDirectory,
-    ctx.buildDirectory
+    ctx.buildDirectory,
+    ctx.getReactNativeProjectDirectory()
   );
   const easFunctions = getEasFunctions(ctx);
   const parser = new BuildConfigParser(buildStepContext, {

--- a/packages/build-tools/src/steps/functions/checkout.ts
+++ b/packages/build-tools/src/steps/functions/checkout.ts
@@ -8,7 +8,7 @@ export function createCheckoutBuildFunction(): BuildFunction {
     name: 'Checkout',
     fn: async (stepsCtx) => {
       stepsCtx.logger.info('Checking out project directory');
-      await fs.move(stepsCtx.projectSourceDirectory, stepsCtx.workingDirectory, {
+      await fs.move(stepsCtx.projectSourceDirectory, stepsCtx.projectTargetDirectory, {
         overwrite: true,
       });
     },

--- a/packages/steps/src/BuildStepContext.ts
+++ b/packages/steps/src/BuildStepContext.ts
@@ -9,7 +9,7 @@ import { BuildStepRuntimeError } from './errors.js';
 import { BuildRuntimePlatform } from './BuildRuntimePlatform.js';
 
 export class BuildStepContext {
-  public readonly baseWorkingDirectory: string;
+  public readonly stepsInternalBuildDirectory: string;
   public readonly workingDirectory: string;
 
   private stepById: Record<string, BuildStep> = {};
@@ -20,10 +20,12 @@ export class BuildStepContext {
     public readonly skipCleanup: boolean,
     public readonly runtimePlatform: BuildRuntimePlatform,
     public readonly projectSourceDirectory: string,
+    public readonly projectTargetDirectory: string,
     workingDirectory?: string
   ) {
-    this.baseWorkingDirectory = path.join(os.tmpdir(), 'eas-build', buildId);
-    this.workingDirectory = workingDirectory ?? path.join(this.baseWorkingDirectory, 'project');
+    this.stepsInternalBuildDirectory = path.join(os.tmpdir(), 'eas-build', buildId);
+    this.workingDirectory =
+      workingDirectory ?? path.join(this.stepsInternalBuildDirectory, 'project');
   }
 
   public registerStep(step: BuildStep): void {
@@ -51,6 +53,7 @@ export class BuildStepContext {
       this.skipCleanup,
       this.runtimePlatform,
       this.projectSourceDirectory,
+      this.projectTargetDirectory,
       workingDirectory ?? this.workingDirectory
     );
   }

--- a/packages/steps/src/BuildTemporaryFiles.ts
+++ b/packages/steps/src/BuildTemporaryFiles.ts
@@ -38,7 +38,7 @@ export async function cleanUpStepTemporaryDirectoriesAsync(
   ctx.logger.debug({ stepTemporaryDirectory }, 'Removed step temporary directory');
 }
 function getTemporaryStepDirPath(ctx: BuildStepContext, stepId: string): string {
-  return path.join(ctx.baseWorkingDirectory, 'steps', stepId);
+  return path.join(ctx.stepsInternalBuildDirectory, 'steps', stepId);
 }
 
 function getTemporaryScriptsDirPath(ctx: BuildStepContext, stepId: string): string {

--- a/packages/steps/src/__tests__/BuildStep-test.ts
+++ b/packages/steps/src/__tests__/BuildStep-test.ts
@@ -202,7 +202,7 @@ describe(BuildStep, () => {
       await fs.mkdir(baseStepCtx.workingDirectory, { recursive: true });
     });
     afterEach(async () => {
-      await fs.rm(baseStepCtx.baseWorkingDirectory, { recursive: true });
+      await fs.rm(baseStepCtx.stepsInternalBuildDirectory, { recursive: true });
     });
 
     it('sets status to FAIL when step fails', async () => {
@@ -472,7 +472,7 @@ describe(BuildStep, () => {
       await fs.mkdir(baseStepCtx.workingDirectory, { recursive: true });
     });
     afterEach(async () => {
-      await fs.rm(baseStepCtx.baseWorkingDirectory, { recursive: true });
+      await fs.rm(baseStepCtx.stepsInternalBuildDirectory, { recursive: true });
     });
 
     it('throws an error when the step has not been executed yet', async () => {
@@ -603,7 +603,7 @@ describe(BuildStep, () => {
       expect(lines.find((line) => line.match(ctx.buildId))).toBeTruthy();
       expect(
         lines.find((line) =>
-          line.startsWith(path.join(ctx.baseWorkingDirectory, 'steps/test1/outputs'))
+          line.startsWith(path.join(ctx.stepsInternalBuildDirectory, 'steps/test1/outputs'))
         )
       ).toBeTruthy();
       expect(lines.find((line) => line.match(ctx.workingDirectory))).toBeTruthy();
@@ -619,7 +619,7 @@ describe(BuildStep.prototype.canBeRunOnRuntimePlatform, () => {
     await fs.mkdir(baseStepCtx.workingDirectory, { recursive: true });
   });
   afterEach(async () => {
-    await fs.rm(baseStepCtx.baseWorkingDirectory, { recursive: true });
+    await fs.rm(baseStepCtx.stepsInternalBuildDirectory, { recursive: true });
   });
 
   it('returns true when the step does not have a platform filter', async () => {

--- a/packages/steps/src/__tests__/BuildStepContext-test.ts
+++ b/packages/steps/src/__tests__/BuildStepContext-test.ts
@@ -14,16 +14,17 @@ import { getError } from './utils/error.js';
 import { createMockLogger } from './utils/logger.js';
 
 describe(BuildStepContext, () => {
-  describe('baseWorkingDirectory', () => {
+  describe('stepsInternalBuildDirectory', () => {
     it('is in os.tmpdir()', () => {
       const ctx = new BuildStepContext(
         uuidv4(),
         createMockLogger(),
         false,
         BuildRuntimePlatform.LINUX,
-        '/non/existent/path'
+        '/non/existent/path',
+        '/another/non/existent/path'
       );
-      expect(ctx.baseWorkingDirectory.startsWith(os.tmpdir())).toBe(true);
+      expect(ctx.stepsInternalBuildDirectory.startsWith(os.tmpdir())).toBe(true);
     });
     it('uses the build id as a path component', () => {
       const buildId = uuidv4();
@@ -32,21 +33,23 @@ describe(BuildStepContext, () => {
         createMockLogger(),
         false,
         BuildRuntimePlatform.LINUX,
-        '/non/existent/path'
+        '/non/existent/path',
+        '/another/non/existent/path'
       );
-      expect(ctx.baseWorkingDirectory).toMatch(buildId);
+      expect(ctx.stepsInternalBuildDirectory).toMatch(buildId);
     });
   });
   describe('workingDirectory', () => {
-    it('defaults to "project" directory in ctx.baseWorkingDirectory', () => {
+    it('defaults to "project" directory in ctx.stepsInternalBuildDirectory', () => {
       const ctx = new BuildStepContext(
         uuidv4(),
         createMockLogger(),
         false,
         BuildRuntimePlatform.LINUX,
-        '/non/existent/path'
+        '/non/existent/path',
+        '/another/non/existent/path'
       );
-      expect(ctx.workingDirectory).toBe(path.join(ctx.baseWorkingDirectory, 'project'));
+      expect(ctx.workingDirectory).toBe(path.join(ctx.stepsInternalBuildDirectory, 'project'));
     });
     it('can use the workingDirectory passed to the constructor', () => {
       const workingDirectory = '/path/to/working/dir';
@@ -56,6 +59,7 @@ describe(BuildStepContext, () => {
         false,
         BuildRuntimePlatform.LINUX,
         '/non/existent/path',
+        '/another/non/existent/path',
         workingDirectory
       );
       expect(ctx.workingDirectory).toBe(workingDirectory);

--- a/packages/steps/src/__tests__/utils/context.ts
+++ b/packages/steps/src/__tests__/utils/context.ts
@@ -12,6 +12,7 @@ interface BuildContextParams {
   skipCleanup?: boolean;
   runtimePlatform?: BuildRuntimePlatform;
   projectSourceDirectory?: string;
+  projectTargetDirectory?: string;
   workingDirectory?: string;
 }
 
@@ -21,6 +22,7 @@ export function createMockContext({
   skipCleanup,
   runtimePlatform,
   projectSourceDirectory,
+  projectTargetDirectory,
   workingDirectory,
 }: BuildContextParams = {}): BuildStepContext {
   return new BuildStepContext(
@@ -29,6 +31,7 @@ export function createMockContext({
     skipCleanup ?? false,
     runtimePlatform ?? BuildRuntimePlatform.LINUX,
     projectSourceDirectory ?? '/non/existent/dir',
+    projectTargetDirectory ?? '/another/non/existent/dir',
     workingDirectory
   );
 }

--- a/packages/steps/src/cli/cli.ts
+++ b/packages/steps/src/cli/cli.ts
@@ -15,7 +15,7 @@ const logger = createLogger({
 
 async function runAsync(
   configPath: string,
-  workingDirectory: string,
+  relativeProjectDirectory: string,
   runtimePlatform: BuildRuntimePlatform
 ): Promise<void> {
   const fakeBuildId = uuidv4();
@@ -24,8 +24,9 @@ async function runAsync(
     logger,
     false,
     runtimePlatform,
-    workingDirectory,
-    workingDirectory
+    relativeProjectDirectory,
+    relativeProjectDirectory,
+    relativeProjectDirectory
   );
   const parser = new BuildConfigParser(ctx, { configPath });
   const workflow = await parser.parseAsync();
@@ -33,17 +34,17 @@ async function runAsync(
 }
 
 const relativeConfigPath = process.argv[2];
-const relativeWorkingDirectoryPath = process.argv[3];
+const relativeProjectDirectoryPath = process.argv[3];
 const platform: BuildRuntimePlatform = (process.argv[4] ??
   process.platform) as BuildRuntimePlatform;
 
-if (!relativeConfigPath || !relativeWorkingDirectoryPath) {
-  console.error('Usage: yarn cli config.yml path/to/working/directory [darwin|linux]');
+if (!relativeConfigPath || !relativeProjectDirectoryPath) {
+  console.error('Usage: yarn cli config.yml path/to/project/directory [darwin|linux]');
   process.exit(1);
 }
 
 const configPath = path.resolve(process.cwd(), relativeConfigPath);
-const workingDirectory = path.resolve(process.cwd(), relativeWorkingDirectoryPath);
+const workingDirectory = path.resolve(process.cwd(), relativeProjectDirectoryPath);
 
 runAsync(configPath, workingDirectory, platform).catch((err) => {
   logger.error({ err }, 'Build failed');


### PR DESCRIPTION
# Why

When working on system tests for custom builds, I realized we don't support building custom builds in a non-root project directory (e.g. when you have a monorepo). This PR fixes the issue.


# How

- Introduced `projectTargetDirectory` to `BuildStepContext` so now there are three paths:
  - `projectSourceDirectory` - temporary path where the project archive is initially unarchived
  - `projectTargetDir` - project root or monorepo/repo root
  - `workingDirectory` -  the so-called "react native directory"
- Renamed `baseWorkingDirectory` to `stepsInternalBuildDirectory` to make it more descriptive.

# Test Plan

- Updated tests.
- Manually tested all examples from `packages/steps/examples`.
- I added a project with custom builds to https://github.com/expo/turtle-v2-example and was able to build the project.