### PR TITLE
[ENG-8775][build-tools][eas-build-job] add credentials to custom builds

### DIFF
--- a/packages/build-tools/src/android/credentials.ts
+++ b/packages/build-tools/src/android/credentials.ts
@@ -2,32 +2,14 @@ import path from 'path';
 
 import { Android } from '@expo/eas-build-job';
 import fs from 'fs-extra';
-import nullthrows from 'nullthrows';
-import { v4 as uuidv4 } from 'uuid';
 
 import { BuildContext } from '../context';
+import { prepareAndroidCredentials } from '../utils/credentials';
 
 async function restoreCredentials(ctx: BuildContext<Android.Job>): Promise<void> {
-  const { buildCredentials } = nullthrows(
-    ctx.job.secrets,
-    'Secrets must be defined for non-custom builds'
-  );
-  if (!buildCredentials) {
-    // TODO: sentry (should be detected earlier)
-    throw new Error('secrets are missing in the job object');
-  }
-  ctx.logger.info("Writing secrets to the project's directory");
-  const keystorePath = path.join(ctx.buildDirectory, `keystore-${uuidv4()}`);
-  await fs.writeFile(keystorePath, Buffer.from(buildCredentials.keystore.dataBase64, 'base64'));
+  const androidCredentials = await prepareAndroidCredentials(ctx, ctx.logger);
   const credentialsJson = {
-    android: {
-      keystore: {
-        keystorePath,
-        keystorePassword: buildCredentials.keystore.keystorePassword,
-        keyAlias: buildCredentials.keystore.keyAlias,
-        keyPassword: buildCredentials.keystore.keyPassword,
-      },
-    },
+    android: androidCredentials,
   };
   await fs.writeFile(
     path.join(ctx.buildDirectory, 'credentials.json'),

--- a/packages/build-tools/src/builders/android.ts
+++ b/packages/build-tools/src/builders/android.ts
@@ -1,5 +1,4 @@
 import { Android, BuildMode, BuildPhase, Workflow } from '@expo/eas-build-job';
-import nullthrows from 'nullthrows';
 
 import { Artifacts, ArtifactType, BuildContext, SkipNativeBuildError } from '../context';
 import { configureExpoUpdatesIfInstalledAsync } from '../utils/expoUpdates';
@@ -55,9 +54,7 @@ async function buildAsync(ctx: BuildContext<Android.Job>): Promise<void> {
     await runHookIfPresent(ctx, Hook.POST_INSTALL);
   });
 
-  if (
-    nullthrows(ctx.job.secrets, 'Secrets must be defined for non-custom builds').buildCredentials
-  ) {
+  if (ctx.job.secrets.buildCredentials) {
     await ctx.runBuildPhase(BuildPhase.PREPARE_CREDENTIALS, async () => {
       await restoreCredentials(ctx);
       await configureBuildGradle(ctx);

--- a/packages/build-tools/src/builders/custom.ts
+++ b/packages/build-tools/src/builders/custom.ts
@@ -1,7 +1,13 @@
 import path from 'path';
 
 import { BuildPhase, Job, Platform } from '@expo/eas-build-job';
-import { BuildConfigParser, BuildStepContext, errors, BuildRuntimePlatform } from '@expo/steps';
+import {
+  BuildConfigParser,
+  BuildStepContext,
+  errors,
+  BuildRuntimePlatform,
+  emptyEasContext,
+} from '@expo/steps';
 import nullthrows from 'nullthrows';
 
 import { Artifacts, BuildContext } from '../context';
@@ -31,7 +37,7 @@ export async function runCustomBuildAsync<T extends Job>(ctx: BuildContext<T>): 
     platformToBuildRuntimePlatform[ctx.job.platform],
     ctx.temporaryCustomBuildDirectory,
     ctx.buildDirectory,
-    {},
+    emptyEasContext,
     ctx.getReactNativeProjectDirectory()
   );
   const easFunctions = getEasFunctions(ctx);

--- a/packages/build-tools/src/builders/custom.ts
+++ b/packages/build-tools/src/builders/custom.ts
@@ -31,7 +31,7 @@ export async function runCustomBuildAsync<T extends Job>(ctx: BuildContext<T>): 
     platformToBuildRuntimePlatform[ctx.job.platform],
     ctx.temporaryCustomBuildDirectory,
     ctx.buildDirectory,
-    { env: ctx.env },
+    {},
     ctx.getReactNativeProjectDirectory()
   );
   const easFunctions = getEasFunctions(ctx);
@@ -53,7 +53,7 @@ export async function runCustomBuildAsync<T extends Job>(ctx: BuildContext<T>): 
     }
   });
   try {
-    await workflow.executeAsync();
+    await workflow.executeAsync(ctx.env);
   } catch (err: any) {
     err.artifacts = ctx.artifacts;
     throw err;

--- a/packages/build-tools/src/builders/custom.ts
+++ b/packages/build-tools/src/builders/custom.ts
@@ -31,6 +31,7 @@ export async function runCustomBuildAsync<T extends Job>(ctx: BuildContext<T>): 
     platformToBuildRuntimePlatform[ctx.job.platform],
     ctx.temporaryCustomBuildDirectory,
     ctx.buildDirectory,
+    { env: ctx.env },
     ctx.getReactNativeProjectDirectory()
   );
   const easFunctions = getEasFunctions(ctx);
@@ -52,7 +53,7 @@ export async function runCustomBuildAsync<T extends Job>(ctx: BuildContext<T>): 
     }
   });
   try {
-    await workflow.executeAsync(ctx.env);
+    await workflow.executeAsync();
   } catch (err: any) {
     err.artifacts = ctx.artifacts;
     throw err;

--- a/packages/build-tools/src/common/easBuildInternal.ts
+++ b/packages/build-tools/src/common/easBuildInternal.ts
@@ -4,7 +4,6 @@ import { Env, Job, Metadata, sanitizeJob, sanitizeMetadata } from '@expo/eas-bui
 import { PipeMode } from '@expo/logger';
 import spawn from '@expo/turtle-spawn';
 import Joi from 'joi';
-import nullthrows from 'nullthrows';
 
 import { BuildContext } from '../context';
 import { isAtLeastNpm7Async } from '../utils/packageManager';
@@ -30,8 +29,7 @@ export async function runEasBuildInternalAsync<TJob extends Job>(
       cwd: ctx.getReactNativeProjectDirectory(),
       env: {
         ...ctx.env,
-        EXPO_TOKEN: nullthrows(ctx.job.secrets, 'Secrets must be defined for non-custom builds')
-          .robotAccessToken,
+        EXPO_TOKEN: ctx.job.secrets.robotAccessToken,
         ...extraEnv,
       },
       logger: ctx.logger,

--- a/packages/build-tools/src/context.ts
+++ b/packages/build-tools/src/context.ts
@@ -10,7 +10,6 @@ import {
   errors,
   Metadata,
   EnvironmentSecretType,
-  Ios,
 } from '@expo/eas-build-job';
 import { ExpoConfig } from '@expo/config';
 import { bunyan } from '@expo/logger';
@@ -21,8 +20,6 @@ import { PackageManager, resolvePackageManager } from './utils/packageManager';
 import { resolveBuildPhaseErrorAsync } from './buildErrors/detectError';
 import { readAppConfig } from './utils/appConfig';
 import { createTemporaryEnvironmentSecretFile } from './utils/environmentSecrets';
-import { IosCredentials } from './ios/credentials/manager';
-import { AndroidCredentials } from './utils/credentials';
 
 export enum ArtifactType {
   APPLICATION_ARCHIVE = 'APPLICATION_ARCHIVE',
@@ -92,7 +89,6 @@ export class BuildContext<TJob extends Job> {
   ) => void;
   public readonly skipNativeBuild?: boolean;
   public artifacts: Artifacts = {};
-  public credentials: (TJob extends Ios.Job ? IosCredentials : AndroidCredentials) | null = null;
 
   private _env: Env;
   private _job: TJob;

--- a/packages/build-tools/src/context.ts
+++ b/packages/build-tools/src/context.ts
@@ -10,6 +10,7 @@ import {
   errors,
   Metadata,
   EnvironmentSecretType,
+  Ios,
 } from '@expo/eas-build-job';
 import { ExpoConfig } from '@expo/config';
 import { bunyan } from '@expo/logger';
@@ -20,6 +21,8 @@ import { PackageManager, resolvePackageManager } from './utils/packageManager';
 import { resolveBuildPhaseErrorAsync } from './buildErrors/detectError';
 import { readAppConfig } from './utils/appConfig';
 import { createTemporaryEnvironmentSecretFile } from './utils/environmentSecrets';
+import { IosCredentials } from './ios/credentials/manager';
+import { AndroidCredentials } from './utils/credentials';
 
 export enum ArtifactType {
   APPLICATION_ARCHIVE = 'APPLICATION_ARCHIVE',
@@ -89,6 +92,7 @@ export class BuildContext<TJob extends Job> {
   ) => void;
   public readonly skipNativeBuild?: boolean;
   public artifacts: Artifacts = {};
+  public credentials: (TJob extends Ios.Job ? IosCredentials : AndroidCredentials) | null = null;
 
   private _env: Env;
   private _job: TJob;

--- a/packages/build-tools/src/ios/__tests__/configure.test.ts
+++ b/packages/build-tools/src/ios/__tests__/configure.test.ts
@@ -1,10 +1,9 @@
 import path from 'path';
 
-import { Ios } from '@expo/eas-build-job';
 import { vol } from 'memfs';
 
 import { configureXcodeProject } from '../configure';
-import ProvisioningProfile, { DistributionType } from '../credentials/provisioningProfile';
+import { DistributionType, ProvisioningProfileData } from '../credentials/provisioningProfile';
 
 jest.mock('fs');
 const originalFs = jest.requireActual('fs');
@@ -43,7 +42,7 @@ describe(configureXcodeProject, () => {
         },
         distributionType: DistributionType.APP_STORE,
         teamId: 'ABCDEFGH',
-        applicationTargetProvisioningProfile: {} as ProvisioningProfile<Ios.Job>,
+        applicationTargetProvisioningProfile: {} as ProvisioningProfileData,
       },
       buildConfiguration: 'Release',
     };
@@ -97,7 +96,7 @@ describe(configureXcodeProject, () => {
         },
         distributionType: DistributionType.APP_STORE,
         teamId: 'ABCDEFGH',
-        applicationTargetProvisioningProfile: {} as ProvisioningProfile<Ios.Job>,
+        applicationTargetProvisioningProfile: {} as ProvisioningProfileData,
       },
       buildConfiguration: 'Release',
     };
@@ -144,7 +143,7 @@ describe(configureXcodeProject, () => {
         },
         distributionType: DistributionType.APP_STORE,
         teamId: 'ABCDEFGH',
-        applicationTargetProvisioningProfile: {} as ProvisioningProfile<Ios.Job>,
+        applicationTargetProvisioningProfile: {} as ProvisioningProfileData,
       },
       buildConfiguration: 'Release',
     };
@@ -214,7 +213,7 @@ describe(configureXcodeProject, () => {
         },
         distributionType: DistributionType.APP_STORE,
         teamId: 'ABCDEFGH',
-        applicationTargetProvisioningProfile: {} as ProvisioningProfile<Ios.Job>,
+        applicationTargetProvisioningProfile: {} as ProvisioningProfileData,
       },
       buildConfiguration: 'Release',
     };

--- a/packages/build-tools/src/ios/configure.ts
+++ b/packages/build-tools/src/ios/configure.ts
@@ -8,7 +8,7 @@ import plist from '@expo/plist';
 
 import { BuildContext } from '../context';
 
-import { Credentials } from './credentials/manager';
+import { IosCredentials } from './credentials/manager';
 
 async function configureXcodeProject(
   ctx: BuildContext<Ios.Job>,
@@ -16,7 +16,7 @@ async function configureXcodeProject(
     credentials,
     buildConfiguration,
   }: {
-    credentials: Credentials;
+    credentials: IosCredentials;
     buildConfiguration: string;
   }
 ): Promise<void> {
@@ -40,7 +40,7 @@ async function configureCredentialsAsync(
     credentials,
     buildConfiguration,
   }: {
-    credentials: Credentials;
+    credentials: IosCredentials;
     buildConfiguration: string;
   }
 ): Promise<void> {

--- a/packages/build-tools/src/ios/credentials/__tests__/manager.test.ios.ts
+++ b/packages/build-tools/src/ios/credentials/__tests__/manager.test.ios.ts
@@ -6,7 +6,7 @@ import { BuildMode, BuildTrigger } from '@expo/eas-build-job/dist/common';
 
 import { BuildContext } from '../../../context';
 import { distributionCertificate, provisioningProfile } from '../__tests__/fixtures';
-import IosCredentialsManager from '../manager';
+import { getIosCredentialsManager } from '../manager';
 
 jest.setTimeout(60 * 1000);
 
@@ -51,7 +51,7 @@ function createTestIosJob({
   };
 }
 
-describe(IosCredentialsManager, () => {
+describe('IosCredentialsManager', () => {
   describe('.prepare', () => {
     it('should prepare credentials for the build process', async () => {
       const targetName = 'testapp';
@@ -71,8 +71,8 @@ describe(IosCredentialsManager, () => {
         runGlobalExpoCliCommand: jest.fn(),
         uploadArtifacts: jest.fn(),
       });
-      const manager = new IosCredentialsManager(ctx);
-      const credentials = await manager.prepare();
+      const manager = getIosCredentialsManager();
+      const credentials = await manager.prepare(ctx, ctx.logger);
       await manager.cleanUp();
 
       assert(credentials, 'credentials must be defined');

--- a/packages/build-tools/src/ios/credentials/__tests__/manager.test.ios.ts
+++ b/packages/build-tools/src/ios/credentials/__tests__/manager.test.ios.ts
@@ -73,7 +73,7 @@ describe('IosCredentialsManager', () => {
       });
       const manager = getIosCredentialsManager();
       const credentials = await manager.prepare(ctx, ctx.logger);
-      await manager.cleanUp();
+      await manager.cleanUp(ctx.logger);
 
       assert(credentials, 'credentials must be defined');
 

--- a/packages/build-tools/src/ios/credentials/manager.ts
+++ b/packages/build-tools/src/ios/credentials/manager.ts
@@ -17,8 +17,9 @@ import ProvisioningProfile, {
   ProvisioningProfileData,
 } from './provisioningProfile';
 
+// keep in sync with EasContext.credentials.ios in @expo/steps package
 export interface IosCredentials {
-  applicationTargetProvisioningProfile: ProvisioningProfile<Ios.Job>;
+  applicationTargetProvisioningProfile: ProvisioningProfileData;
   keychainPath: string;
   targetProvisioningProfiles: TargetProvisioningProfiles;
   distributionType: DistributionType;
@@ -74,7 +75,7 @@ class IosCredentialsManager<TJob extends Ios.Job> {
     const { distributionType, teamId } = applicationTargetProvisioningProfile.data;
 
     return {
-      applicationTargetProvisioningProfile,
+      applicationTargetProvisioningProfile: applicationTargetProvisioningProfile.data,
       keychainPath: this.keychain.data.path,
       targetProvisioningProfiles,
       distributionType,
@@ -82,10 +83,13 @@ class IosCredentialsManager<TJob extends Ios.Job> {
     };
   }
 
-  public async cleanUp(): Promise<void> {
+  public async cleanUp(logger: bunyan): Promise<void> {
     if (this.cleanedUp || (!this.keychain && this.provisioningProfiles.length === 0)) {
+      logger.info('Nothing to clean up');
       return;
     }
+
+    logger.info('Cleaning up iOS credentials');
 
     if (this.keychain) {
       await this.keychain.destroy();
@@ -154,7 +158,7 @@ class IosCredentialsManager<TJob extends Ios.Job> {
 
       return provisioningProfile;
     } catch (err) {
-      await this.cleanUp();
+      await this.cleanUp(logger);
       throw err;
     }
   }

--- a/packages/build-tools/src/ios/fastlane.ts
+++ b/packages/build-tools/src/ios/fastlane.ts
@@ -55,7 +55,7 @@ export async function runFastlaneResign<TJob extends Ios.Job>(
   ctx: BuildContext<TJob>,
   { credentials, ipaPath }: { credentials: IosCredentials; ipaPath: string }
 ): Promise<void> {
-  const { certificateCommonName } = credentials.applicationTargetProvisioningProfile.data;
+  const { certificateCommonName } = credentials.applicationTargetProvisioningProfile;
 
   const fastlaneDirPath = path.join(ctx.buildDirectory, 'fastlane');
   await fs.ensureDir(fastlaneDirPath);

--- a/packages/build-tools/src/ios/fastlane.ts
+++ b/packages/build-tools/src/ios/fastlane.ts
@@ -9,7 +9,7 @@ import nullthrows from 'nullthrows';
 import { BuildContext, SkipNativeBuildError } from '../context';
 
 import { createGymfileForArchiveBuild, createGymfileForSimulatorBuild } from './gymfile';
-import { Credentials } from './credentials/manager';
+import { IosCredentials } from './credentials/manager';
 import { XcodeBuildLogger } from './xcpretty';
 import { isTVOS } from './tvos';
 import { createFastfileForResigningBuild } from './fastfile';
@@ -24,7 +24,7 @@ export async function runFastlaneGym<TJob extends Ios.Job>(
   }: {
     scheme: string;
     buildConfiguration?: string;
-    credentials: Credentials | null;
+    credentials: IosCredentials | null;
     entitlements: object | null;
   }
 ): Promise<void> {
@@ -53,7 +53,7 @@ export async function runFastlaneGym<TJob extends Ios.Job>(
 
 export async function runFastlaneResign<TJob extends Ios.Job>(
   ctx: BuildContext<TJob>,
-  { credentials, ipaPath }: { credentials: Credentials; ipaPath: string }
+  { credentials, ipaPath }: { credentials: IosCredentials; ipaPath: string }
 ): Promise<void> {
   const { certificateCommonName } = credentials.applicationTargetProvisioningProfile.data;
 
@@ -113,7 +113,7 @@ async function ensureGymfileExists<TJob extends Ios.Job>(
   }: {
     scheme: string;
     buildConfiguration?: string;
-    credentials: Credentials | null;
+    credentials: IosCredentials | null;
     logsDirectory: string;
     entitlements: object | null;
   }

--- a/packages/build-tools/src/ios/gymfile.ts
+++ b/packages/build-tools/src/ios/gymfile.ts
@@ -3,7 +3,7 @@ import path from 'path';
 import templateFile from '@expo/template-file';
 import fs from 'fs-extra';
 
-import { Credentials } from './credentials/manager';
+import { IosCredentials } from './credentials/manager';
 
 const ARCHIVE_TEMPLATE_FILE_PATH = path.join(__dirname, '../../templates/Gymfile.archive.template');
 const SIMULATOR_TEMPLATE_FILE_PATH = path.join(
@@ -13,7 +13,7 @@ const SIMULATOR_TEMPLATE_FILE_PATH = path.join(
 
 interface ArchiveBuildOptions {
   outputFile: string;
-  credentials: Credentials;
+  credentials: IosCredentials;
   scheme: string;
   buildConfiguration?: string;
   outputDirectory: string;

--- a/packages/build-tools/src/steps/easFunctions.ts
+++ b/packages/build-tools/src/steps/easFunctions.ts
@@ -7,6 +7,8 @@ import { createUploadArtifactBuildFunction } from './functions/uploadArtifact';
 import { createCheckoutBuildFunction } from './functions/checkout';
 import { createSetUpNpmrcBuildFunction } from './functions/setUpNpmrc';
 import { createInstallNodeModulesBuildFunction } from './functions/installNodeModules';
+import { createPrepareCredentialsBuildFunction } from './functions/prepareCredentials';
+import { createCleanUpCredentialsBuildFunction } from './functions/cleanUpCredentials';
 
 export function getEasFunctions<T extends Job>(ctx: BuildContext<T>): BuildFunction[] {
   return [
@@ -14,5 +16,7 @@ export function getEasFunctions<T extends Job>(ctx: BuildContext<T>): BuildFunct
     createUploadArtifactBuildFunction(ctx),
     createSetUpNpmrcBuildFunction(ctx),
     createInstallNodeModulesBuildFunction(ctx),
+    createPrepareCredentialsBuildFunction(ctx),
+    createCleanUpCredentialsBuildFunction(ctx),
   ];
 }

--- a/packages/build-tools/src/steps/easFunctions.ts
+++ b/packages/build-tools/src/steps/easFunctions.ts
@@ -17,6 +17,6 @@ export function getEasFunctions<T extends Job>(ctx: BuildContext<T>): BuildFunct
     createSetUpNpmrcBuildFunction(ctx),
     createInstallNodeModulesBuildFunction(ctx),
     createPrepareCredentialsBuildFunction(ctx),
-    createCleanUpCredentialsBuildFunction(),
+    createCleanUpCredentialsBuildFunction(ctx),
   ];
 }

--- a/packages/build-tools/src/steps/easFunctions.ts
+++ b/packages/build-tools/src/steps/easFunctions.ts
@@ -17,6 +17,6 @@ export function getEasFunctions<T extends Job>(ctx: BuildContext<T>): BuildFunct
     createSetUpNpmrcBuildFunction(ctx),
     createInstallNodeModulesBuildFunction(ctx),
     createPrepareCredentialsBuildFunction(ctx),
-    createCleanUpCredentialsBuildFunction(ctx),
+    createCleanUpCredentialsBuildFunction(),
   ];
 }

--- a/packages/build-tools/src/steps/functions/cleanUpCredentials.ts
+++ b/packages/build-tools/src/steps/functions/cleanUpCredentials.ts
@@ -19,6 +19,9 @@ export function createCleanUpCredentialsBuildFunction<T extends Job>(
         android: undefined,
         ios: undefined,
       };
+      stepsCtx.logger.info(
+        'Cleared  ${ easCtx.credentials.ios } and ${ easCtx.credentials.android } values'
+      );
     },
   });
 }

--- a/packages/build-tools/src/steps/functions/cleanUpCredentials.ts
+++ b/packages/build-tools/src/steps/functions/cleanUpCredentials.ts
@@ -11,6 +11,7 @@ export function createCleanUpCredentialsBuildFunction<T extends Job>(
     namespace: 'eas',
     id: 'clean_up_credentials',
     name: 'Clean up credentials',
+    enforceBuildStepShouldAlwaysRun: true,
     fn: async (stepsCtx) => {
       if (ctx.job.platform === Platform.IOS) {
         await cleanUpIosCredentials(stepsCtx.logger);

--- a/packages/build-tools/src/steps/functions/cleanUpCredentials.ts
+++ b/packages/build-tools/src/steps/functions/cleanUpCredentials.ts
@@ -15,12 +15,9 @@ export function createCleanUpCredentialsBuildFunction<T extends Job>(
       if (ctx.job.platform === Platform.IOS) {
         await cleanUpIosCredentials(stepsCtx.logger);
       }
-      stepsCtx.sharedEasContext = {
-        ...stepsCtx.sharedEasContext,
-        credentials: {
-          android: undefined,
-          ios: undefined,
-        },
+      stepsCtx.sharedEasContext.credentials = {
+        android: undefined,
+        ios: undefined,
       };
     },
   });

--- a/packages/build-tools/src/steps/functions/cleanUpCredentials.ts
+++ b/packages/build-tools/src/steps/functions/cleanUpCredentials.ts
@@ -1,15 +1,27 @@
-import { BuildFunction, BuildRuntimePlatform } from '@expo/steps';
+import { BuildFunction } from '@expo/steps';
+import { Job, Platform } from '@expo/eas-build-job';
 
 import { cleanUpIosCredentials } from '../../utils/credentials';
+import { BuildContext } from '../../context';
 
-export function createCleanUpCredentialsBuildFunction(): BuildFunction {
+export function createCleanUpCredentialsBuildFunction<T extends Job>(
+  ctx: BuildContext<T>
+): BuildFunction {
   return new BuildFunction({
     namespace: 'eas',
-    id: 'clean_up_ios_credentials',
-    name: 'Clean up iOS credentials',
-    supportedRuntimePlatforms: [BuildRuntimePlatform.DARWIN],
+    id: 'clean_up_credentials',
+    name: 'Clean up credentials',
     fn: async (stepsCtx) => {
-      await cleanUpIosCredentials(stepsCtx.logger);
+      if (ctx.job.platform === Platform.IOS) {
+        await cleanUpIosCredentials(stepsCtx.logger);
+      }
+      stepsCtx.sharedEasContext = {
+        ...stepsCtx.sharedEasContext,
+        credentials: {
+          android: undefined,
+          ios: undefined,
+        },
+      };
     },
   });
 }

--- a/packages/build-tools/src/steps/functions/cleanUpCredentials.ts
+++ b/packages/build-tools/src/steps/functions/cleanUpCredentials.ts
@@ -1,0 +1,19 @@
+import { Ios, Job } from '@expo/eas-build-job';
+import { BuildFunction, BuildRuntimePlatform } from '@expo/steps';
+
+import { BuildContext } from '../../context';
+import { cleanUpIosCredentials } from '../../utils/credentials';
+
+export function createCleanUpCredentialsBuildFunction<T extends Job>(
+  ctx: BuildContext<T>
+): BuildFunction {
+  return new BuildFunction({
+    namespace: 'eas',
+    id: 'clean_up_ios_credentials',
+    name: 'Clean up iOS credentials',
+    supportedRuntimePlatforms: [BuildRuntimePlatform.DARWIN],
+    fn: async (stepsCtx) => {
+      await cleanUpIosCredentials(ctx as BuildContext<Ios.Job>, stepsCtx.logger);
+    },
+  });
+}

--- a/packages/build-tools/src/steps/functions/cleanUpCredentials.ts
+++ b/packages/build-tools/src/steps/functions/cleanUpCredentials.ts
@@ -1,19 +1,15 @@
-import { Ios, Job } from '@expo/eas-build-job';
 import { BuildFunction, BuildRuntimePlatform } from '@expo/steps';
 
-import { BuildContext } from '../../context';
 import { cleanUpIosCredentials } from '../../utils/credentials';
 
-export function createCleanUpCredentialsBuildFunction<T extends Job>(
-  ctx: BuildContext<T>
-): BuildFunction {
+export function createCleanUpCredentialsBuildFunction(): BuildFunction {
   return new BuildFunction({
     namespace: 'eas',
     id: 'clean_up_ios_credentials',
     name: 'Clean up iOS credentials',
     supportedRuntimePlatforms: [BuildRuntimePlatform.DARWIN],
     fn: async (stepsCtx) => {
-      await cleanUpIosCredentials(ctx as BuildContext<Ios.Job>, stepsCtx.logger);
+      await cleanUpIosCredentials(stepsCtx.logger);
     },
   });
 }

--- a/packages/build-tools/src/steps/functions/prepareCredentials.ts
+++ b/packages/build-tools/src/steps/functions/prepareCredentials.ts
@@ -1,0 +1,22 @@
+import { BuildFunction } from '@expo/steps';
+import { Android, Ios, Job, Platform } from '@expo/eas-build-job';
+
+import { BuildContext } from '../../context';
+import { prepareAndroidCredentials, prepareIosCredentials } from '../../utils/credentials';
+
+export function createPrepareCredentialsBuildFunction<T extends Job>(
+  ctx: BuildContext<T>
+): BuildFunction {
+  return new BuildFunction({
+    namespace: 'eas',
+    id: 'prepare_credentials',
+    name: 'Prepare credentials',
+    fn: async (stepsCtx) => {
+      if (ctx.job.platform === Platform.ANDROID) {
+        await prepareAndroidCredentials(ctx as BuildContext<Android.Job>, stepsCtx.logger);
+      } else {
+        await prepareIosCredentials(ctx as BuildContext<Ios.Job>, stepsCtx.logger);
+      }
+    },
+  });
+}

--- a/packages/build-tools/src/steps/functions/prepareCredentials.ts
+++ b/packages/build-tools/src/steps/functions/prepareCredentials.ts
@@ -21,6 +21,7 @@ export function createPrepareCredentialsBuildFunction<T extends Job>(
           ...stepsCtx.sharedEasContext.credentials,
           android: androidCredentials,
         };
+        stepsCtx.logger.info('Set  ${ easCtx.credentials.android } values');
       } else {
         const iosCredentials = await prepareIosCredentials(
           ctx as BuildContext<Ios.Job>,
@@ -30,6 +31,7 @@ export function createPrepareCredentialsBuildFunction<T extends Job>(
           ...stepsCtx.sharedEasContext.credentials,
           ios: iosCredentials,
         };
+        stepsCtx.logger.info('Set  ${ easCtx.credentials.ios } values');
       }
     },
   });

--- a/packages/build-tools/src/steps/functions/prepareCredentials.ts
+++ b/packages/build-tools/src/steps/functions/prepareCredentials.ts
@@ -20,7 +20,7 @@ export function createPrepareCredentialsBuildFunction<T extends Job>(
         stepsCtx.sharedEasContext = {
           ...stepsCtx.sharedEasContext,
           credentials: {
-            ...(stepsCtx.sharedEasContext.credentials ?? {}),
+            ...stepsCtx.sharedEasContext.credentials,
             android: androidCredentials,
           },
         };
@@ -32,7 +32,7 @@ export function createPrepareCredentialsBuildFunction<T extends Job>(
         stepsCtx.sharedEasContext = {
           ...stepsCtx.sharedEasContext,
           credentials: {
-            ...(stepsCtx.sharedEasContext.credentials ?? {}),
+            ...stepsCtx.sharedEasContext.credentials,
             ios: iosCredentials,
           },
         };

--- a/packages/build-tools/src/steps/functions/prepareCredentials.ts
+++ b/packages/build-tools/src/steps/functions/prepareCredentials.ts
@@ -13,9 +13,29 @@ export function createPrepareCredentialsBuildFunction<T extends Job>(
     name: 'Prepare credentials',
     fn: async (stepsCtx) => {
       if (ctx.job.platform === Platform.ANDROID) {
-        await prepareAndroidCredentials(ctx as BuildContext<Android.Job>, stepsCtx.logger);
+        const androidCredentials = await prepareAndroidCredentials(
+          ctx as BuildContext<Android.Job>,
+          stepsCtx.logger
+        );
+        stepsCtx.sharedEasContext = {
+          ...stepsCtx.sharedEasContext,
+          credentials: {
+            ...(stepsCtx.sharedEasContext.credentials ?? {}),
+            android: androidCredentials,
+          },
+        };
       } else {
-        await prepareIosCredentials(ctx as BuildContext<Ios.Job>, stepsCtx.logger);
+        const iosCredentials = await prepareIosCredentials(
+          ctx as BuildContext<Ios.Job>,
+          stepsCtx.logger
+        );
+        stepsCtx.sharedEasContext = {
+          ...stepsCtx.sharedEasContext,
+          credentials: {
+            ...(stepsCtx.sharedEasContext.credentials ?? {}),
+            ios: iosCredentials,
+          },
+        };
       }
     },
   });

--- a/packages/build-tools/src/steps/functions/prepareCredentials.ts
+++ b/packages/build-tools/src/steps/functions/prepareCredentials.ts
@@ -17,24 +17,18 @@ export function createPrepareCredentialsBuildFunction<T extends Job>(
           ctx as BuildContext<Android.Job>,
           stepsCtx.logger
         );
-        stepsCtx.sharedEasContext = {
-          ...stepsCtx.sharedEasContext,
-          credentials: {
-            ...stepsCtx.sharedEasContext.credentials,
-            android: androidCredentials,
-          },
+        stepsCtx.sharedEasContext.credentials = {
+          ...stepsCtx.sharedEasContext.credentials,
+          android: androidCredentials,
         };
       } else {
         const iosCredentials = await prepareIosCredentials(
           ctx as BuildContext<Ios.Job>,
           stepsCtx.logger
         );
-        stepsCtx.sharedEasContext = {
-          ...stepsCtx.sharedEasContext,
-          credentials: {
-            ...stepsCtx.sharedEasContext.credentials,
-            ios: iosCredentials,
-          },
+        stepsCtx.sharedEasContext.credentials = {
+          ...stepsCtx.sharedEasContext.credentials,
+          ios: iosCredentials,
         };
       }
     },

--- a/packages/build-tools/src/utils/credentials.ts
+++ b/packages/build-tools/src/utils/credentials.ts
@@ -1,0 +1,62 @@
+import path from 'path';
+
+import { Android, Ios } from '@expo/eas-build-job';
+import { bunyan } from '@expo/logger';
+import { v4 as uuidv4 } from 'uuid';
+import fs from 'fs-extra';
+
+import { BuildContext } from '../context';
+import { getIosCredentialsManager } from '../ios/credentials/manager';
+
+export interface AndroidCredentials {
+  keystore: {
+    keystorePath: string;
+    keystorePassword: string;
+    keyAlias: string;
+    keyPassword?: string;
+  };
+}
+
+export async function prepareAndroidCredentials(
+  ctx: BuildContext<Android.Job>,
+  logger: bunyan
+): Promise<AndroidCredentials> {
+  const { buildCredentials } = ctx.job.secrets;
+
+  if (!buildCredentials) {
+    // TODO: sentry (should be detected earlier)
+    throw new Error('secrets are missing in the job object');
+  }
+  logger.info("Restoring project's secrets");
+  const keystorePath = path.join(ctx.buildDirectory, `keystore-${uuidv4()}`);
+  await fs.writeFile(keystorePath, Buffer.from(buildCredentials.keystore.dataBase64, 'base64'));
+  const credentialsJson = {
+    keystore: {
+      keystorePath,
+      keystorePassword: buildCredentials.keystore.keystorePassword,
+      keyAlias: buildCredentials.keystore.keyAlias,
+      keyPassword: buildCredentials.keystore.keyPassword,
+    },
+  };
+  return credentialsJson;
+}
+
+export async function prepareIosCredentials(
+  ctx: BuildContext<Ios.Job>,
+  logger: bunyan
+): Promise<void> {
+  const credentialsManager = getIosCredentialsManager();
+  ctx.credentials = await credentialsManager.prepare(ctx, logger);
+}
+
+export async function cleanUpIosCredentials(
+  ctx: BuildContext<Ios.Job>,
+  logger: bunyan
+): Promise<void> {
+  if (ctx.credentials) {
+    logger.info('Cleaning up iOS credentials');
+    await getIosCredentialsManager().cleanUp();
+  } else {
+    logger.info('Nothing to clean up');
+  }
+}

--- a/packages/eas-build-job/src/android.ts
+++ b/packages/eas-build-job/src/android.ts
@@ -72,7 +72,7 @@ export interface Job {
   updates?: {
     channel?: string;
   };
-  secrets?: BuildSecrets;
+  secrets: BuildSecrets;
   builderEnvironment?: BuilderEnvironment;
   cache: Cache;
   developmentClient?: boolean;

--- a/packages/eas-build-job/src/ios.ts
+++ b/packages/eas-build-job/src/ios.ts
@@ -85,7 +85,7 @@ export interface Job {
   updates?: {
     channel?: string;
   };
-  secrets?: BuildSecrets;
+  secrets: BuildSecrets;
   builderEnvironment?: BuilderEnvironment;
   cache: Cache;
   developmentClient?: boolean;

--- a/packages/steps/src/BuildFunction.ts
+++ b/packages/steps/src/BuildFunction.ts
@@ -19,6 +19,7 @@ export class BuildFunction {
   public readonly command?: string;
   public readonly fn?: BuildStepFunction;
   public readonly shell?: string;
+  public readonly enforceBuildStepShouldAlwaysRun: boolean;
 
   public static isFulldIdNamespaced(fullId: string): boolean {
     return fullId.includes('/');
@@ -34,6 +35,7 @@ export class BuildFunction {
     command,
     fn,
     shell,
+    enforceBuildStepShouldAlwaysRun: maybeEnforceBuildStepShouldAlwaysRun,
   }: {
     namespace?: string;
     id: string;
@@ -44,6 +46,7 @@ export class BuildFunction {
     command?: string;
     fn?: BuildStepFunction;
     shell?: string;
+    enforceBuildStepShouldAlwaysRun?: boolean;
   }) {
     assert(command !== undefined || fn !== undefined, 'Either command or fn must be defined.');
     assert(!(command !== undefined && fn !== undefined), 'Command and fn cannot be both set.');
@@ -57,6 +60,7 @@ export class BuildFunction {
     this.command = command;
     this.fn = fn;
     this.shell = shell;
+    this.enforceBuildStepShouldAlwaysRun = maybeEnforceBuildStepShouldAlwaysRun ?? false;
   }
 
   public getFullId(): string {
@@ -107,6 +111,7 @@ export class BuildFunction {
       outputs,
       shell,
       supportedRuntimePlatforms: this.supportedRuntimePlatforms,
+      shouldAlwaysRun: this.enforceBuildStepShouldAlwaysRun,
     });
   }
 }

--- a/packages/steps/src/BuildStep.ts
+++ b/packages/steps/src/BuildStep.ts
@@ -19,7 +19,7 @@ import {
   saveScriptToTemporaryFileAsync,
 } from './BuildTemporaryFiles.js';
 import { spawnAsync } from './utils/shell/spawn.js';
-import { interpolateWithInputs } from './utils/template.js';
+import { interpolateWithEasCtx, interpolateWithInputs } from './utils/template.js';
 import { BuildStepRuntimeError } from './errors.js';
 import { BuildStepEnv } from './BuildStepEnv.js';
 import { BuildRuntimePlatform } from './BuildRuntimePlatform.js';
@@ -258,7 +258,11 @@ export class BuildStep {
       acc[input.id] = input.value ?? '';
       return acc;
     }, {} as Record<string, string>);
-    return interpolateWithInputs(command, vars);
+    const interpolatedWithInputs = interpolateWithInputs(command, vars);
+    return interpolateWithEasCtx(
+      interpolatedWithInputs,
+      (path) => this.ctx.getEasContextValue(path) ?? ''
+    );
   }
 
   private async collectAndValidateOutputsAsync(outputsDir: string): Promise<void> {

--- a/packages/steps/src/BuildStep.ts
+++ b/packages/steps/src/BuildStep.ts
@@ -255,7 +255,7 @@ export class BuildStep {
     inputs?: BuildStepInput[]
   ): string {
     if (!inputs) {
-      return command;
+      return interpolateWithEasCtx(command, (path) => this.ctx.getEasContextValue(path) ?? '');
     }
     const vars = inputs.reduce((acc, input) => {
       acc[input.id] = input.value ?? '';

--- a/packages/steps/src/BuildStep.ts
+++ b/packages/steps/src/BuildStep.ts
@@ -217,7 +217,7 @@ export class BuildStep {
     assert(this.command, 'Command must be defined.');
 
     try {
-      const command = this.interpolateInputsInCommand(this.command, this.inputs);
+      const command = this.interpolateInputsAndEasContextInCommand(this.command, this.inputs);
       this.ctx.logger.debug(`Interpolated inputs in the command template`);
 
       const outputsDir = await createTemporaryOutputsDirectoryAsync(this.ctx, this.id);
@@ -250,7 +250,10 @@ export class BuildStep {
     await this.fn(this.ctx, { inputs: this.inputById, outputs: this.outputById, env });
   }
 
-  private interpolateInputsInCommand(command: string, inputs?: BuildStepInput[]): string {
+  private interpolateInputsAndEasContextInCommand(
+    command: string,
+    inputs?: BuildStepInput[]
+  ): string {
     if (!inputs) {
       return command;
     }

--- a/packages/steps/src/BuildStep.ts
+++ b/packages/steps/src/BuildStep.ts
@@ -54,6 +54,7 @@ const UUID_REGEX =
 export class BuildStep {
   public readonly id: string;
   public readonly name?: string;
+  public readonly shouldAlwaysRun: boolean;
   public readonly displayName: string;
   public readonly supportedRuntimePlatforms?: BuildRuntimePlatform[];
   public readonly inputs?: BuildStepInput[];
@@ -113,6 +114,7 @@ export class BuildStep {
       workingDirectory: maybeWorkingDirectory,
       shell,
       supportedRuntimePlatforms: maybeSupportedRuntimePlatforms,
+      shouldAlwaysRun: maybeShouldAlwaysRun,
     }: {
       id: string;
       name?: string;
@@ -124,6 +126,7 @@ export class BuildStep {
       workingDirectory?: string;
       shell?: string;
       supportedRuntimePlatforms?: BuildRuntimePlatform[];
+      shouldAlwaysRun?: boolean;
     }
   ) {
     assert(command !== undefined || fn !== undefined, 'Either command or fn must be defined.');
@@ -141,6 +144,7 @@ export class BuildStep {
     this.command = command;
     this.shell = shell ?? getDefaultShell();
     this.status = BuildStepStatus.NEW;
+    this.shouldAlwaysRun = maybeShouldAlwaysRun ?? false;
 
     this.internalId = uuidv4();
 

--- a/packages/steps/src/BuildStepContext.ts
+++ b/packages/steps/src/BuildStepContext.ts
@@ -22,7 +22,7 @@ export class BuildStepContext {
     public readonly runtimePlatform: BuildRuntimePlatform,
     public readonly projectSourceDirectory: string,
     public readonly projectTargetDirectory: string,
-    public sharedEasContext: EasContext,
+    public readonly sharedEasContext: EasContext,
     workingDirectory?: string
   ) {
     this.stepsInternalBuildDirectory = path.join(os.tmpdir(), 'eas-build', buildId);

--- a/packages/steps/src/BuildStepContext.ts
+++ b/packages/steps/src/BuildStepContext.ts
@@ -42,6 +42,20 @@ export class BuildStepContext {
     return this.stepById[stepId].getOutputValueByName(outputId);
   }
 
+  public getEasContextValue(path: string): string | undefined {
+    const arrPath = path.split('.').slice(1);
+    let value: any = this.sharedEasContext;
+    for (const key of arrPath) {
+      if (!(key in value)) {
+        throw new BuildStepRuntimeError(
+          `EAS context field "${path}" does not exist. Make sure you are using the correct field name and if so, ensure that steps which sets this field were ran prior to this step.`
+        );
+      }
+      value = value[key];
+    }
+    return value;
+  }
+
   public child({
     logger,
     workingDirectory,

--- a/packages/steps/src/BuildStepContext.ts
+++ b/packages/steps/src/BuildStepContext.ts
@@ -7,6 +7,7 @@ import { BuildStep } from './BuildStep.js';
 import { parseOutputPath } from './utils/template.js';
 import { BuildStepRuntimeError } from './errors.js';
 import { BuildRuntimePlatform } from './BuildRuntimePlatform.js';
+import { EasContext } from './EasContext.js';
 
 export class BuildStepContext {
   public readonly stepsInternalBuildDirectory: string;
@@ -21,6 +22,7 @@ export class BuildStepContext {
     public readonly runtimePlatform: BuildRuntimePlatform,
     public readonly projectSourceDirectory: string,
     public readonly projectTargetDirectory: string,
+    public sharedEasContext: EasContext,
     workingDirectory?: string
   ) {
     this.stepsInternalBuildDirectory = path.join(os.tmpdir(), 'eas-build', buildId);
@@ -54,6 +56,7 @@ export class BuildStepContext {
       this.runtimePlatform,
       this.projectSourceDirectory,
       this.projectTargetDirectory,
+      this.sharedEasContext,
       workingDirectory ?? this.workingDirectory
     );
   }

--- a/packages/steps/src/BuildStepContext.ts
+++ b/packages/steps/src/BuildStepContext.ts
@@ -53,6 +53,9 @@ export class BuildStepContext {
       }
       value = value[key];
     }
+    if (Buffer.isBuffer(value)) {
+      return value.toString();
+    }
     if (typeof value !== 'string' && typeof value !== 'undefined') {
       throw new BuildStepRuntimeError(
         `EAS context field "${path}" is not a string or undefined. It is of type "${typeof value}". We currently only support accessing string or undefined values from the EAS context.`

--- a/packages/steps/src/BuildStepContext.ts
+++ b/packages/steps/src/BuildStepContext.ts
@@ -43,7 +43,7 @@ export class BuildStepContext {
   }
 
   public getEasContextValue(path: string): string | undefined {
-    const arrPath = path.split('.').slice(1);
+    const arrPath = path.split('.');
     let value: any = this.sharedEasContext;
     for (const key of arrPath) {
       if (!(key in value)) {
@@ -52,6 +52,11 @@ export class BuildStepContext {
         );
       }
       value = value[key];
+    }
+    if (typeof value !== 'string' && typeof value !== 'undefined') {
+      throw new BuildStepRuntimeError(
+        `EAS context field "${path}" is not a string or undefined. It is of type "${typeof value}". We currently only support accessing string or undefined values from the EAS context.`
+      );
     }
     return value;
   }

--- a/packages/steps/src/BuildStepInput.ts
+++ b/packages/steps/src/BuildStepInput.ts
@@ -1,6 +1,6 @@
 import { BuildStepContext } from './BuildStepContext.js';
 import { BuildStepRuntimeError } from './errors.js';
-import { interpolateWithOutputsAndEasContext } from './utils/template.js';
+import { interpolateWithEasCtx, interpolateWithOutputs } from './utils/template.js';
 
 export type BuildStepInputById = Record<string, BuildStepInput>;
 export type BuildStepInputProvider = (ctx: BuildStepContext, stepId: string) => BuildStepInput;
@@ -51,9 +51,13 @@ export class BuildStepInput {
     if (rawValue === undefined) {
       return rawValue;
     } else {
-      return interpolateWithOutputsAndEasContext(
+      const interpolatedWithOutputs = interpolateWithOutputs(
         rawValue,
         (path) => this.ctx.getStepOutputValue(path) ?? ''
+      );
+      return interpolateWithEasCtx(
+        interpolatedWithOutputs,
+        (path) => this.ctx.getEasContextValue(path) ?? ''
       );
     }
   }

--- a/packages/steps/src/BuildStepInput.ts
+++ b/packages/steps/src/BuildStepInput.ts
@@ -55,10 +55,18 @@ export class BuildStepInput {
         rawValue,
         (path) => this.ctx.getStepOutputValue(path) ?? ''
       );
-      return interpolateWithEasCtx(
+      const value = interpolateWithEasCtx(
         interpolatedWithOutputs,
         (path) => this.ctx.getEasContextValue(path) ?? ''
       );
+      if (this.allowedValues && !this.allowedValues.includes(value)) {
+        throw new BuildStepRuntimeError(
+          `Input parameter "${this.id}" for step "${
+            this.stepDisplayName
+          }" must be one of: ${this.allowedValues.join(', ')}.`
+        );
+      }
+      return value;
     }
   }
 
@@ -78,6 +86,10 @@ export class BuildStepInput {
       return true;
     }
     return this.allowedValues.includes(value);
+  }
+
+  public getRawValue(): string | undefined {
+    return this._value ?? this.defaultValue;
   }
 }
 

--- a/packages/steps/src/BuildStepInput.ts
+++ b/packages/steps/src/BuildStepInput.ts
@@ -1,6 +1,6 @@
 import { BuildStepContext } from './BuildStepContext.js';
 import { BuildStepRuntimeError } from './errors.js';
-import { interpolateWithOutputs } from './utils/template.js';
+import { interpolateWithOutputsAndEasContext } from './utils/template.js';
 
 export type BuildStepInputById = Record<string, BuildStepInput>;
 export type BuildStepInputProvider = (ctx: BuildStepContext, stepId: string) => BuildStepInput;
@@ -51,7 +51,10 @@ export class BuildStepInput {
     if (rawValue === undefined) {
       return rawValue;
     } else {
-      return interpolateWithOutputs(rawValue, (path) => this.ctx.getStepOutputValue(path) ?? '');
+      return interpolateWithOutputsAndEasContext(
+        rawValue,
+        (path) => this.ctx.getStepOutputValue(path) ?? ''
+      );
     }
   }
 

--- a/packages/steps/src/BuildWorkflow.ts
+++ b/packages/steps/src/BuildWorkflow.ts
@@ -1,12 +1,14 @@
 import { BuildFunctionById } from './BuildFunction.js';
 import { BuildStep } from './BuildStep.js';
 import { BuildStepContext } from './BuildStepContext.js';
+import { BuildStepEnv } from './BuildStepEnv.js';
 
 export class BuildWorkflow {
   public readonly buildSteps: BuildStep[];
   public readonly buildFunctions: BuildFunctionById;
 
   constructor(
+    // @ts-expect-error ctx is not used in this class but let's keep it here for consistency
     private readonly ctx: BuildStepContext,
     { buildSteps, buildFunctions }: { buildSteps: BuildStep[]; buildFunctions: BuildFunctionById }
   ) {
@@ -14,9 +16,9 @@ export class BuildWorkflow {
     this.buildFunctions = buildFunctions;
   }
 
-  public async executeAsync(): Promise<void> {
+  public async executeAsync(env: BuildStepEnv = process.env): Promise<void> {
     for (const step of this.buildSteps) {
-      await step.executeAsync(this.ctx.sharedEasContext.env ?? process.env);
+      await step.executeAsync(env);
     }
   }
 }

--- a/packages/steps/src/BuildWorkflow.ts
+++ b/packages/steps/src/BuildWorkflow.ts
@@ -1,14 +1,12 @@
 import { BuildFunctionById } from './BuildFunction.js';
 import { BuildStep } from './BuildStep.js';
 import { BuildStepContext } from './BuildStepContext.js';
-import { BuildStepEnv } from './BuildStepEnv.js';
 
 export class BuildWorkflow {
   public readonly buildSteps: BuildStep[];
   public readonly buildFunctions: BuildFunctionById;
 
   constructor(
-    // @ts-expect-error ctx is not used in this class but let's keep it here for consistency
     private readonly ctx: BuildStepContext,
     { buildSteps, buildFunctions }: { buildSteps: BuildStep[]; buildFunctions: BuildFunctionById }
   ) {
@@ -16,9 +14,9 @@ export class BuildWorkflow {
     this.buildFunctions = buildFunctions;
   }
 
-  public async executeAsync(env: BuildStepEnv = process.env): Promise<void> {
+  public async executeAsync(): Promise<void> {
     for (const step of this.buildSteps) {
-      await step.executeAsync(env);
+      await step.executeAsync(this.ctx.sharedEasContext.env ?? process.env);
     }
   }
 }

--- a/packages/steps/src/BuildWorkflow.ts
+++ b/packages/steps/src/BuildWorkflow.ts
@@ -1,5 +1,5 @@
 import { BuildFunctionById } from './BuildFunction.js';
-import { BuildStep } from './BuildStep.js';
+import { BuildStep, BuildStepStatus } from './BuildStep.js';
 import { BuildStepContext } from './BuildStepContext.js';
 import { BuildStepEnv } from './BuildStepEnv.js';
 
@@ -17,8 +17,16 @@ export class BuildWorkflow {
   }
 
   public async executeAsync(env: BuildStepEnv = process.env): Promise<void> {
-    for (const step of this.buildSteps) {
-      await step.executeAsync(env);
+    try {
+      for (const step of this.buildSteps) {
+        await step.executeAsync(env);
+      }
+    } finally {
+      for (const step of this.buildSteps) {
+        if (step.status === BuildStepStatus.NEW && step.shouldAlwaysRun) {
+          await step.executeAsync(env);
+        }
+      }
     }
   }
 }

--- a/packages/steps/src/EasContext.ts
+++ b/packages/steps/src/EasContext.ts
@@ -1,0 +1,41 @@
+interface AndroidCredentials {
+  keystore: {
+    keystorePath: string;
+    keystorePassword: string;
+    keyAlias: string;
+    keyPassword?: string;
+  };
+}
+
+enum DistributionType {
+  AD_HOC = 'ad-hoc',
+  APP_STORE = 'app-store',
+  ENTERPRISE = 'enterprise',
+}
+export interface ProvisioningProfileData {
+  path: string;
+  target: string;
+  bundleIdentifier: string;
+  teamId: string;
+  uuid: string;
+  name: string;
+  developerCertificate: Buffer;
+  certificateCommonName: string;
+  distributionType: DistributionType;
+}
+type TargetProvisioningProfiles = Record<string, ProvisioningProfileData>;
+interface IosCredentials {
+  teamId: string;
+  keychainPath: string;
+  distributionType: DistributionType;
+  targetProvisioningProfiles: TargetProvisioningProfiles;
+  applicationTargetProvisioningProfile: ProvisioningProfileData;
+}
+
+export interface EasContext {
+  credentials?: {
+    android?: AndroidCredentials;
+    ios?: IosCredentials | null;
+  };
+  env?: Record<string, string>;
+}

--- a/packages/steps/src/EasContext.ts
+++ b/packages/steps/src/EasContext.ts
@@ -37,5 +37,4 @@ export interface EasContext {
     android?: AndroidCredentials;
     ios?: IosCredentials | null;
   };
-  env?: Record<string, string>;
 }

--- a/packages/steps/src/EasContext.ts
+++ b/packages/steps/src/EasContext.ts
@@ -33,8 +33,12 @@ interface IosCredentials {
 }
 
 export interface EasContext {
-  credentials?: {
+  credentials: {
     android?: AndroidCredentials;
     ios?: IosCredentials | null;
   };
 }
+
+export const emptyEasContext: EasContext = {
+  credentials: {},
+};

--- a/packages/steps/src/EasContext.ts
+++ b/packages/steps/src/EasContext.ts
@@ -42,3 +42,74 @@ export interface EasContext {
 export const emptyEasContext: EasContext = {
   credentials: {},
 };
+
+export const mockAndroidCredentials: AndroidCredentials = {
+  keystore: {
+    keystorePath: 'mock-path',
+    keystorePassword: 'mock-password',
+    keyAlias: 'mock-alias',
+    keyPassword: 'mock-password',
+  },
+};
+
+export const mockIosCredentials: IosCredentials = {
+  teamId: 'mock-team-id',
+  keychainPath: 'mock-keychain-path',
+  distributionType: DistributionType.APP_STORE,
+  targetProvisioningProfiles: {
+    anyString: {
+      path: 'mock-path',
+      target: 'mock-target',
+      bundleIdentifier: 'mock-bundle-identifier',
+      teamId: 'mock-team-id',
+      uuid: 'mock-uuid',
+      name: 'mock-name',
+      developerCertificate: Buffer.from('mock-certificate'),
+      certificateCommonName: 'mock-certificate-common-name',
+      distributionType: DistributionType.APP_STORE,
+    },
+  },
+  applicationTargetProvisioningProfile: {
+    path: 'mock-path',
+    target: 'mock-target',
+    bundleIdentifier: 'mock-bundle-identifier',
+    teamId: 'mock-team-id',
+    uuid: 'mock-uuid',
+    name: 'mock-name',
+    developerCertificate: Buffer.from('mock-certificate'),
+    certificateCommonName: 'mock-certificate-common-name',
+    distributionType: DistributionType.APP_STORE,
+  },
+};
+
+export const fullEasContext: EasContext = {
+  credentials: {
+    android: mockAndroidCredentials,
+    ios: mockIosCredentials,
+  },
+};
+
+export function getAllReachablePathsInEasContextObject(): RegExp[] {
+  const reachablePaths: RegExp[] = [];
+  function traverse(obj: any, path: RegExp[] = []): void {
+    if (typeof obj !== 'object' || obj === null || Buffer.isBuffer(obj)) {
+      reachablePaths.push(
+        path.reduce(
+          (acc, curr) =>
+            new RegExp(
+              `${acc.source.replace('anyString', '[\\S]+')}\\.${curr.source.replace(
+                'anyString',
+                '[\\S]+'
+              )}`
+            )
+        )
+      );
+      return;
+    }
+    for (const key of Object.keys(obj)) {
+      traverse(obj[key], [...path, RegExp(key)]);
+    }
+  }
+  traverse(fullEasContext);
+  return reachablePaths;
+}

--- a/packages/steps/src/__tests__/BuildStep-test.ts
+++ b/packages/steps/src/__tests__/BuildStep-test.ts
@@ -12,20 +12,12 @@ import { BuildStepOutput } from '../BuildStepOutput.js';
 import { BuildStepRuntimeError } from '../errors.js';
 import { nullthrows } from '../utils/nullthrows.js';
 import { BuildRuntimePlatform } from '../BuildRuntimePlatform.js';
+import { mockAndroidCredentials } from '../EasContext.js';
 
 import { createMockContext } from './utils/context.js';
 import { createMockLogger } from './utils/logger.js';
 import { getError, getErrorAsync } from './utils/error.js';
 import { UUID_REGEX } from './utils/uuid.js';
-
-const mockAndroidCredentials = {
-  keystore: {
-    keystorePath: 'mock-path',
-    keystorePassword: 'mock-password',
-    keyAlias: 'mock-alias',
-    keyPassword: 'mock-password',
-  },
-};
 
 describe(BuildStep, () => {
   describe(BuildStep.getNewId, () => {

--- a/packages/steps/src/__tests__/BuildStepContext-test.ts
+++ b/packages/steps/src/__tests__/BuildStepContext-test.ts
@@ -22,7 +22,8 @@ describe(BuildStepContext, () => {
         false,
         BuildRuntimePlatform.LINUX,
         '/non/existent/path',
-        '/another/non/existent/path'
+        '/another/non/existent/path',
+        {}
       );
       expect(ctx.stepsInternalBuildDirectory.startsWith(os.tmpdir())).toBe(true);
     });
@@ -34,7 +35,8 @@ describe(BuildStepContext, () => {
         false,
         BuildRuntimePlatform.LINUX,
         '/non/existent/path',
-        '/another/non/existent/path'
+        '/another/non/existent/path',
+        {}
       );
       expect(ctx.stepsInternalBuildDirectory).toMatch(buildId);
     });
@@ -47,7 +49,8 @@ describe(BuildStepContext, () => {
         false,
         BuildRuntimePlatform.LINUX,
         '/non/existent/path',
-        '/another/non/existent/path'
+        '/another/non/existent/path',
+        {}
       );
       expect(ctx.workingDirectory).toBe(path.join(ctx.stepsInternalBuildDirectory, 'project'));
     });
@@ -60,6 +63,7 @@ describe(BuildStepContext, () => {
         BuildRuntimePlatform.LINUX,
         '/non/existent/path',
         '/another/non/existent/path',
+        {},
         workingDirectory
       );
       expect(ctx.workingDirectory).toBe(workingDirectory);

--- a/packages/steps/src/__tests__/BuildStepContext-test.ts
+++ b/packages/steps/src/__tests__/BuildStepContext-test.ts
@@ -8,7 +8,7 @@ import { BuildStep } from '../BuildStep.js';
 import { BuildStepContext } from '../BuildStepContext.js';
 import { BuildStepRuntimeError } from '../errors.js';
 import { BuildRuntimePlatform } from '../BuildRuntimePlatform.js';
-import { emptyEasContext } from '../EasContext.js';
+import { emptyEasContext, mockAndroidCredentials, mockIosCredentials } from '../EasContext.js';
 
 import { createMockContext } from './utils/context.js';
 import { getError } from './utils/error.js';
@@ -98,14 +98,6 @@ describe(BuildStepContext, () => {
     });
   });
   describe(BuildStepContext.prototype.getEasContextValue, () => {
-    const mockAndroidCredentials = {
-      keystore: {
-        keystorePath: 'mock-path',
-        keystorePassword: 'mock-password',
-        keyAlias: 'mock-alias',
-        keyPassword: 'mock-password',
-      },
-    };
     it('throws an error if the EAS context references a non-existent field', () => {
       const ctx = createMockContext({ easContext: { credentials: {} } });
       const error = getError<BuildStepRuntimeError>(() => {
@@ -135,6 +127,20 @@ describe(BuildStepContext, () => {
         },
       });
       expect(ctx.getEasContextValue('credentials.android.keystore.keystorePath')).toBe('mock-path');
+    });
+    it('converts buffer value to string', () => {
+      const ctx = createMockContext({
+        easContext: {
+          credentials: {
+            ios: mockIosCredentials,
+          },
+        },
+      });
+      expect(
+        ctx.getEasContextValue(
+          'credentials.ios.applicationTargetProvisioningProfile.developerCertificate'
+        )
+      ).toBe('mock-certificate');
     });
   });
   describe(BuildStepContext.prototype.child, () => {

--- a/packages/steps/src/__tests__/BuildStepInput-test.ts
+++ b/packages/steps/src/__tests__/BuildStepInput-test.ts
@@ -1,6 +1,7 @@
 import { BuildStepRuntimeError } from '../errors.js';
 import { BuildStep } from '../BuildStep.js';
 import { BuildStepInput, makeBuildStepInputByIdMap } from '../BuildStepInput.js';
+import { mockAndroidCredentials } from '../EasContext.js';
 
 import { createMockContext } from './utils/context.js';
 
@@ -57,14 +58,6 @@ describe(BuildStepInput, () => {
   });
 
   test('correctly gets value from EAS context', () => {
-    const mockAndroidCredentials = {
-      keystore: {
-        keystorePath: 'mock-path',
-        keystorePassword: 'mock-password',
-        keyAlias: 'mock-alias',
-        keyPassword: 'mock-password',
-      },
-    };
     const ctx = createMockContext({
       easContext: { credentials: { android: mockAndroidCredentials } },
     });

--- a/packages/steps/src/__tests__/BuildStepInput-test.ts
+++ b/packages/steps/src/__tests__/BuildStepInput-test.ts
@@ -55,6 +55,27 @@ describe(BuildStepInput, () => {
       new BuildStepRuntimeError('Input parameter "foo" for step "test1" is required.')
     );
   });
+
+  test('correctly gets value from EAS context', () => {
+    const mockAndroidCredentials = {
+      keystore: {
+        keystorePath: 'mock-path',
+        keystorePassword: 'mock-password',
+        keyAlias: 'mock-alias',
+        keyPassword: 'mock-password',
+      },
+    };
+    const ctx = createMockContext({
+      easContext: { credentials: { android: mockAndroidCredentials } },
+    });
+    const i = new BuildStepInput(ctx, {
+      id: 'foo',
+      stepDisplayName: BuildStep.getDisplayName({ id: 'test1' }),
+      required: true,
+    });
+    i.set('${ easCtx.credentials.android.keystore.keystorePath }');
+    expect(i.value).toBe('mock-path');
+  });
 });
 
 describe(makeBuildStepInputByIdMap, () => {

--- a/packages/steps/src/__tests__/EasContext-test.ts
+++ b/packages/steps/src/__tests__/EasContext-test.ts
@@ -1,0 +1,33 @@
+import { getAllReachablePathsInEasContextObject } from '../EasContext.js';
+
+describe(getAllReachablePathsInEasContextObject, () => {
+  it('returns all possible paths in the eas context object', () => {
+    expect(getAllReachablePathsInEasContextObject()).toEqual([
+      /credentials\.android\.keystore\.keystorePath/,
+      /credentials\.android\.keystore\.keystorePassword/,
+      /credentials\.android\.keystore\.keyAlias/,
+      /credentials\.android\.keystore\.keyPassword/,
+      /credentials\.ios\.teamId/,
+      /credentials\.ios\.keychainPath/,
+      /credentials\.ios\.distributionType/,
+      /credentials\.ios\.targetProvisioningProfiles\.[\S]+\.path/,
+      /credentials\.ios\.targetProvisioningProfiles\.[\S]+\.target/,
+      /credentials\.ios\.targetProvisioningProfiles\.[\S]+\.bundleIdentifier/,
+      /credentials\.ios\.targetProvisioningProfiles\.[\S]+\.teamId/,
+      /credentials\.ios\.targetProvisioningProfiles\.[\S]+\.uuid/,
+      /credentials\.ios\.targetProvisioningProfiles\.[\S]+\.name/,
+      /credentials\.ios\.targetProvisioningProfiles\.[\S]+\.developerCertificate/,
+      /credentials\.ios\.targetProvisioningProfiles\.[\S]+\.certificateCommonName/,
+      /credentials\.ios\.targetProvisioningProfiles\.[\S]+\.distributionType/,
+      /credentials\.ios\.applicationTargetProvisioningProfile\.path/,
+      /credentials\.ios\.applicationTargetProvisioningProfile\.target/,
+      /credentials\.ios\.applicationTargetProvisioningProfile\.bundleIdentifier/,
+      /credentials\.ios\.applicationTargetProvisioningProfile\.teamId/,
+      /credentials\.ios\.applicationTargetProvisioningProfile\.uuid/,
+      /credentials\.ios\.applicationTargetProvisioningProfile\.name/,
+      /credentials\.ios\.applicationTargetProvisioningProfile\.developerCertificate/,
+      /credentials\.ios\.applicationTargetProvisioningProfile\.certificateCommonName/,
+      /credentials\.ios\.applicationTargetProvisioningProfile\.distributionType/,
+    ]);
+  });
+});

--- a/packages/steps/src/__tests__/fixtures/invalid-eas-ctx.yml
+++ b/packages/steps/src/__tests__/fixtures/invalid-eas-ctx.yml
@@ -1,0 +1,6 @@
+build:
+  name: External functions
+  steps:
+    - run:
+        name: Test
+        command: echo "${ easCtx.credentials.android.keystore.invalid }"

--- a/packages/steps/src/__tests__/fixtures/valid-eas-ctx.yml
+++ b/packages/steps/src/__tests__/fixtures/valid-eas-ctx.yml
@@ -1,0 +1,6 @@
+build:
+  name: External functions
+  steps:
+    - run:
+        name: Test
+        command: echo "${ easCtx.credentials.android.keystore.keystorePassword }"

--- a/packages/steps/src/__tests__/utils/context.ts
+++ b/packages/steps/src/__tests__/utils/context.ts
@@ -3,7 +3,7 @@ import { v4 as uuidv4 } from 'uuid';
 
 import { BuildStepContext } from '../../BuildStepContext.js';
 import { BuildRuntimePlatform } from '../../BuildRuntimePlatform.js';
-import { EasContext } from '../../EasContext.js';
+import { EasContext, emptyEasContext } from '../../EasContext.js';
 
 import { createMockLogger } from './logger.js';
 
@@ -35,7 +35,7 @@ export function createMockContext({
     runtimePlatform ?? BuildRuntimePlatform.LINUX,
     projectSourceDirectory ?? '/non/existent/dir',
     projectTargetDirectory ?? '/another/non/existent/dir',
-    easContext ?? {},
+    easContext ?? emptyEasContext,
     workingDirectory
   );
 }

--- a/packages/steps/src/__tests__/utils/context.ts
+++ b/packages/steps/src/__tests__/utils/context.ts
@@ -3,6 +3,7 @@ import { v4 as uuidv4 } from 'uuid';
 
 import { BuildStepContext } from '../../BuildStepContext.js';
 import { BuildRuntimePlatform } from '../../BuildRuntimePlatform.js';
+import { EasContext } from '../../EasContext.js';
 
 import { createMockLogger } from './logger.js';
 
@@ -13,6 +14,7 @@ interface BuildContextParams {
   runtimePlatform?: BuildRuntimePlatform;
   projectSourceDirectory?: string;
   projectTargetDirectory?: string;
+  easContext?: EasContext;
   workingDirectory?: string;
 }
 
@@ -23,6 +25,7 @@ export function createMockContext({
   runtimePlatform,
   projectSourceDirectory,
   projectTargetDirectory,
+  easContext,
   workingDirectory,
 }: BuildContextParams = {}): BuildStepContext {
   return new BuildStepContext(
@@ -32,6 +35,7 @@ export function createMockContext({
     runtimePlatform ?? BuildRuntimePlatform.LINUX,
     projectSourceDirectory ?? '/non/existent/dir',
     projectTargetDirectory ?? '/another/non/existent/dir',
+    easContext ?? {},
     workingDirectory
   );
 }

--- a/packages/steps/src/cli/cli.ts
+++ b/packages/steps/src/cli/cli.ts
@@ -7,6 +7,7 @@ import { BuildConfigParser } from '../BuildConfigParser.js';
 import { BuildStepContext } from '../BuildStepContext.js';
 import { BuildWorkflowError } from '../errors.js';
 import { BuildRuntimePlatform } from '../BuildRuntimePlatform.js';
+import { emptyEasContext } from '../EasContext.js';
 
 const logger = createLogger({
   name: 'steps-cli',
@@ -26,7 +27,7 @@ async function runAsync(
     runtimePlatform,
     relativeProjectDirectory,
     relativeProjectDirectory,
-    {},
+    emptyEasContext,
     relativeProjectDirectory
   );
   const parser = new BuildConfigParser(ctx, { configPath });

--- a/packages/steps/src/cli/cli.ts
+++ b/packages/steps/src/cli/cli.ts
@@ -26,6 +26,7 @@ async function runAsync(
     runtimePlatform,
     relativeProjectDirectory,
     relativeProjectDirectory,
+    {},
     relativeProjectDirectory
   );
   const parser = new BuildConfigParser(ctx, { configPath });

--- a/packages/steps/src/index.ts
+++ b/packages/steps/src/index.ts
@@ -7,3 +7,4 @@ export { BuildStepOutput } from './BuildStepOutput.js';
 export { BuildStepContext } from './BuildStepContext.js';
 export { BuildWorkflow } from './BuildWorkflow.js';
 export * as errors from './errors.js';
+export { emptyEasContext } from './EasContext.js';

--- a/packages/steps/src/utils/__tests__/template-test.ts
+++ b/packages/steps/src/utils/__tests__/template-test.ts
@@ -2,6 +2,7 @@ import { BuildConfigError } from '../../errors.js';
 import { getError } from '../../__tests__/utils/error.js';
 import {
   findOutputPaths,
+  interpolateWithEasCtx,
   interpolateWithInputs,
   interpolateWithOutputs,
   parseOutputPath,
@@ -29,6 +30,24 @@ describe(interpolateWithOutputs, () => {
       }
     );
     expect(result).toBe('foobarbaz');
+  });
+});
+
+describe(interpolateWithEasCtx, () => {
+  test('interpolation', () => {
+    const result = interpolateWithEasCtx(
+      'test credentials: ${ easCtx.credentials.ios.teamId } ${ easCtx.credentials.android.keychainPassword }',
+      (path) => {
+        if (path === 'credentials.ios.teamId') {
+          return 'mock-team-id';
+        } else if (path === 'credentials.android.keychainPassword') {
+          return 'mock-keychain-password';
+        } else {
+          return 'x';
+        }
+      }
+    );
+    expect(result).toBe('test credentials: mock-team-id mock-keychain-password');
   });
 });
 

--- a/packages/steps/src/utils/template.ts
+++ b/packages/steps/src/utils/template.ts
@@ -4,6 +4,7 @@ import { nullthrows } from './nullthrows.js';
 
 export const BUILD_STEP_INPUT_EXPRESSION_REGEXP = /\${\s*inputs\.([\S]+)\s*}/;
 export const BUILD_STEP_OUTPUT_EXPRESSION_REGEXP = /\${\s*steps\.([\S]+)\s*}/;
+export const EAS_CTX_EXPRESSION_REGEXP = /\${\s*easCtx\.([\S]+)\s*}/;
 
 export function interpolateWithInputs(
   templateString: string,
@@ -17,6 +18,13 @@ export function interpolateWithOutputs(
   fn: (path: string) => string
 ): string {
   return interpolate(templateString, BUILD_STEP_OUTPUT_EXPRESSION_REGEXP, fn);
+}
+
+export function interpolateWithEasCtx(
+  templateString: string,
+  fn: (path: string) => string
+): string {
+  return interpolate(templateString, EAS_CTX_EXPRESSION_REGEXP, fn);
 }
 
 function interpolate(


### PR DESCRIPTION
# Why

https://linear.app/expo/issue/ENG-8775/implement-easprepare-credentials-and-easclean-up-credentials-ios

# How

Add the `sharedEasContext` object to the `BuildContext` class. It will be the object using which we will be passing some context information from `eas` namespaced functions to other steps.

Add new `eas/prepare_credentials` and `eas/clean_up_credentials`. Make sure that the `eas/clean_up_credentials` function is always executed (even if a previous step failed). These functions pass information to other steps using the `sharedEasContext` object.

Interpolate the `easCtx` object with commands and inputs to make it globally available from every step. Validate if referenced part of `easCtx` exists when accessing it (runtime). Validate in `BuildWorkflowValidator` if the selected property from the `easCtx` is even possible to be accessed.

While testing I was using changes from https://github.com/expo/eas-cli/pull/1859 to provide credentials to custom builds.

# Test Plan

1. Added automated tests
2. Run builds locally using
```yml
build:
  name: Run tests
  steps:
    - eas/checkout
    - eas/use_npm_token
    - eas/install_node_modules
    - run:
        name: Run tests
        command: |
          echo "Running tests..."
          npm test
    - eas/prepare_credentials
    - run:
        name: Check if Android credentials are available
        command: |
          echo "Android Keystore Path: ${ easCtx.credentials.android.keystore.keystorePath }"
    - eas/clean_up_credentials
```
workflow

iOS build:
![Screenshot 2023-06-01 at 14 47 45](https://github.com/expo/eas-build/assets/55145344/2a7ed2b7-c541-4213-8e72-ead6e61d3f47)

Android build:
![Screenshot 2023-06-01 at 15 51 57](https://github.com/expo/eas-build/assets/55145344/b93f8c7b-7637-4b85-9f3e-f5cc68a2a92b)

3. Run build locally using
```yml
build:
  name: Run tests
  steps:
    - eas/checkout
    - eas/use_npm_token
    - eas/install_node_modules
    - run:
        name: Run tests
        command: |
          echo "Running tests..."
          npm test
    - eas/prepare_credentials
    - run:
        name: Check if Android credentials are available
        command: |
          echo "${ easCtx.credentials.android.keystore.invalid }"
    - eas/clean_up_credentials
```
workflow
![Screenshot 2023-06-01 at 14 40 11](https://github.com/expo/eas-build/assets/55145344/d0c1cc14-d4b6-4b5f-a3a4-1ed63523a83e)

4. Run builds locally using
```yml
build:
  name: Run tests
  steps:
    - eas/checkout
    - eas/use_npm_token
    - eas/install_node_modules
    - run:
        name: Run tests
        command: |
          echo "Running tests..."
          npm test
    - eas/prepare_credentials
    - run:
        name: Check if iOS credentials are available
        command: |
          echo "iOS keystore path: ${ easCtx.credentials.ios.keychainPath }"
    - eas/clean_up_credentials
```
workflow

iOS build:
![Screenshot 2023-06-01 at 16 07 44](https://github.com/expo/eas-build/assets/55145344/1169dbda-5761-48ae-a804-903f115d154f)


Android build:
![Screenshot 2023-06-01 at 16 06 23](https://github.com/expo/eas-build/assets/55145344/21d53124-93c8-47eb-972b-1a91a670d4c1)

EDIT: I made the `eas/clean_up_credentials` function run even if some previous steps failed

![Screenshot 2023-06-01 at 16 44 25](https://github.com/expo/eas-build/assets/55145344/1d5abe50-2dda-430b-8947-19c61c0c5dfc)




