### PR TITLE
[logger] Move `@types/bunyan` to dependencies

### DIFF
--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -19,10 +19,10 @@
   "bugs": "https://github.com/expo/eas-build/issues",
   "license": "BUSL-1.1",
   "dependencies": {
+    "@types/bunyan": "^1.8.8",
     "bunyan": "^1.8.15"
   },
   "devDependencies": {
-    "@types/bunyan": "^1.8.8",
     "@types/jest": "^29.4.0",
     "@types/node": "^18.11.18",
     "jest": "^29.4.1",


### PR DESCRIPTION
# Why

Ought to fix https://github.com/expo/eas-cli/actions/runs/5244436582/jobs/9470444952.

# How

There are two ways to approach this error:
1. move `@types/bunyan` from `devDependencies` to `dependencies` so that `@expo/logger` exposes types for what it exports,
2. require each consumer of the `@expo/logger` package to install `@types/bunyan` on its own.

I think the former approach is better because:
- we "own" the `bunyan` instance we're exporting so we "know" what are its types
- mismatch between what the consumer installs and what we export is less likely.

# Test Plan

I'll see if the upgrade in `expo-cli` works nicely.

Not planning to deploy `turtle-v2` after upgrade (it's just types).