### PR TITLE
[build-tools] Fix installing node_modules in workspaces

### DIFF
--- a/packages/build-tools/src/common/prebuild.ts
+++ b/packages/build-tools/src/common/prebuild.ts
@@ -7,7 +7,7 @@ import { BuildContext } from '../context';
 import { isAtLeastNpm7Async } from '../utils/packageManager';
 import { runExpoCliCommand, shouldUseGlobalExpoCli } from '../utils/project';
 
-import { installDependenciesAsync } from './installDependencies';
+import { installDependenciesAsync, resolvePackagerDir } from './installDependencies';
 
 export interface PrebuildOptions {
   extraEnvs?: Record<string, string>;
@@ -37,7 +37,7 @@ export async function prebuildAsync<TJob extends Job>(
   await runExpoCliCommand(ctx, prebuildCommandArgs, spawnOptions, {
     npmVersionAtLeast7: await isAtLeastNpm7Async(),
   });
-  await installDependenciesAsync(ctx, { logger, workingDir });
+  await installDependenciesAsync(ctx, { logger, workingDir: resolvePackagerDir(ctx) });
 }
 
 function getPrebuildCommandArgs<TJob extends Job>(


### PR DESCRIPTION
# Why

In https://github.com/expo/eas-build/commit/3e1995f112b52ed9adf1df944212f53909b36f56 logic to resolve workingdir was moved to outside function, but the correct directorry was only resolved when doing initial install, but not when runinng install after prebuild

https://github.com/expo/eas-cli/issues/1879

# How

resolve workspace root when running install before prebuild

# Test Plan

