### PR TITLE
[ENG-8944][steps] allow for `boolean` and `number` inputs types

### DIFF
--- a/packages/build-tools/src/steps/functions/prebuild.ts
+++ b/packages/build-tools/src/steps/functions/prebuild.ts
@@ -1,5 +1,5 @@
 import { Job } from '@expo/eas-build-job';
-import { BuildFunction, BuildStepInput } from '@expo/steps';
+import { BuildFunction, BuildStepInput, BuildStepInputValueTypeName } from '@expo/steps';
 
 import { BuildContext } from '../../context';
 import { prebuildAsync } from '../../common/prebuild';
@@ -13,10 +13,12 @@ export function createPrebuildBuildFunction<T extends Job>(ctx: BuildContext<T>)
       BuildStepInput.createProvider({
         id: 'skip_dependency_update',
         defaultValue: false,
+        allowedValueTypeName: BuildStepInputValueTypeName.BOOLEAN,
       }),
       BuildStepInput.createProvider({
         id: 'clean',
         defaultValue: false,
+        allowedValueTypeName: BuildStepInputValueTypeName.BOOLEAN,
       }),
       BuildStepInput.createProvider({
         id: 'apple_team_id',

--- a/packages/steps/src/BuildConfigParser.ts
+++ b/packages/steps/src/BuildConfigParser.ts
@@ -20,7 +20,11 @@ import {
 import { BuildFunction, BuildFunctionById } from './BuildFunction.js';
 import { BuildStep } from './BuildStep.js';
 import { BuildStepContext } from './BuildStepContext.js';
-import { BuildStepInput, BuildStepInputProvider } from './BuildStepInput.js';
+import {
+  BuildStepInput,
+  BuildStepInputProvider,
+  BuildStepInputValueTypeName,
+} from './BuildStepInput.js';
 import { BuildStepOutput, BuildStepOutputProvider } from './BuildStepOutput.js';
 import { BuildWorkflow } from './BuildWorkflow.js';
 import { BuildWorkflowValidator } from './BuildWorkflowValidator.js';
@@ -195,6 +199,7 @@ export class BuildConfigParser {
           stepDisplayName,
           defaultValue: value,
           required: true,
+          allowedValueTypeName: typeof value as BuildStepInputValueTypeName,
         })
     );
   }
@@ -210,6 +215,7 @@ export class BuildConfigParser {
             required: entry.required ?? true,
             defaultValue: entry.defaultValue,
             allowedValues: entry.allowedValues,
+            allowedValueTypeName: entry.allowedValueType,
           });
     });
   }

--- a/packages/steps/src/BuildFunction.ts
+++ b/packages/steps/src/BuildFunction.ts
@@ -3,11 +3,11 @@ import assert from 'assert';
 import { BuildRuntimePlatform } from './BuildRuntimePlatform.js';
 import { BuildStep, BuildStepFunction } from './BuildStep.js';
 import { BuildStepContext } from './BuildStepContext.js';
-import { BuildStepInputProvider } from './BuildStepInput.js';
+import { BuildStepInputProvider, BuildStepInputValueType } from './BuildStepInput.js';
 import { BuildStepOutputProvider } from './BuildStepOutput.js';
 
 export type BuildFunctionById = Record<string, BuildFunction>;
-export type BuildFunctionCallInputs = Record<string, string | boolean>;
+export type BuildFunctionCallInputs = Record<string, BuildStepInputValueType>;
 
 export class BuildFunction {
   public readonly namespace?: string;

--- a/packages/steps/src/BuildStepInput.ts
+++ b/packages/steps/src/BuildStepInput.ts
@@ -77,17 +77,17 @@ export class BuildStepInput {
     }
   }
 
+  public get rawValue(): BuildStepInputValueType | undefined {
+    return this._value ?? this.defaultValue;
+  }
+
   public set(value: BuildStepInputValueType | undefined): BuildStepInput {
     if (this.required && value === undefined) {
       throw new BuildStepRuntimeError(
         `Input parameter "${this.id}" for step "${this.stepDisplayName}" is required.`
       );
     }
-    if (typeof value !== this.allowedValueTypeName && value !== undefined) {
-      throw new BuildStepRuntimeError(
-        `Input parameter "${this.id}" for step "${this.stepDisplayName}" must be of type "${this.allowedValueTypeName}".`
-      );
-    }
+
     this._value = value;
     return this;
   }

--- a/packages/steps/src/BuildStepInput.ts
+++ b/packages/steps/src/BuildStepInput.ts
@@ -2,14 +2,22 @@ import { BuildStepContext } from './BuildStepContext.js';
 import { BuildStepRuntimeError } from './errors.js';
 import { interpolateWithOutputs } from './utils/template.js';
 
+export enum BuildStepInputValueTypeName {
+  STRING = 'string',
+  BOOLEAN = 'boolean',
+  NUMBER = 'number',
+}
+export type BuildStepInputValueType = string | boolean | number;
+
 export type BuildStepInputById = Record<string, BuildStepInput>;
 export type BuildStepInputProvider = (ctx: BuildStepContext, stepId: string) => BuildStepInput;
 
 interface BuildStepInputProviderParams {
   id: string;
-  allowedValues?: (string | boolean)[];
-  defaultValue?: string | boolean;
+  allowedValues?: BuildStepInputValueType[];
+  defaultValue?: BuildStepInputValueType;
   required?: boolean;
+  allowedValueTypeName?: BuildStepInputValueTypeName;
 }
 
 interface BuildStepInputParams extends BuildStepInputProviderParams {
@@ -19,11 +27,12 @@ interface BuildStepInputParams extends BuildStepInputProviderParams {
 export class BuildStepInput {
   public readonly id: string;
   public readonly stepDisplayName: string;
-  public readonly defaultValue?: string | boolean;
-  public readonly allowedValues?: (string | boolean)[];
+  public readonly defaultValue?: BuildStepInputValueType;
+  public readonly allowedValues?: BuildStepInputValueType[];
+  public readonly allowedValueTypeName: BuildStepInputValueTypeName;
   public readonly required: boolean;
 
-  private _value?: string | boolean;
+  private _value?: BuildStepInputValueType;
 
   public static createProvider(params: BuildStepInputProviderParams): BuildStepInputProvider {
     return (ctx, stepDisplayName) => new BuildStepInput(ctx, { ...params, stepDisplayName });
@@ -31,34 +40,52 @@ export class BuildStepInput {
 
   constructor(
     private readonly ctx: BuildStepContext,
-    { id, stepDisplayName, allowedValues, defaultValue, required = true }: BuildStepInputParams
+    {
+      id,
+      stepDisplayName,
+      allowedValues,
+      defaultValue,
+      required = true,
+      allowedValueTypeName = BuildStepInputValueTypeName.STRING,
+    }: BuildStepInputParams
   ) {
     this.id = id;
     this.stepDisplayName = stepDisplayName;
     this.allowedValues = allowedValues;
     this.defaultValue = defaultValue;
     this.required = required;
+    this.allowedValueTypeName = allowedValueTypeName;
   }
 
-  public get value(): string | boolean | undefined {
+  public get value(): BuildStepInputValueType | undefined {
     const rawValue = this._value ?? this.defaultValue;
     if (this.required && rawValue === undefined) {
       throw new BuildStepRuntimeError(
         `Input parameter "${this.id}" for step "${this.stepDisplayName}" is required but it was not set.`
       );
     }
+    if (typeof rawValue !== this.allowedValueTypeName && rawValue !== undefined) {
+      throw new BuildStepRuntimeError(
+        `Input parameter "${this.id}" for step "${this.stepDisplayName}" must be of type "${this.allowedValueTypeName}".`
+      );
+    }
 
-    if (rawValue === undefined || typeof rawValue === 'boolean') {
+    if (rawValue === undefined || typeof rawValue === 'boolean' || typeof rawValue === 'number') {
       return rawValue;
     } else {
       return interpolateWithOutputs(rawValue, (path) => this.ctx.getStepOutputValue(path) ?? '');
     }
   }
 
-  public set(value: string | boolean | undefined): BuildStepInput {
+  public set(value: BuildStepInputValueType | undefined): BuildStepInput {
     if (this.required && value === undefined) {
       throw new BuildStepRuntimeError(
         `Input parameter "${this.id}" for step "${this.stepDisplayName}" is required.`
+      );
+    }
+    if (typeof value !== this.allowedValueTypeName && value !== undefined) {
+      throw new BuildStepRuntimeError(
+        `Input parameter "${this.id}" for step "${this.stepDisplayName}" must be of type "${this.allowedValueTypeName}".`
       );
     }
     this._value = value;

--- a/packages/steps/src/BuildWorkflowValidator.ts
+++ b/packages/steps/src/BuildWorkflowValidator.ts
@@ -54,7 +54,7 @@ export class BuildWorkflowValidator {
           errors.push(error);
         }
         const paths =
-          typeof currentStepInput.defaultValue !== 'boolean'
+          typeof currentStepInput.defaultValue === 'string'
             ? findOutputPaths(currentStepInput.defaultValue)
             : [];
         for (const { stepId: referencedStepId, outputId: referencedStepOutputId } of paths) {

--- a/packages/steps/src/BuildWorkflowValidator.ts
+++ b/packages/steps/src/BuildWorkflowValidator.ts
@@ -38,6 +38,23 @@ export class BuildWorkflowValidator {
     const visitedStepByStepId: Record<string, BuildStep> = {};
     for (const currentStep of this.workflow.buildSteps) {
       for (const currentStepInput of currentStep.inputs ?? []) {
+        if (currentStepInput.required && currentStepInput.rawValue === undefined) {
+          const error = new BuildConfigError(
+            `Input parameter "${currentStepInput.id}" for step "${currentStep.displayName}" is required but it was not set.`
+          );
+          errors.push(error);
+        }
+
+        if (
+          currentStepInput.rawValue !== undefined &&
+          typeof currentStepInput.rawValue !== currentStepInput.allowedValueTypeName
+        ) {
+          const error = new BuildConfigError(
+            `Input parameter "${currentStepInput.id}" for step "${currentStep.displayName}" is set to "${currentStepInput.rawValue}" which is not of type "${currentStepInput.allowedValueTypeName}".`
+          );
+          errors.push(error);
+        }
+
         if (currentStepInput.defaultValue === undefined) {
           continue;
         }

--- a/packages/steps/src/__tests__/BuildConfig-test.ts
+++ b/packages/steps/src/__tests__/BuildConfig-test.ts
@@ -525,7 +525,8 @@ describe(validateConfig, () => {
                 {
                   name: 'i3',
                   default_value: true,
-                  allowed_values: [true, false, '1'],
+                  allowed_values: [true, false],
+                  type: 'boolean',
                 },
                 {
                   name: 'i4',

--- a/packages/steps/src/__tests__/BuildFunction-test.ts
+++ b/packages/steps/src/__tests__/BuildFunction-test.ts
@@ -1,6 +1,10 @@
 import { BuildFunction } from '../BuildFunction.js';
 import { BuildStep, BuildStepFunction } from '../BuildStep.js';
-import { BuildStepInput, BuildStepInputProvider } from '../BuildStepInput.js';
+import {
+  BuildStepInput,
+  BuildStepInputProvider,
+  BuildStepInputValueTypeName,
+} from '../BuildStepInput.js';
 import { BuildStepOutput, BuildStepOutputProvider } from '../BuildStepOutput.js';
 
 import { createMockContext } from './utils/context.js';
@@ -122,8 +126,17 @@ describe(BuildFunction, () => {
     it('creates function inputs and outputs', () => {
       const ctx = createMockContext();
       const inputProviders: BuildStepInputProvider[] = [
-        BuildStepInput.createProvider({ id: 'input1', defaultValue: true }),
+        BuildStepInput.createProvider({
+          id: 'input1',
+          defaultValue: true,
+          allowedValueTypeName: BuildStepInputValueTypeName.BOOLEAN,
+        }),
         BuildStepInput.createProvider({ id: 'input2' }),
+        BuildStepInput.createProvider({
+          id: 'input3',
+          defaultValue: 1,
+          allowedValueTypeName: BuildStepInputValueTypeName.NUMBER,
+        }),
       ];
       const outputProviders: BuildStepOutputProvider[] = [
         BuildStepOutput.createProvider({ id: 'output1' }),
@@ -139,7 +152,7 @@ describe(BuildFunction, () => {
       });
       const step = func.createBuildStepFromFunctionCall(ctx, {
         callInputs: {
-          input1: 'abc',
+          input1: true,
           input2: 'def',
         },
         workingDirectory: ctx.workingDirectory,
@@ -150,6 +163,7 @@ describe(BuildFunction, () => {
       expect(func.outputProviders?.[1]).toBe(outputProviders[1]);
       expect(step.inputs?.[0].id).toBe('input1');
       expect(step.inputs?.[1].id).toBe('input2');
+      expect(step.inputs?.[2].id).toBe('input3');
       expect(step.outputs?.[0].id).toBe('output1');
       expect(step.outputs?.[1].id).toBe('output2');
     });
@@ -158,7 +172,11 @@ describe(BuildFunction, () => {
       const inputProviders: BuildStepInputProvider[] = [
         BuildStepInput.createProvider({ id: 'input1', defaultValue: 'xyz1' }),
         BuildStepInput.createProvider({ id: 'input2', defaultValue: 'xyz2' }),
-        BuildStepInput.createProvider({ id: 'input3', defaultValue: 'xyz3' }),
+        BuildStepInput.createProvider({
+          id: 'input3',
+          defaultValue: true,
+          allowedValueTypeName: BuildStepInputValueTypeName.BOOLEAN,
+        }),
       ];
       const func = new BuildFunction({
         id: 'test1',

--- a/packages/steps/src/__tests__/BuildStep-test.ts
+++ b/packages/steps/src/__tests__/BuildStep-test.ts
@@ -7,7 +7,7 @@ import { v4 as uuidv4 } from 'uuid';
 
 import { BuildStep, BuildStepFunction, BuildStepStatus } from '../BuildStep.js';
 import { BuildStepContext } from '../BuildStepContext.js';
-import { BuildStepInput } from '../BuildStepInput.js';
+import { BuildStepInput, BuildStepInputValueTypeName } from '../BuildStepInput.js';
 import { BuildStepOutput } from '../BuildStepOutput.js';
 import { BuildStepRuntimeError } from '../errors.js';
 import { nullthrows } from '../utils/nullthrows.js';
@@ -439,6 +439,13 @@ describe(BuildStep, () => {
             id: 'foo3',
             stepDisplayName: displayName,
             defaultValue: true,
+            allowedValueTypeName: BuildStepInputValueTypeName.BOOLEAN,
+          }),
+          new BuildStepInput(baseStepCtx, {
+            id: 'foo4',
+            stepDisplayName: displayName,
+            defaultValue: 27,
+            allowedValueTypeName: BuildStepInputValueTypeName.NUMBER,
           }),
         ];
         const outputs: BuildStepOutput[] = [
@@ -450,7 +457,9 @@ describe(BuildStep, () => {
         ];
 
         const fn: BuildStepFunction = (_ctx, { inputs, outputs }) => {
-          outputs.abc.set(`${inputs.foo1.value} ${inputs.foo2.value} ${inputs.foo3.value}`);
+          outputs.abc.set(
+            `${inputs.foo1.value} ${inputs.foo2.value} ${inputs.foo3.value} ${inputs.foo4.value}`
+          );
         };
 
         const step = new BuildStep(baseStepCtx, {
@@ -464,7 +473,7 @@ describe(BuildStep, () => {
 
         await step.executeAsync(env);
 
-        expect(step.getOutputValueByName('abc')).toBe('bar1 bar2 true');
+        expect(step.getOutputValueByName('abc')).toBe('bar1 bar2 true 27');
       });
     });
   });

--- a/packages/steps/src/__tests__/BuildStepInput-test.ts
+++ b/packages/steps/src/__tests__/BuildStepInput-test.ts
@@ -114,20 +114,6 @@ describe(BuildStepInput, () => {
       new BuildStepRuntimeError('Input parameter "foo" for step "test1" is required.')
     );
   });
-
-  test('enforces allowed value type policy when setting value', () => {
-    const ctx = createMockContext();
-    const i = new BuildStepInput(ctx, {
-      id: 'foo',
-      stepDisplayName: BuildStep.getDisplayName({ id: 'test1' }),
-      allowedValueTypeName: BuildStepInputValueTypeName.BOOLEAN,
-    });
-    expect(() => {
-      i.set('bar');
-    }).toThrowError(
-      new BuildStepRuntimeError('Input parameter "foo" for step "test1" must be of type "boolean".')
-    );
-  });
 });
 
 describe(makeBuildStepInputByIdMap, () => {

--- a/packages/steps/src/__tests__/BuildStepInput-test.ts
+++ b/packages/steps/src/__tests__/BuildStepInput-test.ts
@@ -101,6 +101,23 @@ describe(BuildStepInput, () => {
     );
   });
 
+  test('enforces correct value type when reading a value', () => {
+    const ctx = createMockContext();
+    const i = new BuildStepInput(ctx, {
+      id: 'foo',
+      stepDisplayName: BuildStep.getDisplayName({ id: 'test1' }),
+      required: true,
+      allowedValueTypeName: BuildStepInputValueTypeName.BOOLEAN,
+    });
+    i.set('bar');
+    expect(() => {
+      // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+      i.value;
+    }).toThrowError(
+      new BuildStepRuntimeError('Input parameter "foo" for step "test1" must be of type "boolean".')
+    );
+  });
+
   test('enforces required policy when setting value', () => {
     const ctx = createMockContext();
     const i = new BuildStepInput(ctx, {

--- a/packages/steps/src/__tests__/fixtures/functions-with-platforms-property.yml
+++ b/packages/steps/src/__tests__/fixtures/functions-with-platforms-property.yml
@@ -9,6 +9,7 @@ functions:
   say_bye_linux_and_darwin:
     name: Bye!
     inputs:
-      - name
+      - name: name
+        type: string
     command: echo "Bye, ${ inputs.name }!"
     supported_platforms: [darwin, linux]

--- a/packages/steps/src/__tests__/fixtures/functions.yml
+++ b/packages/steps/src/__tests__/fixtures/functions.yml
@@ -17,6 +17,7 @@ build:
     - say_hi_2:
         inputs:
           greeting: Hello
+          number: 123
 
 functions:
   say_hi:
@@ -45,5 +46,8 @@ functions:
         default_value: Brent
       - name: test
         default_value: false
-        allowed_values: [false, true, "1"]
+        allowed_values: [false, true]
+        type: boolean
+      - name: number
+        type: number
     command: echo "${ inputs.greeting }, ${ inputs.name }!"

--- a/packages/steps/src/__tests__/fixtures/inputs.yml
+++ b/packages/steps/src/__tests__/fixtures/inputs.yml
@@ -7,4 +7,5 @@ build:
           name: Dominik Sokal
           country: Poland
           boolean_value: true
+          number_value: 123
         command: echo "Hi, ${ inputs.name }, ${ inputs.boolean_value }!"

--- a/packages/steps/src/__tests__/fixtures/invalid-functions.yml
+++ b/packages/steps/src/__tests__/fixtures/invalid-functions.yml
@@ -6,6 +6,6 @@ functions:
     name: Hi!
     inputs:
       - name: name
-        type: string
+        type: boolean
         allowed_values: [Wojtek, Dominik, Szymon, Brent]
     command: echo "Hi, ${ inputs.name }!"

--- a/packages/steps/src/index.ts
+++ b/packages/steps/src/index.ts
@@ -2,7 +2,7 @@ export { readAndValidateBuildConfigAsync } from './BuildConfig.js';
 export { BuildConfigParser } from './BuildConfigParser.js';
 export { BuildFunction } from './BuildFunction.js';
 export { BuildRuntimePlatform } from './BuildRuntimePlatform.js';
-export { BuildStepInput } from './BuildStepInput.js';
+export { BuildStepInput, BuildStepInputValueTypeName } from './BuildStepInput.js';
 export { BuildStepOutput } from './BuildStepOutput.js';
 export { BuildStepContext } from './BuildStepContext.js';
 export { BuildWorkflow } from './BuildWorkflow.js';


### PR DESCRIPTION
# Why

https://linear.app/expo/issue/ENG-8944/allow-number-and-boolean-inputs-for-custom-builds-steps-and-functions

# How

Allow for `boolean` and `number` input types.

Make sure that user can specify the input type for a given input
```yml
say_hi_2:
    name: Hi!
    supported_platforms: [darwin, linux]
    inputs:
      - name: greeting
        default_value: Hi
        allowed_values: [Hi, Hello]
      - name: name
        default_value: Brent
      - name: test
        default_value: false
        allowed_values: [false, true]
        type: boolean
      - name: number
        type: number
    command: echo "${ inputs.greeting }, ${ inputs.name }!"
```

`type` might be one of `boolean`, `string`, and `number` values
input can have only one `type` specified, it is `string` by default

Improve build workflow validator:
- validate if the specified input value is of the correct type
- validate if `required` inputs are set (or at least have a chance to be set)

# Test Plan

Automated tests

# Future work

Improving typescript typing of inputs will be done in separate PR
