### PR TITLE
[build-tools] create example target custom builds configs

### DIFF
--- a/packages/build-tools/src/steps/configs/android/base.yml
+++ b/packages/build-tools/src/steps/configs/android/base.yml
@@ -1,3 +1,4 @@
+# this is the config the users will see when they eject
 build:
   name: base Android build implemented using automagical eas functions
   steps:

--- a/packages/build-tools/src/steps/configs/android/base.yml
+++ b/packages/build-tools/src/steps/configs/android/base.yml
@@ -1,0 +1,24 @@
+build:
+  name: base Android build implemented using automagical eas functions
+  steps:
+    - eas/checkout
+
+    # auto selects package manager
+    # installs node_modules
+    - eas/install_node_modules
+
+    # runs expo prebuild
+    - eas/prebuild
+        # inputs:
+        #   clear: true
+        #   skip_dependency_update: ['react', 'react-native']
+
+    # configures credentials
+    # injects credentials into gradle
+    # injects version code and name into gradle
+    # runs gradle
+    - eas/build_react_native_app
+
+    # auto finds and uploads build artifacts
+    # auto finds and uploads application archives
+    - eas/find_and_upload_build_artifacts

--- a/packages/build-tools/src/steps/configs/android/base.yml
+++ b/packages/build-tools/src/steps/configs/android/base.yml
@@ -13,6 +13,8 @@ build:
         #   clear: true
         #   skip_dependency_update: ['react', 'react-native']
 
+    - eas/configure_expo_updates_if_installed
+
     # configures credentials
     # injects credentials into gradle
     # injects version code and name into gradle

--- a/packages/build-tools/src/steps/configs/android/customized.yml
+++ b/packages/build-tools/src/steps/configs/android/customized.yml
@@ -1,0 +1,39 @@
+build:
+  name: highly customized Android builds example
+  steps:
+    - eas/checkout
+
+    - run:
+        name: Install dependencies
+        command: yarn install
+
+    - run:
+        name: Run expo prebuild
+        command: npx expo prebuild --non-interactive --no-install --platform android
+
+    - utils/inject_android_credentials:
+        inputs:
+          credentials: ${ globalCtx.secrets.buildCredentials } # can pass other object or specify it inline
+
+    - utils/inject_version_code_and_version_name:
+        inputs:
+          version_code: ${ globalCtx.job.secrets.version.versionCode } # can pass other value or specify it inline
+          version_name: ${ globalCtx.job.secrets.version.versionName } # can pass other value or specify it inline
+
+    - run:
+        name: Build Android app
+        working_directory: ./android
+        command: gradle :app:bundleRelease
+
+    # important: eas/upload_artifact for app archive can be called exactly once with current implementation
+    - eas/upload_artifact:
+        name: Upload application archive
+        inputs:
+          path: fixtures/app.aab
+
+    # important: eas/upload_artifact for build-artifact can be called exactly once with current implementation
+    - eas/upload_artifact:
+        name: Upload build artifact
+        inputs:
+          type: build-artifact
+          path: assets/icon.png

--- a/packages/build-tools/src/steps/configs/android/customized.yml
+++ b/packages/build-tools/src/steps/configs/android/customized.yml
@@ -14,12 +14,12 @@ build:
 
     - utils/inject_android_credentials:
         inputs:
-          credentials: ${ globalCtx.secrets.buildCredentials } # can pass other object or specify it inline
+          credentials: ${ eas.secrets.buildCredentials } # can pass other object or specify it inline
 
     - utils/configure_android_versions:
         inputs:
-          version_code: ${ globalCtx.job.secrets.version.versionCode } # can pass other value or specify it inline
-          version: ${ globalCtx.job.secrets.version.versionName } # can pass other value or specify it inline
+          version_code: ${ eas.job.secrets.version.versionCode } # can pass other value or specify it inline
+          version: ${ eas.job.secrets.version.versionName } # can pass other value or specify it inline
 
     - run:
         name: Build Android app

--- a/packages/build-tools/src/steps/configs/android/customized.yml
+++ b/packages/build-tools/src/steps/configs/android/customized.yml
@@ -15,10 +15,10 @@ build:
         inputs:
           credentials: ${ globalCtx.secrets.buildCredentials } # can pass other object or specify it inline
 
-    - utils/inject_version_code_and_version_name:
+    - utils/configure_android_versions:
         inputs:
           version_code: ${ globalCtx.job.secrets.version.versionCode } # can pass other value or specify it inline
-          version_name: ${ globalCtx.job.secrets.version.versionName } # can pass other value or specify it inline
+          version: ${ globalCtx.job.secrets.version.versionName } # can pass other value or specify it inline
 
     - run:
         name: Build Android app

--- a/packages/build-tools/src/steps/configs/android/customized.yml
+++ b/packages/build-tools/src/steps/configs/android/customized.yml
@@ -1,3 +1,4 @@
+# this is the example of customized config for running Android builds the users can build using custom builds
 build:
   name: highly customized Android builds example
   steps:

--- a/packages/build-tools/src/steps/configs/ios/base.yml
+++ b/packages/build-tools/src/steps/configs/ios/base.yml
@@ -19,6 +19,8 @@ build:
         working_directory: ./ios
         command: pod install
 
+    - eas/configure_expo_updates_if_installed
+
     # configures credentials
     # prepares Xcode project
     # configures build number and app version

--- a/packages/build-tools/src/steps/configs/ios/base.yml
+++ b/packages/build-tools/src/steps/configs/ios/base.yml
@@ -1,3 +1,4 @@
+# this is the config the users will see when they eject
 build:
   name: base iOS build implemented using automagical eas functions
   steps:

--- a/packages/build-tools/src/steps/configs/ios/base.yml
+++ b/packages/build-tools/src/steps/configs/ios/base.yml
@@ -1,0 +1,32 @@
+build:
+  name: base iOS build implemented using automagical eas functions
+  steps:
+    - eas/checkout
+
+    # auto selects package manager
+    # installs node_modules
+    - eas/install_node_modules
+
+    # runs expo prebuild
+    # auto resolves Apple team id if applicable
+    - eas/prebuild
+        # inputs:
+        #   clear: true
+        #   skip_dependency_update: ['react', 'react-native']
+
+    - run:
+        name: Install pods
+        working_directory: ./ios
+        command: pod install
+
+    # configures credentials
+    # prepares Xcode project
+    # configures build number and app version
+    # creates gymfile
+    # runs fastlane
+    - eas/build_react_native_app
+
+    # auto finds and uploads build artifacts
+    # auto finds and uploads application archives
+    # auto finds and uploads Xcode logs
+    - eas/find_and_upload_build_artifacts

--- a/packages/build-tools/src/steps/configs/ios/customized.yml
+++ b/packages/build-tools/src/steps/configs/ios/customized.yml
@@ -1,0 +1,82 @@
+build:
+  name: highly customized iOS builds example
+  steps:
+    - eas/checkout
+
+    - run:
+        name: Install dependencies
+        command: yarn install
+
+    # reads Apple team id from job credentials
+    - eas/read_team_id
+
+    - run:
+        env:
+          APPLE_TEAM_ID: ${ eas/read_team_id.apple_team_id } # or other custom value
+        name: Run expo prebuild
+        command: npx expo prebuild --non-interactive --no-install --platform ios
+
+    - run:
+        name: Install pods
+        working_directory: ./ios
+        command: pod install
+
+    - utils/configure_ios_credentials:
+        inputs:
+          credentials: ${ globalCtx.job.secrets.buildCredentials } # can pass other object or specify it inline
+
+    - utils/set_ios_build_number_and_app_version:
+        inputs:
+          build_number: ${ globalCtx.job.secrets.version.buildNumber } # can pass other value or specify it inline
+          app_version: ${ globalCtx.job.secrets.version.appVersion } # can pass other value or specify it inline
+
+    - utils/generate_gymfile_from_template:
+        inputs:
+          keychain_path: ${ utils/generate_ios_credentials_and_prepare_xcode_project.keychain_path } # or other custom value
+          provisioning_profiles: ${ utils/generate_ios_credentials_and_prepare_xcode_project.provisioning_profiles } # or other custom value
+          extra:
+            sample: sample_value
+          # can pass any template
+          template: |
+            suppress_xcode_output(true)
+            clean(<%- CLEAN %>)
+
+            scheme("<%- SCHEME %>")
+            <% if (SCHEME_BUILD_CONFIGURATION) { %>
+            configuration("<%- SCHEME_BUILD_CONFIGURATION %>")
+            <% } %>
+
+            export_options({
+              method: "<%- EXPORT_METHOD %>",
+              provisioningProfiles: {<% _.forEach(PROFILES, function(profile) { %>
+                "<%- profile.BUNDLE_ID %>" => "<%- profile.UUID %>",<% }); %>
+              }<% if (ICLOUD_CONTAINER_ENVIRONMENT) { %>,
+              iCloudContainerEnvironment: "<%- ICLOUD_CONTAINER_ENVIRONMENT %>"
+            <% } %>
+            })
+
+            export_xcargs "OTHER_CODE_SIGN_FLAGS=\"--keychain <%- KEYCHAIN_PATH %>\""
+
+            disable_xcpretty(true)
+            buildlog_path("<%- LOGS_DIRECTORY %>")
+
+            output_directory("<%- OUTPUT_DIRECTORY %>")
+            some_other_value("<%- EXTRA_SAMPLE %>")
+
+    - run:
+        name: Build iOS app
+        working_directory: ./ios
+        command: fastlane gym
+
+    # important: eas/upload_artifact for app archive can be called exactly once with current implementation
+    - eas/upload_artifact:
+        name: Upload application archive
+        inputs:
+          path: fixtures/app.ipa
+
+    # important: eas/upload_artifact for build-artifact can be called exactly once with current implementation
+    - eas/upload_artifact:
+        name: Upload build artifact
+        inputs:
+          type: build-artifact
+          path: assets/icon.png

--- a/packages/build-tools/src/steps/configs/ios/customized.yml
+++ b/packages/build-tools/src/steps/configs/ios/customized.yml
@@ -11,7 +11,7 @@ build:
     # reads Apple team id from job credentials
     - utils/resolve_apple_team_id_from_credentials:
         inputs:
-          credentials: ${ globalCtx.job.secrets.buildCredentials } # can pass other object or specify it inline
+          credentials: ${ eas.job.secrets.buildCredentials } # can pass other object or specify it inline
 
 
     - run:
@@ -27,12 +27,12 @@ build:
 
     - utils/configure_ios_credentials:
         inputs:
-          credentials: ${ globalCtx.job.secrets.buildCredentials } # can pass other object or specify it inline
+          credentials: ${ eas.job.secrets.buildCredentials } # can pass other object or specify it inline
 
     - utils/configure_ios_versions:
         inputs:
-          build_number: ${ globalCtx.job.secrets.version.build_number } # can pass other value or specify it inline
-          version: ${ globalCtx.job.secrets.version.appVersion } # can pass other value or specify it inline
+          build_number: ${ eas.job.secrets.version.build_number } # can pass other value or specify it inline
+          version: ${ eas.job.secrets.version.appVersion } # can pass other value or specify it inline
 
     - utils/generate_gymfile_from_template:
         inputs:

--- a/packages/build-tools/src/steps/configs/ios/customized.yml
+++ b/packages/build-tools/src/steps/configs/ios/customized.yml
@@ -1,3 +1,4 @@
+# this is the example of customized config for running iOS builds the users can build using custom builds
 build:
   name: highly customized iOS builds example
   steps:

--- a/packages/build-tools/src/steps/configs/ios/customized.yml
+++ b/packages/build-tools/src/steps/configs/ios/customized.yml
@@ -8,11 +8,14 @@ build:
         command: yarn install
 
     # reads Apple team id from job credentials
-    - eas/read_team_id
+    - utils/resolve_apple_team_id_from_credentials:
+        inputs:
+          credentials: ${ globalCtx.job.secrets.buildCredentials } # can pass other object or specify it inline
+
 
     - run:
         env:
-          APPLE_TEAM_ID: ${ eas/read_team_id.apple_team_id } # or other custom value
+          APPLE_TEAM_ID: ${ eas/read_team_id.apple_team_id } # or skip previous step and provide the value directlly
         name: Run expo prebuild
         command: npx expo prebuild --non-interactive --no-install --platform ios
 

--- a/packages/build-tools/src/steps/configs/ios/customized.yml
+++ b/packages/build-tools/src/steps/configs/ios/customized.yml
@@ -25,10 +25,10 @@ build:
         inputs:
           credentials: ${ globalCtx.job.secrets.buildCredentials } # can pass other object or specify it inline
 
-    - utils/set_ios_build_number_and_app_version:
+    - utils/configure_ios_versions:
         inputs:
-          build_number: ${ globalCtx.job.secrets.version.buildNumber } # can pass other value or specify it inline
-          app_version: ${ globalCtx.job.secrets.version.appVersion } # can pass other value or specify it inline
+          build_number: ${ globalCtx.job.secrets.version.build_number } # can pass other value or specify it inline
+          version: ${ globalCtx.job.secrets.version.appVersion } # can pass other value or specify it inline
 
     - utils/generate_gymfile_from_template:
         inputs:


### PR DESCRIPTION
# Why

Create example target custom build configs for iOS and Android, so it will be easier to visualize what is my vision and conception for the future of custom builds.

# How

Create example target custom build configs for iOS and Android
