### PR TITLE
Replace `@expo/bunyan` with `bunyan`

### DIFF
--- a/packages/build-tools/src/__mocks__/@expo/logger.ts
+++ b/packages/build-tools/src/__mocks__/@expo/logger.ts
@@ -1,4 +1,4 @@
-import bunyan from '@expo/bunyan';
+import bunyan from 'bunyan';
 
 export function createLogger(): bunyan {
   const logger = {

--- a/packages/local-build-plugin/package.json
+++ b/packages/local-build-plugin/package.json
@@ -25,10 +25,10 @@
   "license": "BUSL-1.1",
   "dependencies": {
     "@expo/build-tools": "1.0.18",
-    "@expo/bunyan": "^4.0.0",
     "@expo/eas-build-job": "1.0.13",
     "@expo/spawn-async": "^1.7.0",
     "@expo/turtle-spawn": "1.0.13",
+    "bunyan": "^1.8.15",
     "chalk": "^4.1.2",
     "env-paths": "^2.2.1",
     "fs-extra": "^11.1.0",
@@ -40,6 +40,7 @@
     "uuid": "^9.0.0"
   },
   "devDependencies": {
+    "@types/bunyan": "^1.8.8",
     "@types/fs-extra": "^11.0.1",
     "@types/hapi__joi": "^17.1.9",
     "@types/lodash": "^4.14.191",

--- a/packages/local-build-plugin/src/logger.ts
+++ b/packages/local-build-plugin/src/logger.ts
@@ -1,6 +1,6 @@
 import { Writable } from 'stream';
 
-import bunyan from '@expo/bunyan';
+import bunyan from 'bunyan';
 import chalk from 'chalk';
 import omit from 'lodash/omit';
 import { LogBuffer } from '@expo/build-tools';

--- a/packages/logger/README.md
+++ b/packages/logger/README.md
@@ -1,6 +1,6 @@
 # @expo/logger
 
-`@expo/logger` is a wrapper around `@expo/bunyan` library.
+`@expo/logger` is a wrapper around `bunyan` library.
 
 ## Repository
 

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -19,9 +19,10 @@
   "bugs": "https://github.com/expo/eas-build/issues",
   "license": "BUSL-1.1",
   "dependencies": {
-    "@expo/bunyan": "^4.0.0"
+    "bunyan": "^1.8.15"
   },
   "devDependencies": {
+    "@types/bunyan": "^1.8.8",
     "@types/jest": "^29.4.0",
     "@types/node": "^18.11.18",
     "jest": "^29.4.1",

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -19,8 +19,7 @@
   "bugs": "https://github.com/expo/eas-build/issues",
   "license": "BUSL-1.1",
   "dependencies": {
-    "bunyan": "^1.8.15",
-    "uuid": "^9.0.0"
+    "bunyan": "^1.8.15"
   },
   "devDependencies": {
     "@types/bunyan": "^1.8.8",

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -19,7 +19,8 @@
   "bugs": "https://github.com/expo/eas-build/issues",
   "license": "BUSL-1.1",
   "dependencies": {
-    "bunyan": "^1.8.15"
+    "bunyan": "^1.8.15",
+    "uuid": "^9.0.0"
   },
   "devDependencies": {
     "@types/bunyan": "^1.8.8",

--- a/packages/logger/src/index.ts
+++ b/packages/logger/src/index.ts
@@ -1,28 +1,15 @@
 import bunyan from 'bunyan';
-import { v1 } from 'uuid';
 
 import LoggerLevel from './level';
 import { pipe, pipeSpawnOutput, PipeMode } from './pipe';
 
 const DEFAULT_LOGGER_NAME = 'expo-logger';
 
-interface BunyanLogger extends bunyan {
-  _emit: (rec: any, noEmit: boolean) => string;
-}
-
 function createLogger(options: bunyan.LoggerOptions): bunyan {
-  const logger = bunyan.createLogger({
+  return bunyan.createLogger({
     serializers: bunyan.stdSerializers,
     ...options,
-  }) as BunyanLogger;
-
-  const originalEmit = logger._emit.bind(logger);
-  logger._emit = (rec, noEmit) => {
-    rec.id = v1();
-    return originalEmit(rec, noEmit);
-  };
-
-  return logger;
+  });
 }
 
 const defaultLogger = createLogger({

--- a/packages/logger/src/index.ts
+++ b/packages/logger/src/index.ts
@@ -1,15 +1,28 @@
 import bunyan from 'bunyan';
+import { v1 } from 'uuid';
 
 import LoggerLevel from './level';
 import { pipe, pipeSpawnOutput, PipeMode } from './pipe';
 
 const DEFAULT_LOGGER_NAME = 'expo-logger';
 
+interface BunyanLogger extends bunyan {
+  _emit: (rec: any, noEmit: boolean) => string;
+}
+
 function createLogger(options: bunyan.LoggerOptions): bunyan {
-  return bunyan.createLogger({
+  const logger = bunyan.createLogger({
     serializers: bunyan.stdSerializers,
     ...options,
-  });
+  }) as BunyanLogger;
+
+  const originalEmit = logger._emit.bind(logger);
+  logger._emit = (rec, noEmit) => {
+    rec.id = v1();
+    return originalEmit(rec, noEmit);
+  };
+
+  return logger;
 }
 
 const defaultLogger = createLogger({

--- a/packages/logger/src/index.ts
+++ b/packages/logger/src/index.ts
@@ -1,4 +1,4 @@
-import bunyan from '@expo/bunyan';
+import bunyan from 'bunyan';
 
 import LoggerLevel from './level';
 import { pipe, pipeSpawnOutput, PipeMode } from './pipe';
@@ -18,4 +18,5 @@ const defaultLogger = createLogger({
 });
 
 export default defaultLogger;
-export { LoggerLevel, bunyan, createLogger, pipe, pipeSpawnOutput, PipeMode };
+export { LoggerLevel, createLogger, pipe, pipeSpawnOutput, PipeMode };
+export type { bunyan };

--- a/packages/logger/src/pipe.ts
+++ b/packages/logger/src/pipe.ts
@@ -1,6 +1,6 @@
 import { Readable } from 'stream';
 
-import bunyan from '@expo/bunyan';
+import type bunyan from 'bunyan';
 
 type LineLogger = (line: string) => void;
 type LineTransformer = (line: string) => string | null;

--- a/packages/steps/package.json
+++ b/packages/steps/package.json
@@ -34,7 +34,6 @@
     "@jest/globals": "^29.4.1",
     "@types/jest": "^29.4.0",
     "@types/node": "^18.11.18",
-    "bunyan": "^1.8.15",
     "chokidar-cli": "^3.0.0",
     "eslint-plugin-async-protect": "^3.0.0",
     "jest": "^29.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -568,16 +568,6 @@
     minimatch "^3.1.2"
     strip-json-comments "^3.1.1"
 
-"@expo/bunyan@^4.0.0":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@expo/bunyan/-/bunyan-4.0.0.tgz#be0c1de943c7987a9fbd309ea0b1acd605890c7b"
-  integrity sha512-Ydf4LidRB/EBI+YrB+cVLqIseiRfjUI/AeHBgjGMtq3GroraDu81OV7zqophRgupngoL3iS3JUMDMnxO7g39qA==
-  dependencies:
-    uuid "^8.0.0"
-  optionalDependencies:
-    mv "~2"
-    safe-json-stringify "~1"
-
 "@expo/config-plugins@^5.0.4", "@expo/config-plugins@~5.0.3":
   version "5.0.4"
   resolved "https://registry.yarnpkg.com/@expo/config-plugins/-/config-plugins-5.0.4.tgz#216fea6558fe66615af1370de55193f4181cb23e"
@@ -2141,6 +2131,13 @@
   integrity sha512-Vs0hm0vPahPMYi9tDjtP66llufgO3ST16WXaSTtDGEl9cewAl3AibmxWw6TINOqHPT9z0uABKAYjT9jNSg4npw==
   dependencies:
     "@babel/types" "^7.3.0"
+
+"@types/bunyan@^1.8.8":
+  version "1.8.8"
+  resolved "https://registry.yarnpkg.com/@types/bunyan/-/bunyan-1.8.8.tgz#8d6d33f090f37c07e2a80af30ae728450a101008"
+  integrity sha512-Cblq+Yydg3u+sGiz2mjHjC5MPmdjY+No4qvHrF+BUhblsmSfMvsHLbOG62tPbonsqBj6sbWv1LHcsoe5Jw+/Ow==
+  dependencies:
+    "@types/node" "*"
 
 "@types/cacheable-request@^6.0.1":
   version "6.0.1"
@@ -8509,7 +8506,7 @@ uuid@^7.0.3:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-7.0.3.tgz#c5c9f2c8cf25dc0a372c4df1441c41f5bd0c680b"
   integrity sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==
 
-uuid@^8.0.0, uuid@^8.3.2:
+uuid@^8.3.2:
   version "8.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==


### PR DESCRIPTION
# Why

Use maintained dependencies.

# How

Inspected differences between `@expo/bunyan` and `bunyan`. There are two:

- `@expo/bunyan` adds unique `id` to every log ([commit](https://github.com/trentm/node-bunyan/commit/e061d981f14d19376d99bd4e4bd7404dab553132)). Do we know if we depend on `id` being present anywhere, or why was it added? I tried to find any usage in `universe`, but didn't find any.
- [removes](https://github.com/trentm/node-bunyan/commit/d8a22b369a98fb70a2ed5b48b4548216e4e62bd8)/[disables](https://github.com/trentm/node-bunyan/commit/428e78233d2049f780c2475a51c392b67704f08c) dtrace — if I understand correctly, Dominik hinted in the issue description that it could have been removed because `expo-cli` depended on `@expo/bunyan`. My wishful guess is that this is no longer an issue, but it's just a guess…

What do you think? We [_could_](https://github.com/expo/eas-build/pull/231/commits/c5b7a8d5f89a56eab3f2799c30ba97a6e2d6c65d) keep adding unique `id` using private `bunyan` API (but hence it's private I don't think it's a good idea).

# Test Plan

Built a test Expo app locally with [the script suggested in the docs](https://github.com/expo/eas-build/blob/df67875b24a643ba821d1092a40683107c518391/DEVELOPMENT.md#L14-L22).