### PR TITLE
[bulid-tools] move some functions to stop using old context

### DIFF
--- a/packages/build-tools/src/builders/custom.ts
+++ b/packages/build-tools/src/builders/custom.ts
@@ -22,7 +22,7 @@ export async function runCustomBuildAsync<T extends Job>(ctx: BuildContext<T>): 
   );
 
   const globalContext = new BuildStepGlobalContext(customBuildCtx, false);
-  const easFunctions = getEasFunctions(ctx);
+  const easFunctions = getEasFunctions(customBuildCtx, ctx);
   const parser = new BuildConfigParser(globalContext, {
     configPath,
     externalFunctions: easFunctions,

--- a/packages/build-tools/src/common/prebuild.ts
+++ b/packages/build-tools/src/common/prebuild.ts
@@ -11,8 +11,6 @@ import { installDependenciesAsync, resolvePackagerDir } from './installDependenc
 
 export interface PrebuildOptions {
   extraEnvs?: Record<string, string>;
-  clean?: boolean;
-  skipDependencyUpdate?: string;
 }
 
 export async function prebuildAsync<TJob extends Job>(
@@ -33,28 +31,19 @@ export async function prebuildAsync<TJob extends Job>(
     },
   };
 
-  const prebuildCommandArgs = getPrebuildCommandArgs(ctx, { options });
+  const prebuildCommandArgs = getPrebuildCommandArgs(ctx);
   await runExpoCliCommand(ctx, prebuildCommandArgs, spawnOptions, {
     npmVersionAtLeast7: await isAtLeastNpm7Async(),
   });
   await installDependenciesAsync(ctx, { logger, workingDir: resolvePackagerDir(ctx) });
 }
 
-function getPrebuildCommandArgs<TJob extends Job>(
-  ctx: BuildContext<TJob>,
-  { options }: { options?: PrebuildOptions }
-): string[] {
+function getPrebuildCommandArgs<TJob extends Job>(ctx: BuildContext<TJob>): string[] {
   let prebuildCommand =
     ctx.job.experimental?.prebuildCommand ??
     `prebuild --non-interactive --no-install --platform ${ctx.job.platform}`;
   if (!prebuildCommand.match(/(?:--platform| -p)/)) {
     prebuildCommand = `${prebuildCommand} --platform ${ctx.job.platform}`;
-  }
-  if (options?.skipDependencyUpdate) {
-    prebuildCommand = `${prebuildCommand} --skip-dependency-update ${options.skipDependencyUpdate}`;
-  }
-  if (options?.clean) {
-    prebuildCommand = `${prebuildCommand} --clean`;
   }
   const npxCommandPrefix = 'npx ';
   const expoCommandPrefix = 'expo ';

--- a/packages/build-tools/src/steps/easFunctions.ts
+++ b/packages/build-tools/src/steps/easFunctions.ts
@@ -2,6 +2,7 @@ import { Job } from '@expo/eas-build-job';
 import { BuildFunction } from '@expo/steps';
 
 import { BuildContext } from '../context';
+import { CustomBuildContext } from '../customBuildContext';
 
 import { createUploadArtifactBuildFunction } from './functions/utils/uploadArtifact';
 import { createCheckoutBuildFunction } from './functions/eas/checkout';
@@ -12,15 +13,18 @@ import { createPrebuildBuildFunction } from './functions/eas/prebuild';
 import { createBuildReactNativeAppBuildFunction } from './functions/eas/buildReactNativeApp';
 import { createFindAndUploadBuildArtifactsBuildFunction } from './functions/eas/findAndUploadBuildArtifacts';
 
-export function getEasFunctions<T extends Job>(ctx: BuildContext<T>): BuildFunction[] {
+export function getEasFunctions(
+  ctx: CustomBuildContext,
+  oldCtx: BuildContext<Job> // TODO: remove
+): BuildFunction[] {
   return [
     createCheckoutBuildFunction(),
     createUploadArtifactBuildFunction(ctx),
     createSetUpNpmrcBuildFunction(ctx),
     createInstallNodeModulesBuildFunction(ctx),
     createPrebuildBuildFunction(ctx),
-    createRunGradleBuildFunction(ctx),
-    createBuildReactNativeAppBuildFunction(ctx),
-    createFindAndUploadBuildArtifactsBuildFunction(ctx),
+    createRunGradleBuildFunction(oldCtx),
+    createBuildReactNativeAppBuildFunction(oldCtx),
+    createFindAndUploadBuildArtifactsBuildFunction(oldCtx),
   ];
 }

--- a/packages/build-tools/src/steps/functions/eas/installNodeModules.ts
+++ b/packages/build-tools/src/steps/functions/eas/installNodeModules.ts
@@ -1,21 +1,46 @@
-import { Job } from '@expo/eas-build-job';
 import { BuildFunction } from '@expo/steps';
+import { BuildStepContext } from '@expo/steps/dist_esm/BuildStepContext';
+import spawn from '@expo/turtle-spawn';
 
-import { BuildContext } from '../../../context';
-import { installDependenciesAsync } from '../../../common/installDependencies';
+import { CustomBuildContext } from '../../../customBuildContext';
+import {
+  findPackagerRootDir,
+  PackageManager,
+  resolvePackageManager,
+} from '../../../utils/packageManager';
+import { isUsingYarn2 } from '../../../utils/project';
 
-export function createInstallNodeModulesBuildFunction<T extends Job>(
-  ctx: BuildContext<T>
-): BuildFunction {
+export function createInstallNodeModulesBuildFunction(ctx: CustomBuildContext): BuildFunction {
   return new BuildFunction({
     namespace: 'eas',
     id: 'install_node_modules',
     name: 'Install node modules',
-    fn: async (stepsCtx) => {
-      await installDependenciesAsync(ctx, {
-        logger: stepsCtx.logger,
-        workingDir: stepsCtx.workingDirectory,
-      });
+    fn: async (stepCtx) => {
+      await installNodeModules(stepCtx, ctx);
     },
+  });
+}
+
+export async function installNodeModules(
+  stepCtx: BuildStepContext,
+  ctx: CustomBuildContext
+): Promise<void> {
+  const { logger } = stepCtx;
+  const packageManager = resolvePackageManager(ctx.projectTargetDirectory);
+  const packagerRunDir = findPackagerRootDir(stepCtx.workingDirectory);
+  let args = ['install'];
+  if (packageManager === PackageManager.PNPM) {
+    args = ['install', '--no-frozen-lockfile'];
+  } else if (packageManager === PackageManager.YARN) {
+    const isYarn2 = await isUsingYarn2(stepCtx.workingDirectory);
+    if (isYarn2) {
+      args = ['install', '--no-immutable'];
+    }
+  }
+  logger.info(`Running "${packageManager} ${args.join(' ')}" in ${packagerRunDir} directory`);
+  await spawn(packageManager, args, {
+    cwd: packagerRunDir,
+    logger: stepCtx.logger,
+    env: ctx.env,
   });
 }

--- a/packages/build-tools/src/steps/functions/eas/setUpNpmrc.ts
+++ b/packages/build-tools/src/steps/functions/eas/setUpNpmrc.ts
@@ -1,16 +1,39 @@
-import { Job } from '@expo/eas-build-job';
+import path from 'path';
+
+import fs from 'fs-extra';
 import { BuildFunction } from '@expo/steps';
 
-import { BuildContext } from '../../../context';
-import { setUpNpmrcAsync } from '../../../utils/npmrc';
+import { CustomBuildContext } from '../../../customBuildContext';
+import { findPackagerRootDir } from '../../../utils/packageManager';
 
-export function createSetUpNpmrcBuildFunction<T extends Job>(ctx: BuildContext<T>): BuildFunction {
+const NPMRC_TEMPLATE_PATH = path.join(__dirname, '../../templates/npmrc');
+
+export function createSetUpNpmrcBuildFunction(ctx: CustomBuildContext): BuildFunction {
   return new BuildFunction({
     namespace: 'eas',
     id: 'use_npm_token',
     name: 'Use NPM_TOKEN',
-    fn: async (stepsCtx) => {
-      await setUpNpmrcAsync(ctx, stepsCtx.logger);
+    fn: async (stepCtx) => {
+      const { logger } = stepCtx;
+      if (ctx.env.NPM_TOKEN) {
+        logger.info('We detected that you set the NPM_TOKEN environment variable');
+        const projectNpmrcPath = path.join(ctx.projectTargetDirectory, '.npmrc');
+        if (await fs.pathExists(projectNpmrcPath)) {
+          logger.info('.npmrc already exists in your project directory, skipping generation');
+        } else {
+          const npmrcContents = await fs.readFile(NPMRC_TEMPLATE_PATH, 'utf8');
+          logger.info('Creating .npmrc in your project directory with the following contents:');
+          logger.info(npmrcContents);
+          await fs.copy(NPMRC_TEMPLATE_PATH, projectNpmrcPath);
+        }
+      } else {
+        const projectNpmrcPath = path.join(findPackagerRootDir(stepCtx.workingDirectory), '.npmrc');
+        if (await fs.pathExists(projectNpmrcPath)) {
+          logger.info(
+            `.npmrc found at ${path.relative(ctx.projectTargetDirectory, projectNpmrcPath)}`
+          );
+        }
+      }
     },
   });
 }

--- a/packages/build-tools/src/steps/functions/utils/uploadArtifact.ts
+++ b/packages/build-tools/src/steps/functions/utils/uploadArtifact.ts
@@ -1,19 +1,17 @@
 import path from 'path';
 
-import { Job } from '@expo/eas-build-job';
 import { BuildFunction, BuildStepInput } from '@expo/steps';
 import nullthrows from 'nullthrows';
 
-import { ArtifactType, BuildContext } from '../../../context';
+import { ArtifactType } from '../../../context';
+import { CustomBuildContext } from '../../../customBuildContext';
 
 enum BuildArtifactType {
   APPLICATION_ARCHIVE = 'application-archive',
   BUILD_ARTIFACT = 'build-artifact',
 }
 
-export function createUploadArtifactBuildFunction<T extends Job>(
-  ctx: BuildContext<T>
-): BuildFunction {
+export function createUploadArtifactBuildFunction(ctx: CustomBuildContext): BuildFunction {
   return new BuildFunction({
     namespace: 'utils',
     id: 'upload_artifact',
@@ -34,7 +32,7 @@ export function createUploadArtifactBuildFunction<T extends Job>(
         stepsCtx.workingDirectory,
         nullthrows(inputs.path.value).toString()
       );
-      await ctx.uploadArtifacts(artifactType, [filePath], stepsCtx.logger);
+      await ctx.runtimeApi.uploadArtifacts(artifactType, [filePath], stepsCtx.logger);
     },
   });
 }


### PR DESCRIPTION
# Why

Move some steps to use new conext

# How

- setup .npmc (just copy paste)
- install dependencies (mostlly copy paste + resolve package manager early and extract install function so it can be used in prebuild)
- prebuild 
  - drop support for global cli
  - extract the case of customPrebuild command to separate function so it can be removed easily in the future.
  - fix type of skipDependencyUpdate arg
  
- Tried to avoid touching code related to non custom builds
  - removed options skipDependencyUpdate and clean (it should not be used in regular builds and custom ones have separate implementation now)

# Test Plan

Run some examples, but I didn't test them to carefully. (A lot of changes is landing right now, so it might be better to prioritize speed, so we do not block each other and test it e2e when publishing packages.)