### PR TITLE
[steps] support overriding env variables

### DIFF
--- a/packages/build-tools/src/builders/custom.ts
+++ b/packages/build-tools/src/builders/custom.ts
@@ -41,7 +41,7 @@ export async function runCustomBuildAsync<T extends Job>(ctx: BuildContext<T>): 
     }
   });
   try {
-    await workflow.executeAsync(ctx.env);
+    await workflow.executeAsync();
   } catch (err: any) {
     err.artifacts = ctx.artifacts;
     throw err;

--- a/packages/steps/bin/set-env
+++ b/packages/steps/bin/set-env
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+NAME=$1
+VALUE=$2
+
+if [[ -z "$__EXPO_STEPS_ENVS_DIR" ]]; then
+  echo "Set __EXPO_STEPS_ENVS_DIR"
+  exit 1
+fi
+
+if [[ -z "$NAME" || -z "$VALUE" ]]; then
+  echo "Usage: set-env NAME VALUE"
+  exit 2
+fi
+
+if [[ "$NAME" == *"="* ]]; then
+  echo "Environment name can't include ="
+  exit 1
+fi
+
+echo -n $VALUE > $__EXPO_STEPS_ENVS_DIR/$NAME

--- a/packages/steps/examples/inputs-and-outputs/config.yml
+++ b/packages/steps/examples/inputs-and-outputs/config.yml
@@ -1,5 +1,5 @@
 build:
-  name: Inputs and outputs
+  name: Inputs, outputs and envs
   steps:
     - run:
         name: Say HI
@@ -24,6 +24,13 @@ build:
           echo "Producing more output"
           set-output required_param "abc 123 456"
     - run:
+        name: Set env variable
+        command: |
+          echo "Setting env variable EXAMPLE_VALUE=123"
+          set-env EXAMPLE_VALUE "123 
+
+          test"
+    - run:
         name: Use output from another step
         inputs:
           foo: ${ steps.id123.foo }
@@ -33,3 +40,4 @@ build:
           echo "foo = \"${ inputs.foo }\""
           echo "bar = \"${ inputs.bar }\""
           echo "baz = \"${ inputs.baz }\""
+          echo "env EXAMPLE_VALUE=$EXAMPLE_VALUE"

--- a/packages/steps/src/BuildStepContext.ts
+++ b/packages/steps/src/BuildStepContext.ts
@@ -51,6 +51,14 @@ export class BuildStepGlobalContext {
     return this.provider.defaultWorkingDirectory;
   }
 
+  public get env(): BuildStepEnv {
+    return this.provider.env;
+  }
+
+  public updateEnv(updatedEnv: BuildStepEnv): void {
+    this.provider.updateEnv(updatedEnv);
+  }
+
   public registerStep(step: BuildStep): void {
     this.stepById[step.id] = step;
   }

--- a/packages/steps/src/BuildTemporaryFiles.ts
+++ b/packages/steps/src/BuildTemporaryFiles.ts
@@ -26,6 +26,15 @@ export async function createTemporaryOutputsDirectoryAsync(
   return directory;
 }
 
+export async function createTemporaryEnvsDirectoryAsync(
+  ctx: BuildStepGlobalContext,
+  stepId: string
+): Promise<string> {
+  const directory = getTemporaryEnvsDirPath(ctx, stepId);
+  await fs.mkdir(directory, { recursive: true });
+  return directory;
+}
+
 export async function cleanUpStepTemporaryDirectoriesAsync(
   ctx: BuildStepGlobalContext,
   stepId: string
@@ -37,6 +46,7 @@ export async function cleanUpStepTemporaryDirectoriesAsync(
   await fs.rm(stepTemporaryDirectory, { recursive: true, force: true });
   ctx.baseLogger.debug({ stepTemporaryDirectory }, 'Removed step temporary directory');
 }
+
 function getTemporaryStepDirPath(ctx: BuildStepGlobalContext, stepId: string): string {
   return path.join(ctx.stepsInternalBuildDirectory, 'steps', stepId);
 }
@@ -47,4 +57,8 @@ function getTemporaryScriptsDirPath(ctx: BuildStepGlobalContext, stepId: string)
 
 function getTemporaryOutputsDirPath(ctx: BuildStepGlobalContext, stepId: string): string {
   return path.join(getTemporaryStepDirPath(ctx, stepId), 'outputs');
+}
+
+function getTemporaryEnvsDirPath(ctx: BuildStepGlobalContext, stepId: string): string {
+  return path.join(getTemporaryStepDirPath(ctx, stepId), 'envs');
 }

--- a/packages/steps/src/BuildWorkflow.ts
+++ b/packages/steps/src/BuildWorkflow.ts
@@ -1,6 +1,5 @@
 import { BuildFunctionById } from './BuildFunction.js';
 import { BuildStep } from './BuildStep.js';
-import { BuildStepEnv } from './BuildStepEnv.js';
 import { BuildStepGlobalContext } from './BuildStepContext.js';
 
 export class BuildWorkflow {
@@ -16,9 +15,9 @@ export class BuildWorkflow {
     this.buildFunctions = buildFunctions;
   }
 
-  public async executeAsync(env: BuildStepEnv = process.env): Promise<void> {
+  public async executeAsync(): Promise<void> {
     for (const step of this.buildSteps) {
-      await step.executeAsync(env);
+      await step.executeAsync();
     }
   }
 }

--- a/packages/steps/src/__tests__/BuildWorkflow-test.ts
+++ b/packages/steps/src/__tests__/BuildWorkflow-test.ts
@@ -1,7 +1,6 @@
-import { anything, instance, mock, verify } from 'ts-mockito';
+import { instance, mock, verify } from 'ts-mockito';
 
 import { BuildStep } from '../BuildStep.js';
-import { BuildStepEnv } from '../BuildStepEnv.js';
 import { BuildWorkflow } from '../BuildWorkflow.js';
 
 import { createGlobalContextMock } from './utils/context.js';
@@ -24,10 +23,10 @@ describe(BuildWorkflow, () => {
       const workflow = new BuildWorkflow(ctx, { buildSteps, buildFunctions: {} });
       await workflow.executeAsync();
 
-      verify(mockBuildStep1.executeAsync(anything())).once();
-      verify(mockBuildStep2.executeAsync(anything())).once();
-      verify(mockBuildStep3.executeAsync(anything())).once();
-      verify(mockBuildStep4.executeAsync(anything())).never();
+      verify(mockBuildStep1.executeAsync()).once();
+      verify(mockBuildStep2.executeAsync()).once();
+      verify(mockBuildStep3.executeAsync()).once();
+      verify(mockBuildStep4.executeAsync()).never();
     });
 
     it('executes steps in correct order', async () => {
@@ -45,35 +44,9 @@ describe(BuildWorkflow, () => {
       const workflow = new BuildWorkflow(ctx, { buildSteps, buildFunctions: {} });
       await workflow.executeAsync();
 
-      verify(mockBuildStep1.executeAsync(anything())).calledBefore(
-        mockBuildStep3.executeAsync(anything())
-      );
-      verify(mockBuildStep3.executeAsync(anything())).calledBefore(
-        mockBuildStep2.executeAsync(anything())
-      );
-      verify(mockBuildStep2.executeAsync(anything())).once();
-    });
-
-    it('executes steps with environment variables passed to the workflow', async () => {
-      const mockBuildStep1 = mock<BuildStep>();
-      const mockBuildStep2 = mock<BuildStep>();
-      const mockBuildStep3 = mock<BuildStep>();
-
-      const buildSteps: BuildStep[] = [
-        instance(mockBuildStep1),
-        instance(mockBuildStep3),
-        instance(mockBuildStep2),
-      ];
-
-      const mockEnv: BuildStepEnv = { ABC: '123' };
-
-      const ctx = createGlobalContextMock();
-      const workflow = new BuildWorkflow(ctx, { buildSteps, buildFunctions: {} });
-      await workflow.executeAsync(mockEnv);
-
-      verify(mockBuildStep1.executeAsync(mockEnv));
-      verify(mockBuildStep2.executeAsync(mockEnv));
-      verify(mockBuildStep3.executeAsync(mockEnv));
+      verify(mockBuildStep1.executeAsync()).calledBefore(mockBuildStep3.executeAsync());
+      verify(mockBuildStep3.executeAsync()).calledBefore(mockBuildStep2.executeAsync());
+      verify(mockBuildStep2.executeAsync()).once();
     });
   });
 });


### PR DESCRIPTION
# Why

Add support for overriding envs during the build.

# How

Add set-env executable that will write envs to internal steps directory, similar to how outputs work.
At the end of the build step, all the values are read from directory and added to global context as envs.


# Test Plan

test + run local turtle
