### PR TITLE
[ENG-8843][ENG-8844][build-tools] Implement `eas/run_gradle` and `eas/prebuild` functions for customizable builds

### DIFF
--- a/packages/build-tools/src/builders/android.ts
+++ b/packages/build-tools/src/builders/android.ts
@@ -1,9 +1,15 @@
+import path from 'path';
+
 import { Android, BuildMode, BuildPhase, Workflow } from '@expo/eas-build-job';
 import nullthrows from 'nullthrows';
 
 import { Artifacts, ArtifactType, BuildContext, SkipNativeBuildError } from '../context';
 import { configureExpoUpdatesIfInstalledAsync } from '../utils/expoUpdates';
-import { runGradleCommand, ensureLFLineEndingsInGradlewScript } from '../android/gradle';
+import {
+  runGradleCommand,
+  ensureLFLineEndingsInGradlewScript,
+  resolveVersionOverridesEnvs,
+} from '../android/gradle';
 import { findArtifacts } from '../utils/artifacts';
 import { Hook, runHookIfPresent } from '../utils/hooks';
 import { restoreCredentials } from '../android/credentials';
@@ -44,7 +50,10 @@ async function buildAsync(ctx: BuildContext<Android.Job>): Promise<void> {
       );
       return;
     }
-    await prebuildAsync(ctx);
+    await prebuildAsync(ctx, {
+      logger: ctx.logger,
+      workingDir: ctx.getReactNativeProjectDirectory(),
+    });
   });
 
   await ctx.runBuildPhase(BuildPhase.RESTORE_CACHE, async () => {
@@ -72,7 +81,12 @@ async function buildAsync(ctx: BuildContext<Android.Job>): Promise<void> {
   }
   await ctx.runBuildPhase(BuildPhase.RUN_GRADLEW, async () => {
     const gradleCommand = resolveGradleCommand(ctx.job);
-    await runGradleCommand(ctx, gradleCommand);
+    await runGradleCommand(ctx, {
+      logger: ctx.logger,
+      gradleCommand,
+      androidDir: path.join(ctx.getReactNativeProjectDirectory(), 'android'),
+      extraEnvs: resolveVersionOverridesEnvs(ctx),
+    });
   });
 
   await ctx.runBuildPhase(BuildPhase.PRE_UPLOAD_ARTIFACTS_HOOK, async () => {

--- a/packages/build-tools/src/builders/ios.ts
+++ b/packages/build-tools/src/builders/ios.ts
@@ -53,7 +53,11 @@ async function buildAsync(ctx: BuildContext<Ios.Job>): Promise<void> {
       const extraEnvs: Record<string, string> = credentials?.teamId
         ? { APPLE_TEAM_ID: credentials.teamId }
         : {};
-      await prebuildAsync(ctx, { extraEnvs });
+      await prebuildAsync(ctx, {
+        logger: ctx.logger,
+        workingDir: ctx.getReactNativeProjectDirectory(),
+        options: { extraEnvs },
+      });
     });
 
     await ctx.runBuildPhase(BuildPhase.RESTORE_CACHE, async () => {

--- a/packages/build-tools/src/common/setup.ts
+++ b/packages/build-tools/src/common/setup.ts
@@ -17,7 +17,7 @@ import { readPackageJson, shouldUseGlobalExpoCli } from '../utils/project';
 import { getParentAndDescendantProcessPidsAsync } from '../utils/processes';
 
 import { prepareProjectSourcesAsync } from './projectSources';
-import { installDependenciesAsync } from './installDependencies';
+import { installDependenciesAsync, resolvePackagerDir } from './installDependencies';
 import { configureEnvFromBuildProfileAsync, runEasBuildInternalAsync } from './easBuildInternal';
 
 const MAX_EXPO_DOCTOR_TIMEOUT_MS = 30 * 1000;
@@ -50,7 +50,10 @@ export async function setupAsync<TJob extends Job>(ctx: BuildContext<TJob>): Pro
   });
 
   await ctx.runBuildPhase(BuildPhase.INSTALL_DEPENDENCIES, async () => {
-    await installDependenciesAsync(ctx, ctx.logger);
+    await installDependenciesAsync(ctx, {
+      logger: ctx.logger,
+      workingDir: resolvePackagerDir(ctx),
+    });
   });
 
   if (ctx.job.triggeredBy === BuildTrigger.GIT_BASED_INTEGRATION) {

--- a/packages/build-tools/src/steps/easFunctions.ts
+++ b/packages/build-tools/src/steps/easFunctions.ts
@@ -7,6 +7,8 @@ import { createUploadArtifactBuildFunction } from './functions/uploadArtifact';
 import { createCheckoutBuildFunction } from './functions/checkout';
 import { createSetUpNpmrcBuildFunction } from './functions/setUpNpmrc';
 import { createInstallNodeModulesBuildFunction } from './functions/installNodeModules';
+import { createRunGradleBuildFunction } from './functions/runGradle';
+import { createPrebuildBuildFunction } from './functions/prebuild';
 
 export function getEasFunctions<T extends Job>(ctx: BuildContext<T>): BuildFunction[] {
   return [
@@ -14,5 +16,7 @@ export function getEasFunctions<T extends Job>(ctx: BuildContext<T>): BuildFunct
     createUploadArtifactBuildFunction(ctx),
     createSetUpNpmrcBuildFunction(ctx),
     createInstallNodeModulesBuildFunction(ctx),
+    createPrebuildBuildFunction(ctx),
+    createRunGradleBuildFunction(ctx),
   ];
 }

--- a/packages/build-tools/src/steps/functions/installNodeModules.ts
+++ b/packages/build-tools/src/steps/functions/installNodeModules.ts
@@ -12,7 +12,10 @@ export function createInstallNodeModulesBuildFunction<T extends Job>(
     id: 'install_node_modules',
     name: 'Install node modules',
     fn: async (stepsCtx) => {
-      await installDependenciesAsync(ctx, stepsCtx.logger);
+      await installDependenciesAsync(ctx, {
+        logger: stepsCtx.logger,
+        workingDir: stepsCtx.workingDirectory,
+      });
     },
   });
 }

--- a/packages/build-tools/src/steps/functions/prebuild.ts
+++ b/packages/build-tools/src/steps/functions/prebuild.ts
@@ -1,0 +1,29 @@
+import { Job } from '@expo/eas-build-job';
+import { BuildFunction, BuildStepInput } from '@expo/steps';
+
+import { BuildContext } from '../../context';
+import { prebuildAsync } from '../../common/prebuild';
+
+export function createPrebuildBuildFunction<T extends Job>(ctx: BuildContext<T>): BuildFunction {
+  return new BuildFunction({
+    namespace: 'eas',
+    id: 'prebuild',
+    name: 'Prebuild',
+    inputProviders: [
+      BuildStepInput.createProvider({
+        id: 'apple_team_id',
+        required: false,
+      }),
+    ],
+    fn: async (stepsCtx, { inputs }) => {
+      const extraEnvs: Record<string, string> = inputs.apple_team_id.value
+        ? { APPLE_TEAM_ID: inputs.apple_team_id.value }
+        : {};
+      await prebuildAsync(ctx, {
+        logger: stepsCtx.logger,
+        workingDir: stepsCtx.workingDirectory,
+        options: { extraEnvs },
+      });
+    },
+  });
+}

--- a/packages/build-tools/src/steps/functions/runGradle.ts
+++ b/packages/build-tools/src/steps/functions/runGradle.ts
@@ -1,0 +1,28 @@
+import { Job } from '@expo/eas-build-job';
+import { BuildFunction, BuildStepInput } from '@expo/steps';
+import nullthrows from 'nullthrows';
+
+import { BuildContext } from '../../context';
+import { runGradleCommand } from '../../android/gradle';
+
+export function createRunGradleBuildFunction<T extends Job>(ctx: BuildContext<T>): BuildFunction {
+  return new BuildFunction({
+    namespace: 'eas',
+    id: 'run_gradle',
+    name: 'Run Gradle',
+    inputProviders: [
+      BuildStepInput.createProvider({
+        id: 'gradle_command',
+        defaultValue: ':app:bundleRelease',
+      }),
+    ],
+    fn: async (stepsCtx, { inputs }) => {
+      // TODO: resolve extra envs for GH builds using resolveVersionOverridesEnvs function when adding GH builds support
+      await runGradleCommand(ctx, {
+        logger: stepsCtx.logger,
+        gradleCommand: nullthrows(inputs.gradle_command.value),
+        androidDir: stepsCtx.workingDirectory,
+      });
+    },
+  });
+}


### PR DESCRIPTION
# Why

Add `eas/prebuild` and `eas/run_gradle` reusable functions

# How

Add `eas/prebuild` and `eas/run_gradle` reusable functions

Make sure we are respecting the working dir set for step during the process

# Test Plan

Run builds locally using standard workflow.

Run custom build locally using:
```yml
build:
  name: Run simple android apk build
  steps:
    - eas/checkout
    - eas/use_npm_token
    - eas/install_node_modules
    - eas/prebuild
    - eas/run_gradle:
        working_directory: ./android
        inputs:
          gradle_command: :app:assembleRelease
    - eas/upload_artifacts:
        inputs:
          type: application-archive
          path: ./android/app/build/outputs/apk/release/app-release.apk
```
config
