### PR TITLE
[steps] refactor context to simplify injecting logic into stpes library

### DIFF
--- a/packages/build-tools/src/builders/custom.ts
+++ b/packages/build-tools/src/builders/custom.ts
@@ -1,40 +1,29 @@
 import path from 'path';
 
-import { BuildPhase, Job, Platform } from '@expo/eas-build-job';
-import { BuildConfigParser, BuildStepContext, errors, BuildRuntimePlatform } from '@expo/steps';
+import { BuildPhase, Job } from '@expo/eas-build-job';
+import { BuildConfigParser, BuildStepGlobalContext, errors } from '@expo/steps';
 import nullthrows from 'nullthrows';
 
 import { Artifacts, BuildContext } from '../context';
 import { prepareProjectSourcesAsync } from '../common/projectSources';
 import { getEasFunctions } from '../steps/easFunctions';
-
-const platformToBuildRuntimePlatform: Record<Platform, BuildRuntimePlatform> = {
-  [Platform.ANDROID]: BuildRuntimePlatform.LINUX,
-  [Platform.IOS]: BuildRuntimePlatform.DARWIN,
-};
+import { CustomBuildContext } from '../customBuildContext';
 
 export async function runCustomBuildAsync<T extends Job>(ctx: BuildContext<T>): Promise<Artifacts> {
-  await prepareProjectSourcesAsync(ctx, ctx.temporaryCustomBuildDirectory);
+  const customBuildCtx = new CustomBuildContext(ctx);
+  await prepareProjectSourcesAsync(ctx, customBuildCtx.projectSourceDirectory);
   const relativeConfigPath = nullthrows(
     ctx.job.customBuildConfig?.path,
     'Custom build config must be defined for custom builds'
   );
   const configPath = path.join(
-    ctx.getReactNativeProjectDirectory(ctx.temporaryCustomBuildDirectory),
+    ctx.getReactNativeProjectDirectory(customBuildCtx.projectSourceDirectory),
     relativeConfigPath
   );
 
-  const buildStepContext = new BuildStepContext(
-    ctx.env.EAS_BUILD_ID,
-    ctx.logger.child({ phase: BuildPhase.CUSTOM }),
-    false,
-    platformToBuildRuntimePlatform[ctx.job.platform],
-    ctx.temporaryCustomBuildDirectory,
-    ctx.buildDirectory,
-    ctx.getReactNativeProjectDirectory()
-  );
+  const globalContext = new BuildStepGlobalContext(customBuildCtx, false);
   const easFunctions = getEasFunctions(ctx);
-  const parser = new BuildConfigParser(buildStepContext, {
+  const parser = new BuildConfigParser(globalContext, {
     configPath,
     externalFunctions: easFunctions,
   });

--- a/packages/build-tools/src/context.ts
+++ b/packages/build-tools/src/context.ts
@@ -139,13 +139,10 @@ export class BuildContext<TJob extends Job> {
   public get buildDirectory(): string {
     return path.join(this.workingdir, 'build');
   }
-  public get temporaryCustomBuildDirectory(): string {
-    return path.join(this.workingdir, 'temporary-custom-build');
-  }
   public get buildLogsDirectory(): string {
     return path.join(this.workingdir, 'logs');
   }
-  public get environmentSecrectsDirectory(): string {
+  public get environmentSecretsDirectory(): string {
     return path.join(this.workingdir, 'environment-secrets');
   }
   public get packageManager(): PackageManager {
@@ -315,7 +312,7 @@ export class BuildContext<TJob extends Job> {
         environmentSecrets[name] = value;
       } else {
         environmentSecrets[name] = createTemporaryEnvironmentSecretFile(
-          this.environmentSecrectsDirectory,
+          this.environmentSecretsDirectory,
           value
         );
       }

--- a/packages/build-tools/src/customBuildContext.ts
+++ b/packages/build-tools/src/customBuildContext.ts
@@ -1,0 +1,62 @@
+import path from 'path';
+
+import { BuildPhase, Env, Job, Platform } from '@expo/eas-build-job';
+import { bunyan } from '@expo/logger';
+import { ExternalBuildContextProvider, BuildRuntimePlatform } from '@expo/steps';
+
+import { BuildContext } from './context';
+
+const platformToBuildRuntimePlatform: Record<Platform, BuildRuntimePlatform> = {
+  [Platform.ANDROID]: BuildRuntimePlatform.LINUX,
+  [Platform.IOS]: BuildRuntimePlatform.DARWIN,
+};
+
+export class CustomBuildContext implements ExternalBuildContextProvider {
+  /*
+   * Directory that contains project sources before eas/checkout.
+   */
+  public readonly projectSourceDirectory: string;
+
+  /*
+   * Directory where build is executed. eas/checkout will copy sources here.
+   */
+  public readonly projectTargetDirectory: string;
+
+  /*
+   * Directory where all build steps will be executed unless configured otherwise.
+   */
+  public readonly defaultWorkingDirectory: string;
+
+  public readonly logger: bunyan;
+
+  private _env: Env;
+  private readonly job: Job;
+
+  constructor(buildCtx: BuildContext<Job>) {
+    this._env = buildCtx.env;
+    this.job = buildCtx.job;
+
+    this.logger = buildCtx.logger.child({ phase: BuildPhase.CUSTOM });
+    this.projectSourceDirectory = path.join(buildCtx.workingdir, 'temporary-custom-build');
+    this.projectTargetDirectory = path.join(buildCtx.workingdir, 'build');
+    this.defaultWorkingDirectory = buildCtx.getReactNativeProjectDirectory();
+  }
+
+  public get runtimePlatform(): BuildRuntimePlatform {
+    return platformToBuildRuntimePlatform[this.job.platform];
+  }
+
+  public get env(): Env {
+    return this._env;
+  }
+
+  public staticContext(): any {
+    return {
+      job: this.job,
+    };
+  }
+
+  public updateEnv(env: Env): void {
+    this._env = env;
+  }
+}

--- a/packages/build-tools/src/steps/functions/eas/checkout.ts
+++ b/packages/build-tools/src/steps/functions/eas/checkout.ts
@@ -8,9 +8,13 @@ export function createCheckoutBuildFunction(): BuildFunction {
     name: 'Checkout',
     fn: async (stepsCtx) => {
       stepsCtx.logger.info('Checking out project directory');
-      await fs.move(stepsCtx.projectSourceDirectory, stepsCtx.projectTargetDirectory, {
-        overwrite: true,
-      });
+      await fs.move(
+        stepsCtx.global.projectSourceDirectory,
+        stepsCtx.global.projectTargetDirectory,
+        {
+          overwrite: true,
+        }
+      );
     },
   });
 }

--- a/packages/steps/src/BuildConfigParser.ts
+++ b/packages/steps/src/BuildConfigParser.ts
@@ -19,12 +19,12 @@ import {
 } from './BuildConfig.js';
 import { BuildFunction, BuildFunctionById } from './BuildFunction.js';
 import { BuildStep } from './BuildStep.js';
-import { BuildStepContext } from './BuildStepContext.js';
 import {
   BuildStepInput,
   BuildStepInputProvider,
   BuildStepInputValueTypeName,
 } from './BuildStepInput.js';
+import { BuildStepGlobalContext } from './BuildStepContext.js';
 import { BuildStepOutput, BuildStepOutputProvider } from './BuildStepOutput.js';
 import { BuildWorkflow } from './BuildWorkflow.js';
 import { BuildWorkflowValidator } from './BuildWorkflowValidator.js';
@@ -37,7 +37,7 @@ export class BuildConfigParser {
   private readonly externalFunctions?: BuildFunction[];
 
   constructor(
-    private readonly ctx: BuildStepContext,
+    private readonly ctx: BuildStepGlobalContext,
     { configPath, externalFunctions }: { configPath: string; externalFunctions?: BuildFunction[] }
   ) {
     this.validateExternalFunctions(externalFunctions);

--- a/packages/steps/src/BuildFunction.ts
+++ b/packages/steps/src/BuildFunction.ts
@@ -2,7 +2,7 @@ import assert from 'assert';
 
 import { BuildRuntimePlatform } from './BuildRuntimePlatform.js';
 import { BuildStep, BuildStepFunction } from './BuildStep.js';
-import { BuildStepContext } from './BuildStepContext.js';
+import { BuildStepGlobalContext } from './BuildStepContext.js';
 import { BuildStepInputProvider, BuildStepInputValueType } from './BuildStepInput.js';
 import { BuildStepOutputProvider } from './BuildStepOutput.js';
 
@@ -64,7 +64,7 @@ export class BuildFunction {
   }
 
   public createBuildStepFromFunctionCall(
-    ctx: BuildStepContext,
+    ctx: BuildStepGlobalContext,
     {
       id,
       name,

--- a/packages/steps/src/BuildStepContext.ts
+++ b/packages/steps/src/BuildStepContext.ts
@@ -2,30 +2,53 @@ import os from 'os';
 import path from 'path';
 
 import { bunyan } from '@expo/logger';
+import { v4 as uuidv4 } from 'uuid';
 
 import { BuildStep } from './BuildStep.js';
 import { parseOutputPath } from './utils/template.js';
 import { BuildStepRuntimeError } from './errors.js';
 import { BuildRuntimePlatform } from './BuildRuntimePlatform.js';
+import { BuildStepEnv } from './BuildStepEnv.js';
 
-export class BuildStepContext {
+export interface ExternalBuildContextProvider {
+  readonly projectSourceDirectory: string;
+  readonly projectTargetDirectory: string;
+  readonly defaultWorkingDirectory: string;
+  readonly runtimePlatform: BuildRuntimePlatform;
+  readonly logger: bunyan;
+
+  readonly staticContext: any;
+
+  readonly env: BuildStepEnv;
+  updateEnv(env: BuildStepEnv): void;
+}
+
+export class BuildStepGlobalContext {
   public readonly stepsInternalBuildDirectory: string;
-  public readonly workingDirectory: string;
+  public readonly runtimePlatform: BuildRuntimePlatform;
+  public readonly baseLogger: bunyan;
 
   private stepById: Record<string, BuildStep> = {};
 
   constructor(
-    public readonly buildId: string,
-    public readonly logger: bunyan,
-    public readonly skipCleanup: boolean,
-    public readonly runtimePlatform: BuildRuntimePlatform,
-    public readonly projectSourceDirectory: string,
-    public readonly projectTargetDirectory: string,
-    workingDirectory?: string
+    private readonly provider: ExternalBuildContextProvider,
+    public readonly skipCleanup: boolean
   ) {
-    this.stepsInternalBuildDirectory = path.join(os.tmpdir(), 'eas-build', buildId);
-    this.workingDirectory =
-      workingDirectory ?? path.join(this.stepsInternalBuildDirectory, 'project');
+    this.stepsInternalBuildDirectory = path.join(os.tmpdir(), 'eas-build', uuidv4());
+    this.runtimePlatform = provider.runtimePlatform;
+    this.baseLogger = provider.logger;
+  }
+
+  public get projectSourceDirectory(): string {
+    return this.provider.projectSourceDirectory;
+  }
+
+  public get projectTargetDirectory(): string {
+    return this.provider.projectTargetDirectory;
+  }
+
+  public get defaultWorkingDirectory(): string {
+    return this.provider.defaultWorkingDirectory;
   }
 
   public registerStep(step: BuildStep): void {
@@ -40,21 +63,30 @@ export class BuildStepContext {
     return this.stepById[stepId].getOutputValueByName(outputId);
   }
 
-  public child({
-    logger,
-    workingDirectory,
-  }: {
-    logger?: bunyan;
-    workingDirectory?: string;
-  } = {}): BuildStepContext {
-    return new BuildStepContext(
-      this.buildId,
-      logger ?? this.logger,
-      this.skipCleanup,
-      this.runtimePlatform,
-      this.projectSourceDirectory,
-      this.projectTargetDirectory,
-      workingDirectory ?? this.workingDirectory
-    );
+  public stepCtx(options: { logger: bunyan; workingDirectory: string }): BuildStepContext {
+    return new BuildStepContext(this, options);
+  }
+}
+
+export class BuildStepContext {
+  public readonly logger: bunyan;
+  public readonly workingDirectory: string;
+
+  constructor(
+    private readonly ctx: BuildStepGlobalContext,
+    {
+      logger,
+      workingDirectory,
+    }: {
+      logger: bunyan;
+      workingDirectory: string;
+    }
+  ) {
+    this.logger = logger ?? ctx.baseLogger;
+    this.workingDirectory = workingDirectory ?? ctx.defaultWorkingDirectory;
+  }
+
+  public get global(): BuildStepGlobalContext {
+    return this.ctx;
   }
 }

--- a/packages/steps/src/BuildStepInput.ts
+++ b/packages/steps/src/BuildStepInput.ts
@@ -1,4 +1,4 @@
-import { BuildStepContext } from './BuildStepContext.js';
+import { BuildStepGlobalContext } from './BuildStepContext.js';
 import { BuildStepRuntimeError } from './errors.js';
 import { interpolateWithOutputs } from './utils/template.js';
 
@@ -10,7 +10,10 @@ export enum BuildStepInputValueTypeName {
 export type BuildStepInputValueType = string | boolean | number;
 
 export type BuildStepInputById = Record<string, BuildStepInput>;
-export type BuildStepInputProvider = (ctx: BuildStepContext, stepId: string) => BuildStepInput;
+export type BuildStepInputProvider = (
+  ctx: BuildStepGlobalContext,
+  stepId: string
+) => BuildStepInput;
 
 interface BuildStepInputProviderParams {
   id: string;
@@ -39,7 +42,7 @@ export class BuildStepInput {
   }
 
   constructor(
-    private readonly ctx: BuildStepContext,
+    private readonly ctx: BuildStepGlobalContext,
     {
       id,
       stepDisplayName,

--- a/packages/steps/src/BuildStepOutput.ts
+++ b/packages/steps/src/BuildStepOutput.ts
@@ -1,9 +1,9 @@
-import { BuildStepContext } from './BuildStepContext.js';
+import { BuildStepGlobalContext } from './BuildStepContext.js';
 import { BuildStepRuntimeError } from './errors.js';
 
 export type BuildStepOutputById = Record<string, BuildStepOutput>;
 export type BuildStepOutputProvider = (
-  ctx: BuildStepContext,
+  ctx: BuildStepGlobalContext,
   stepDisplayName: string
 ) => BuildStepOutput;
 
@@ -29,7 +29,7 @@ export class BuildStepOutput {
 
   constructor(
     // @ts-expect-error ctx is not used in this class but let's keep it here for consistency
-    private readonly ctx: BuildStepContext,
+    private readonly ctx: BuildStepGlobalContext,
     { id, stepDisplayName, required = true }: BuildStepOutputParams
   ) {
     this.id = id;

--- a/packages/steps/src/BuildTemporaryFiles.ts
+++ b/packages/steps/src/BuildTemporaryFiles.ts
@@ -3,10 +3,10 @@ import fs from 'fs/promises';
 
 import { v4 as uuidv4 } from 'uuid';
 
-import { BuildStepContext } from './BuildStepContext.js';
+import { BuildStepGlobalContext } from './BuildStepContext.js';
 
 export async function saveScriptToTemporaryFileAsync(
-  ctx: BuildStepContext,
+  ctx: BuildStepGlobalContext,
   stepId: string,
   scriptContents: string
 ): Promise<string> {
@@ -18,7 +18,7 @@ export async function saveScriptToTemporaryFileAsync(
 }
 
 export async function createTemporaryOutputsDirectoryAsync(
-  ctx: BuildStepContext,
+  ctx: BuildStepGlobalContext,
   stepId: string
 ): Promise<string> {
   const directory = getTemporaryOutputsDirPath(ctx, stepId);
@@ -27,7 +27,7 @@ export async function createTemporaryOutputsDirectoryAsync(
 }
 
 export async function cleanUpStepTemporaryDirectoriesAsync(
-  ctx: BuildStepContext,
+  ctx: BuildStepGlobalContext,
   stepId: string
 ): Promise<void> {
   if (ctx.skipCleanup) {
@@ -35,16 +35,16 @@ export async function cleanUpStepTemporaryDirectoriesAsync(
   }
   const stepTemporaryDirectory = getTemporaryStepDirPath(ctx, stepId);
   await fs.rm(stepTemporaryDirectory, { recursive: true, force: true });
-  ctx.logger.debug({ stepTemporaryDirectory }, 'Removed step temporary directory');
+  ctx.baseLogger.debug({ stepTemporaryDirectory }, 'Removed step temporary directory');
 }
-function getTemporaryStepDirPath(ctx: BuildStepContext, stepId: string): string {
+function getTemporaryStepDirPath(ctx: BuildStepGlobalContext, stepId: string): string {
   return path.join(ctx.stepsInternalBuildDirectory, 'steps', stepId);
 }
 
-function getTemporaryScriptsDirPath(ctx: BuildStepContext, stepId: string): string {
+function getTemporaryScriptsDirPath(ctx: BuildStepGlobalContext, stepId: string): string {
   return path.join(getTemporaryStepDirPath(ctx, stepId), 'scripts');
 }
 
-function getTemporaryOutputsDirPath(ctx: BuildStepContext, stepId: string): string {
+function getTemporaryOutputsDirPath(ctx: BuildStepGlobalContext, stepId: string): string {
   return path.join(getTemporaryStepDirPath(ctx, stepId), 'outputs');
 }

--- a/packages/steps/src/BuildWorkflow.ts
+++ b/packages/steps/src/BuildWorkflow.ts
@@ -1,7 +1,7 @@
 import { BuildFunctionById } from './BuildFunction.js';
 import { BuildStep } from './BuildStep.js';
-import { BuildStepContext } from './BuildStepContext.js';
 import { BuildStepEnv } from './BuildStepEnv.js';
+import { BuildStepGlobalContext } from './BuildStepContext.js';
 
 export class BuildWorkflow {
   public readonly buildSteps: BuildStep[];
@@ -9,7 +9,7 @@ export class BuildWorkflow {
 
   constructor(
     // @ts-expect-error ctx is not used in this class but let's keep it here for consistency
-    private readonly ctx: BuildStepContext,
+    private readonly ctx: BuildStepGlobalContext,
     { buildSteps, buildFunctions }: { buildSteps: BuildStep[]; buildFunctions: BuildFunctionById }
   ) {
     this.buildSteps = buildSteps;

--- a/packages/steps/src/BuildWorkflowValidator.ts
+++ b/packages/steps/src/BuildWorkflowValidator.ts
@@ -109,7 +109,7 @@ export class BuildWorkflowValidator {
       if (!step.canBeRunOnRuntimePlatform()) {
         const error = new BuildConfigError(
           `Step "${step.displayName}" is not allowed on platform "${
-            step.ctx.runtimePlatform
+            step.ctx.global.runtimePlatform
           }". Allowed platforms for this step are: ${nullthrows(
             step.supportedRuntimePlatforms,
             `step.supportedRuntimePlatforms can't be falsy if canBeRunOnRuntimePlatform() is false`

--- a/packages/steps/src/__tests__/BuildFunction-test.ts
+++ b/packages/steps/src/__tests__/BuildFunction-test.ts
@@ -7,7 +7,7 @@ import {
 } from '../BuildStepInput.js';
 import { BuildStepOutput, BuildStepOutputProvider } from '../BuildStepOutput.js';
 
-import { createMockContext } from './utils/context.js';
+import { createGlobalContextMock } from './utils/context.js';
 import { UUID_REGEX } from './utils/uuid.js';
 
 describe(BuildFunction, () => {
@@ -75,14 +75,14 @@ describe(BuildFunction, () => {
 
   describe(BuildFunction.prototype.createBuildStepFromFunctionCall, () => {
     it('returns a BuildStep object', () => {
-      const ctx = createMockContext();
+      const ctx = createGlobalContextMock();
       const func = new BuildFunction({
         id: 'test1',
         name: 'Test function',
         command: 'echo 123',
       });
       const step = func.createBuildStepFromFunctionCall(ctx, {
-        workingDirectory: ctx.workingDirectory,
+        workingDirectory: ctx.defaultWorkingDirectory,
       });
       expect(step).toBeInstanceOf(BuildStep);
       expect(step.id).toMatch(UUID_REGEX);
@@ -90,7 +90,7 @@ describe(BuildFunction, () => {
       expect(step.command).toBe('echo 123');
     });
     it('works with build step function', () => {
-      const ctx = createMockContext();
+      const ctx = createGlobalContextMock();
       const fn: BuildStepFunction = () => {};
       const buildFunction = new BuildFunction({
         id: 'test1',
@@ -98,7 +98,7 @@ describe(BuildFunction, () => {
         fn,
       });
       const step = buildFunction.createBuildStepFromFunctionCall(ctx, {
-        workingDirectory: ctx.workingDirectory,
+        workingDirectory: ctx.defaultWorkingDirectory,
       });
       expect(step).toBeInstanceOf(BuildStep);
       expect(step.id).toMatch(UUID_REGEX);
@@ -106,7 +106,7 @@ describe(BuildFunction, () => {
       expect(step.fn).toBe(fn);
     });
     it('can override id and shell from function definition', () => {
-      const ctx = createMockContext();
+      const ctx = createGlobalContextMock();
       const func = new BuildFunction({
         id: 'test1',
         name: 'Test function',
@@ -116,7 +116,7 @@ describe(BuildFunction, () => {
       const step = func.createBuildStepFromFunctionCall(ctx, {
         id: 'test2',
         shell: '/bin/zsh',
-        workingDirectory: ctx.workingDirectory,
+        workingDirectory: ctx.defaultWorkingDirectory,
       });
       expect(func.id).toBe('test1');
       expect(func.shell).toBe('/bin/bash');
@@ -124,7 +124,7 @@ describe(BuildFunction, () => {
       expect(step.shell).toBe('/bin/zsh');
     });
     it('creates function inputs and outputs', () => {
-      const ctx = createMockContext();
+      const ctx = createGlobalContextMock();
       const inputProviders: BuildStepInputProvider[] = [
         BuildStepInput.createProvider({
           id: 'input1',
@@ -155,7 +155,7 @@ describe(BuildFunction, () => {
           input1: true,
           input2: 'def',
         },
-        workingDirectory: ctx.workingDirectory,
+        workingDirectory: ctx.defaultWorkingDirectory,
       });
       expect(func.inputProviders?.[0]).toBe(inputProviders[0]);
       expect(func.inputProviders?.[1]).toBe(inputProviders[1]);
@@ -168,7 +168,7 @@ describe(BuildFunction, () => {
       expect(step.outputs?.[1].id).toBe('output2');
     });
     it('passes values to build inputs', () => {
-      const ctx = createMockContext();
+      const ctx = createGlobalContextMock();
       const inputProviders: BuildStepInputProvider[] = [
         BuildStepInput.createProvider({ id: 'input1', defaultValue: 'xyz1' }),
         BuildStepInput.createProvider({ id: 'input2', defaultValue: 'xyz2' }),
@@ -191,7 +191,7 @@ describe(BuildFunction, () => {
           input2: 'def',
           input3: false,
         },
-        workingDirectory: ctx.workingDirectory,
+        workingDirectory: ctx.defaultWorkingDirectory,
       });
       expect(step.inputs?.[0].value).toBe('abc');
       expect(step.inputs?.[1].value).toBe('def');

--- a/packages/steps/src/__tests__/BuildStepInput-test.ts
+++ b/packages/steps/src/__tests__/BuildStepInput-test.ts
@@ -6,11 +6,11 @@ import {
   makeBuildStepInputByIdMap,
 } from '../BuildStepInput.js';
 
-import { createMockContext } from './utils/context.js';
+import { createGlobalContextMock } from './utils/context.js';
 
 describe(BuildStepInput, () => {
   test('basic case string', () => {
-    const ctx = createMockContext();
+    const ctx = createGlobalContextMock();
     const i = new BuildStepInput(ctx, {
       id: 'foo',
       stepDisplayName: BuildStep.getDisplayName({ id: 'test1' }),
@@ -20,7 +20,7 @@ describe(BuildStepInput, () => {
   });
 
   test('basic case boolean', () => {
-    const ctx = createMockContext();
+    const ctx = createGlobalContextMock();
     const i = new BuildStepInput(ctx, {
       id: 'foo',
       stepDisplayName: BuildStep.getDisplayName({ id: 'test1' }),
@@ -31,7 +31,7 @@ describe(BuildStepInput, () => {
   });
 
   test('basic case number', () => {
-    const ctx = createMockContext();
+    const ctx = createGlobalContextMock();
     const i = new BuildStepInput(ctx, {
       id: 'foo',
       stepDisplayName: BuildStep.getDisplayName({ id: 'test1' }),
@@ -42,7 +42,7 @@ describe(BuildStepInput, () => {
   });
 
   test('basic case undefined', () => {
-    const ctx = createMockContext();
+    const ctx = createGlobalContextMock();
     const i = new BuildStepInput(ctx, {
       id: 'foo',
       stepDisplayName: BuildStep.getDisplayName({ id: 'test1' }),
@@ -53,7 +53,7 @@ describe(BuildStepInput, () => {
   });
 
   test('default value string', () => {
-    const ctx = createMockContext();
+    const ctx = createGlobalContextMock();
     const i = new BuildStepInput(ctx, {
       id: 'foo',
       stepDisplayName: BuildStep.getDisplayName({ id: 'test1' }),
@@ -63,7 +63,7 @@ describe(BuildStepInput, () => {
   });
 
   test('default value boolean', () => {
-    const ctx = createMockContext();
+    const ctx = createGlobalContextMock();
     const i = new BuildStepInput(ctx, {
       id: 'foo',
       stepDisplayName: BuildStep.getDisplayName({ id: 'test1' }),
@@ -74,7 +74,7 @@ describe(BuildStepInput, () => {
   });
 
   test('default value number', () => {
-    const ctx = createMockContext();
+    const ctx = createGlobalContextMock();
     const i = new BuildStepInput(ctx, {
       id: 'foo',
       stepDisplayName: BuildStep.getDisplayName({ id: 'test1' }),
@@ -85,7 +85,7 @@ describe(BuildStepInput, () => {
   });
 
   test('enforces required policy when reading value', () => {
-    const ctx = createMockContext();
+    const ctx = createGlobalContextMock();
     const i = new BuildStepInput(ctx, {
       id: 'foo',
       stepDisplayName: BuildStep.getDisplayName({ id: 'test1' }),
@@ -102,7 +102,7 @@ describe(BuildStepInput, () => {
   });
 
   test('enforces correct value type when reading a value', () => {
-    const ctx = createMockContext();
+    const ctx = createGlobalContextMock();
     const i = new BuildStepInput(ctx, {
       id: 'foo',
       stepDisplayName: BuildStep.getDisplayName({ id: 'test1' }),
@@ -119,7 +119,7 @@ describe(BuildStepInput, () => {
   });
 
   test('enforces required policy when setting value', () => {
-    const ctx = createMockContext();
+    const ctx = createGlobalContextMock();
     const i = new BuildStepInput(ctx, {
       id: 'foo',
       stepDisplayName: BuildStep.getDisplayName({ id: 'test1' }),
@@ -139,7 +139,7 @@ describe(makeBuildStepInputByIdMap, () => {
   });
 
   it('returns object with inputs indexed by their ids', () => {
-    const ctx = createMockContext();
+    const ctx = createGlobalContextMock();
     const inputs: BuildStepInput[] = [
       new BuildStepInput(ctx, {
         id: 'foo1',

--- a/packages/steps/src/__tests__/BuildStepOutput-test.ts
+++ b/packages/steps/src/__tests__/BuildStepOutput-test.ts
@@ -2,11 +2,11 @@ import { BuildStep } from '../BuildStep.js';
 import { BuildStepOutput, makeBuildStepOutputByIdMap } from '../BuildStepOutput.js';
 import { BuildStepRuntimeError } from '../errors.js';
 
-import { createMockContext } from './utils/context.js';
+import { createGlobalContextMock } from './utils/context.js';
 
 describe(BuildStepOutput, () => {
   test('basic case', () => {
-    const ctx = createMockContext();
+    const ctx = createGlobalContextMock();
     const o = new BuildStepOutput(ctx, {
       id: 'foo',
       stepDisplayName: BuildStep.getDisplayName({ id: 'test1' }),
@@ -16,7 +16,7 @@ describe(BuildStepOutput, () => {
   });
 
   test('enforces required policy when reading value', () => {
-    const ctx = createMockContext();
+    const ctx = createGlobalContextMock();
     const o = new BuildStepOutput(ctx, {
       id: 'foo',
       stepDisplayName: BuildStep.getDisplayName({ id: 'test1' }),
@@ -33,7 +33,7 @@ describe(BuildStepOutput, () => {
   });
 
   test('enforces required policy when setting value', () => {
-    const ctx = createMockContext();
+    const ctx = createGlobalContextMock();
     const i = new BuildStepOutput(ctx, {
       id: 'foo',
       stepDisplayName: BuildStep.getDisplayName({ id: 'test1' }),
@@ -53,7 +53,7 @@ describe(makeBuildStepOutputByIdMap, () => {
   });
 
   it('returns object with outputs indexed by their ids', () => {
-    const ctx = createMockContext();
+    const ctx = createGlobalContextMock();
     const outputs: BuildStepOutput[] = [
       new BuildStepOutput(ctx, {
         id: 'abc1',

--- a/packages/steps/src/__tests__/BuildTemporaryFiles-test.ts
+++ b/packages/steps/src/__tests__/BuildTemporaryFiles-test.ts
@@ -7,16 +7,16 @@ import {
   saveScriptToTemporaryFileAsync,
 } from '../BuildTemporaryFiles.js';
 
-import { createMockContext } from './utils/context.js';
+import { createGlobalContextMock } from './utils/context.js';
 
 describe(saveScriptToTemporaryFileAsync, () => {
   it('saves the script in a directory inside os.tmpdir()', async () => {
-    const ctx = createMockContext();
+    const ctx = createGlobalContextMock();
     const scriptPath = await saveScriptToTemporaryFileAsync(ctx, 'foo', 'echo 123\necho 456');
     expect(scriptPath.startsWith(os.tmpdir())).toBe(true);
   });
   it('saves the script to a temporary file', async () => {
-    const ctx = createMockContext();
+    const ctx = createGlobalContextMock();
     const contents = 'echo 123\necho 456';
     const scriptPath = await saveScriptToTemporaryFileAsync(ctx, 'foo', contents);
     await expect(fs.readFile(scriptPath, 'utf-8')).resolves.toBe(contents);
@@ -25,12 +25,12 @@ describe(saveScriptToTemporaryFileAsync, () => {
 
 describe(createTemporaryOutputsDirectoryAsync, () => {
   it('creates a temporary directory for output values', async () => {
-    const ctx = createMockContext();
+    const ctx = createGlobalContextMock();
     const outputsPath = await createTemporaryOutputsDirectoryAsync(ctx, 'foo');
     await expect(fs.stat(outputsPath)).resolves.not.toThrow();
   });
   it('creates a temporary directory inside os.tmpdir()', async () => {
-    const ctx = createMockContext();
+    const ctx = createGlobalContextMock();
     const outputsPath = await createTemporaryOutputsDirectoryAsync(ctx, 'foo');
     expect(outputsPath.startsWith(os.tmpdir())).toBe(true);
   });
@@ -38,7 +38,7 @@ describe(createTemporaryOutputsDirectoryAsync, () => {
 
 describe(cleanUpStepTemporaryDirectoriesAsync, () => {
   it('removes the step temporary directories', async () => {
-    const ctx = createMockContext();
+    const ctx = createGlobalContextMock();
     const scriptPath = await saveScriptToTemporaryFileAsync(ctx, 'foo', 'echo 123');
     const outputsPath = await createTemporaryOutputsDirectoryAsync(ctx, 'foo');
     await expect(fs.stat(scriptPath)).resolves.toBeTruthy();
@@ -49,7 +49,7 @@ describe(cleanUpStepTemporaryDirectoriesAsync, () => {
   });
 
   it(`doesn't fail if temporary directories don't exist`, async () => {
-    const ctx = createMockContext();
+    const ctx = createGlobalContextMock();
     await expect(cleanUpStepTemporaryDirectoriesAsync(ctx, 'foo')).resolves.not.toThrow();
   });
 });

--- a/packages/steps/src/__tests__/BuildWorkflow-test.ts
+++ b/packages/steps/src/__tests__/BuildWorkflow-test.ts
@@ -4,7 +4,7 @@ import { BuildStep } from '../BuildStep.js';
 import { BuildStepEnv } from '../BuildStepEnv.js';
 import { BuildWorkflow } from '../BuildWorkflow.js';
 
-import { createMockContext } from './utils/context.js';
+import { createGlobalContextMock } from './utils/context.js';
 
 describe(BuildWorkflow, () => {
   describe(BuildWorkflow.prototype.executeAsync, () => {
@@ -20,7 +20,7 @@ describe(BuildWorkflow, () => {
         instance(mockBuildStep3),
       ];
 
-      const ctx = createMockContext();
+      const ctx = createGlobalContextMock();
       const workflow = new BuildWorkflow(ctx, { buildSteps, buildFunctions: {} });
       await workflow.executeAsync();
 
@@ -41,7 +41,7 @@ describe(BuildWorkflow, () => {
         instance(mockBuildStep2),
       ];
 
-      const ctx = createMockContext();
+      const ctx = createGlobalContextMock();
       const workflow = new BuildWorkflow(ctx, { buildSteps, buildFunctions: {} });
       await workflow.executeAsync();
 
@@ -67,7 +67,7 @@ describe(BuildWorkflow, () => {
 
       const mockEnv: BuildStepEnv = { ABC: '123' };
 
-      const ctx = createMockContext();
+      const ctx = createGlobalContextMock();
       const workflow = new BuildWorkflow(ctx, { buildSteps, buildFunctions: {} });
       await workflow.executeAsync(mockEnv);
 

--- a/packages/steps/src/__tests__/BuildWorkflowValidator-test.ts
+++ b/packages/steps/src/__tests__/BuildWorkflowValidator-test.ts
@@ -9,43 +9,38 @@ import { BuildConfigError, BuildWorkflowError } from '../errors.js';
 import { BuildRuntimePlatform } from '../BuildRuntimePlatform.js';
 import { BuildFunction } from '../BuildFunction.js';
 
-import { createMockContext } from './utils/context.js';
+import { createGlobalContextMock } from './utils/context.js';
 import { getError } from './utils/error.js';
 
 describe(BuildWorkflowValidator, () => {
   test('non unique step ids', async () => {
-    const ctx = createMockContext();
+    const ctx = createGlobalContextMock();
     const workflow = new BuildWorkflow(ctx, {
       buildSteps: [
         new BuildStep(ctx, {
           id: 'test1',
           displayName: BuildStep.getDisplayName({ id: 'test1', command: 'echo 123' }),
           command: 'echo 123',
-          workingDirectory: ctx.workingDirectory,
         }),
         new BuildStep(ctx, {
           id: 'test1',
           displayName: BuildStep.getDisplayName({ id: 'test1', command: 'echo 456' }),
           command: 'echo 456',
-          workingDirectory: ctx.workingDirectory,
         }),
         new BuildStep(ctx, {
           id: 'test1',
           displayName: BuildStep.getDisplayName({ id: 'test1', command: 'echo 789' }),
           command: 'echo 789',
-          workingDirectory: ctx.workingDirectory,
         }),
         new BuildStep(ctx, {
           id: 'test3',
           displayName: BuildStep.getDisplayName({ id: 'test3', command: 'echo 123' }),
           command: 'echo 123',
-          workingDirectory: ctx.workingDirectory,
         }),
         new BuildStep(ctx, {
           id: 'test3',
           displayName: BuildStep.getDisplayName({ id: 'test3', command: 'echo 456' }),
           command: 'echo 456',
-          workingDirectory: ctx.workingDirectory,
         }),
       ],
       buildFunctions: {},
@@ -62,7 +57,7 @@ describe(BuildWorkflowValidator, () => {
     expect(error.errors[0].message).toBe('Duplicated step IDs: "test1", "test3"');
   });
   test('input set to a non-allowed value', async () => {
-    const ctx = createMockContext();
+    const ctx = createGlobalContextMock();
 
     const id1 = 'test1';
     const command1 = 'set-output output1 123';
@@ -90,7 +85,6 @@ describe(BuildWorkflowValidator, () => {
             }),
           ],
           command: command1,
-          workingDirectory: ctx.workingDirectory,
         }),
       ],
       buildFunctions: {},
@@ -112,7 +106,7 @@ describe(BuildWorkflowValidator, () => {
     );
   });
   test('required function input without default value and value passed to step', async () => {
-    const ctx = createMockContext();
+    const ctx = createGlobalContextMock();
 
     const func = new BuildFunction({
       id: 'say_hi',
@@ -147,7 +141,7 @@ describe(BuildWorkflowValidator, () => {
     );
   });
   test('invalid input type passed to step', async () => {
-    const ctx = createMockContext();
+    const ctx = createGlobalContextMock();
 
     const func = new BuildFunction({
       id: 'say_hi',
@@ -184,7 +178,7 @@ describe(BuildWorkflowValidator, () => {
     );
   });
   test('output from future step', async () => {
-    const ctx = createMockContext();
+    const ctx = createGlobalContextMock();
 
     const id1 = 'test1';
     const command1 = 'set-output output1 123';
@@ -208,7 +202,6 @@ describe(BuildWorkflowValidator, () => {
             }),
           ],
           command: command1,
-          workingDirectory: ctx.workingDirectory,
         }),
         new BuildStep(ctx, {
           id: id2,
@@ -221,7 +214,6 @@ describe(BuildWorkflowValidator, () => {
             }),
           ],
           command: command2,
-          workingDirectory: ctx.workingDirectory,
         }),
       ],
       buildFunctions: {},
@@ -244,7 +236,7 @@ describe(BuildWorkflowValidator, () => {
     const command = 'echo ${ inputs.input1 }';
     const displayName = BuildStep.getDisplayName({ id, command });
 
-    const ctx = createMockContext();
+    const ctx = createGlobalContextMock();
     const workflow = new BuildWorkflow(ctx, {
       buildSteps: [
         new BuildStep(ctx, {
@@ -259,7 +251,6 @@ describe(BuildWorkflowValidator, () => {
             }),
           ],
           command,
-          workingDirectory: ctx.workingDirectory,
         }),
       ],
       buildFunctions: {},
@@ -290,7 +281,7 @@ describe(BuildWorkflowValidator, () => {
     const command3 = 'echo ${ inputs.input1 }';
     const displayName3 = BuildStep.getDisplayName({ id: id3, command: command3 });
 
-    const ctx = createMockContext();
+    const ctx = createGlobalContextMock();
     const workflow = new BuildWorkflow(ctx, {
       buildSteps: [
         new BuildStep(ctx, {
@@ -304,7 +295,6 @@ describe(BuildWorkflowValidator, () => {
             }),
           ],
           command: command1,
-          workingDirectory: ctx.workingDirectory,
         }),
         new BuildStep(ctx, {
           id: id2,
@@ -318,7 +308,6 @@ describe(BuildWorkflowValidator, () => {
             }),
           ],
           command: command2,
-          workingDirectory: ctx.workingDirectory,
         }),
         new BuildStep(ctx, {
           id: id3,
@@ -332,7 +321,6 @@ describe(BuildWorkflowValidator, () => {
             }),
           ],
           command: command3,
-          workingDirectory: ctx.workingDirectory,
         }),
       ],
       buildFunctions: {},
@@ -363,7 +351,7 @@ describe(BuildWorkflowValidator, () => {
     const command3 = 'echo ${ inputs.input1 }';
     const displayName3 = BuildStep.getDisplayName({ id: id3, command: command3 });
 
-    const ctx = createMockContext();
+    const ctx = createGlobalContextMock();
     const workflow = new BuildWorkflow(ctx, {
       buildSteps: [
         new BuildStep(ctx, {
@@ -377,7 +365,6 @@ describe(BuildWorkflowValidator, () => {
             }),
           ],
           command: command1,
-          workingDirectory: ctx.workingDirectory,
         }),
         new BuildStep(ctx, {
           id: id2,
@@ -391,7 +378,6 @@ describe(BuildWorkflowValidator, () => {
             }),
           ],
           command: command2,
-          workingDirectory: ctx.workingDirectory,
         }),
         new BuildStep(ctx, {
           id: id3,
@@ -405,7 +391,6 @@ describe(BuildWorkflowValidator, () => {
             }),
           ],
           command: 'echo ${ inputs.input2 }',
-          workingDirectory: ctx.workingDirectory,
         }),
       ],
       buildFunctions: {},
@@ -432,14 +417,13 @@ describe(BuildWorkflowValidator, () => {
     const displayName = BuildStep.getDisplayName({ id });
     const fn: BuildStepFunction = () => {};
 
-    const ctx = createMockContext({ runtimePlatform: BuildRuntimePlatform.LINUX });
+    const ctx = createGlobalContextMock({ runtimePlatform: BuildRuntimePlatform.LINUX });
     const workflow = new BuildWorkflow(ctx, {
       buildSteps: [
         new BuildStep(ctx, {
           id,
           displayName,
           fn,
-          workingDirectory: ctx.workingDirectory,
           supportedRuntimePlatforms: [BuildRuntimePlatform.DARWIN],
         }),
       ],

--- a/packages/steps/src/index.ts
+++ b/packages/steps/src/index.ts
@@ -4,6 +4,6 @@ export { BuildFunction } from './BuildFunction.js';
 export { BuildRuntimePlatform } from './BuildRuntimePlatform.js';
 export { BuildStepInput, BuildStepInputValueTypeName } from './BuildStepInput.js';
 export { BuildStepOutput } from './BuildStepOutput.js';
-export { BuildStepContext } from './BuildStepContext.js';
+export { BuildStepGlobalContext, ExternalBuildContextProvider } from './BuildStepContext.js';
 export { BuildWorkflow } from './BuildWorkflow.js';
 export * as errors from './errors.js';


### PR DESCRIPTION
# Why

Refactor context in steps library to make it easier to inject logic from build-tools.

# How

- Separate BuildStepContext into 2 separate types (BuildStepContext - per step context, BuildGlobalContext- context global for entire build)
- Move most BuildStepContext constructor arguments into BuildContextProvider
- Stop using buildId in steps library. As far as I can see that value was only used as random id, so replacing it with just uuidv4() should be fine.
- Provide a way to override env variables in the middle of the build.

# Test Plan

- tests
- cli.sh with some of examples
- run local turtle and running custom build from turtle-v2-example