### PR TITLE
[ENG-9019][steps] add support for step envs

### DIFF
--- a/packages/build-tools/src/steps/functions/eas/installNodeModules.ts
+++ b/packages/build-tools/src/steps/functions/eas/installNodeModules.ts
@@ -1,4 +1,4 @@
-import { BuildFunction } from '@expo/steps';
+import { BuildFunction, BuildStepEnv } from '@expo/steps';
 import { BuildStepContext } from '@expo/steps/dist_esm/BuildStepContext';
 import spawn from '@expo/turtle-spawn';
 
@@ -15,15 +15,16 @@ export function createInstallNodeModulesBuildFunction(ctx: CustomBuildContext): 
     namespace: 'eas',
     id: 'install_node_modules',
     name: 'Install node modules',
-    fn: async (stepCtx) => {
-      await installNodeModules(stepCtx, ctx);
+    fn: async (stepCtx, { env }) => {
+      await installNodeModules(stepCtx, ctx, env);
     },
   });
 }
 
 export async function installNodeModules(
   stepCtx: BuildStepContext,
-  ctx: CustomBuildContext
+  ctx: CustomBuildContext,
+  env: BuildStepEnv
 ): Promise<void> {
   const { logger } = stepCtx;
   const packageManager = resolvePackageManager(ctx.projectTargetDirectory);
@@ -41,6 +42,6 @@ export async function installNodeModules(
   await spawn(packageManager, args, {
     cwd: packagerRunDir,
     logger: stepCtx.logger,
-    env: ctx.env,
+    env,
   });
 }

--- a/packages/build-tools/src/steps/functions/eas/prebuild.ts
+++ b/packages/build-tools/src/steps/functions/eas/prebuild.ts
@@ -29,18 +29,10 @@ export function createPrebuildBuildFunction(ctx: CustomBuildContext): BuildFunct
         defaultValue: false,
         allowedValueTypeName: BuildStepInputValueTypeName.BOOLEAN,
       }),
-      BuildStepInput.createProvider({
-        id: 'apple_team_id',
-        required: false,
-      }),
     ],
-    fn: async (stepCtx, { inputs }) => {
+    fn: async (stepCtx, { inputs, env }) => {
       const { logger } = stepCtx;
       // TODO: make sure we can pass Apple Team ID to prebuild when adding credentials for custom builds
-      const extraEnvs: Record<string, string> = inputs.apple_team_id.value
-        ? { APPLE_TEAM_ID: inputs.apple_team_id.value.toString() }
-        : {};
-
       const packageManager = resolvePackageManager(ctx.projectTargetDirectory);
       const prebuildCommandArgs = getPrebuildCommandArgs(ctx.job, {
         clean: inputs.clean.value as boolean,
@@ -52,8 +44,7 @@ export function createPrebuildBuildFunction(ctx: CustomBuildContext): BuildFunct
         logger,
         env: {
           EXPO_IMAGE_UTILS_NO_SHARP: '1',
-          ...extraEnvs,
-          ...ctx.env,
+          ...env,
         },
       };
       if (packageManager === PackageManager.NPM) {
@@ -65,7 +56,7 @@ export function createPrebuildBuildFunction(ctx: CustomBuildContext): BuildFunct
       } else {
         throw new Error(`Unsupported package manager: ${packageManager}`);
       }
-      await installNodeModules(stepCtx, ctx);
+      await installNodeModules(stepCtx, ctx, env);
     },
   });
 }

--- a/packages/build-tools/src/steps/functions/eas/setUpNpmrc.ts
+++ b/packages/build-tools/src/steps/functions/eas/setUpNpmrc.ts
@@ -13,9 +13,9 @@ export function createSetUpNpmrcBuildFunction(ctx: CustomBuildContext): BuildFun
     namespace: 'eas',
     id: 'use_npm_token',
     name: 'Use NPM_TOKEN',
-    fn: async (stepCtx) => {
+    fn: async (stepCtx, { env }) => {
       const { logger } = stepCtx;
-      if (ctx.env.NPM_TOKEN) {
+      if (env.NPM_TOKEN) {
         logger.info('We detected that you set the NPM_TOKEN environment variable');
         const projectNpmrcPath = path.join(ctx.projectTargetDirectory, '.npmrc');
         if (await fs.pathExists(projectNpmrcPath)) {

--- a/packages/steps/src/BuildConfig.ts
+++ b/packages/steps/src/BuildConfig.ts
@@ -9,6 +9,7 @@ import { BuildConfigError, BuildWorkflowError } from './errors.js';
 import { BuildRuntimePlatform } from './BuildRuntimePlatform.js';
 import { BuildFunction } from './BuildFunction.js';
 import { BuildStepInputValueType, BuildStepInputValueTypeName } from './BuildStepInput.js';
+import { BuildStepEnv } from './BuildStepEnv.js';
 
 export type BuildFunctions = Record<string, BuildFunctionConfig>;
 
@@ -48,7 +49,7 @@ export type BuildFunctionCallConfig = {
   name?: string;
   workingDirectory?: string;
   shell?: string;
-  env?: Record<string, string>;
+  env?: BuildStepEnv;
 };
 
 export type BuildStepInputs = Record<string, BuildStepInputValueType>;
@@ -148,7 +149,7 @@ const BuildFunctionCallSchema = Joi.object({
   name: Joi.string(),
   workingDirectory: Joi.string(),
   shell: Joi.string(),
-  env: Joi.object().pattern(Joi.string(), Joi.string()),
+  env: Joi.object().pattern(Joi.string(), Joi.string().allow('')),
 }).rename('working_directory', 'workingDirectory');
 
 const BuildStepConfigSchema = Joi.any<BuildStepConfig>()

--- a/packages/steps/src/BuildConfig.ts
+++ b/packages/steps/src/BuildConfig.ts
@@ -48,6 +48,7 @@ export type BuildFunctionCallConfig = {
   name?: string;
   workingDirectory?: string;
   shell?: string;
+  env?: Record<string, string>;
 };
 
 export type BuildStepInputs = Record<string, BuildStepInputValueType>;
@@ -147,6 +148,7 @@ const BuildFunctionCallSchema = Joi.object({
   name: Joi.string(),
   workingDirectory: Joi.string(),
   shell: Joi.string(),
+  env: Joi.object().pattern(Joi.string(), Joi.string()),
 }).rename('working_directory', 'workingDirectory');
 
 const BuildStepConfigSchema = Joi.any<BuildStepConfig>()

--- a/packages/steps/src/BuildConfigParser.ts
+++ b/packages/steps/src/BuildConfigParser.ts
@@ -87,6 +87,7 @@ export class BuildConfigParser {
       workingDirectory,
       shell,
       command,
+      env,
     } = run;
     const id = BuildStep.getNewId(maybeId);
     const displayName = BuildStep.getDisplayName({ id, name, command });
@@ -103,6 +104,7 @@ export class BuildConfigParser {
       workingDirectory,
       shell,
       command,
+      env,
     });
   }
 
@@ -144,6 +146,7 @@ export class BuildConfigParser {
       callInputs: buildFunctionCallConfig.inputs,
       workingDirectory: buildFunctionCallConfig.workingDirectory,
       shell: buildFunctionCallConfig.shell,
+      env: buildFunctionCallConfig.env,
     });
   }
 

--- a/packages/steps/src/BuildFunction.ts
+++ b/packages/steps/src/BuildFunction.ts
@@ -5,6 +5,7 @@ import { BuildStep, BuildStepFunction } from './BuildStep.js';
 import { BuildStepGlobalContext } from './BuildStepContext.js';
 import { BuildStepInputProvider, BuildStepInputValueType } from './BuildStepInput.js';
 import { BuildStepOutputProvider } from './BuildStepOutput.js';
+import { BuildStepEnv } from './BuildStepEnv.js';
 
 export type BuildFunctionById = Record<string, BuildFunction>;
 export type BuildFunctionCallInputs = Record<string, BuildStepInputValueType>;
@@ -78,7 +79,7 @@ export class BuildFunction {
       callInputs?: BuildFunctionCallInputs;
       workingDirectory?: string;
       shell?: string;
-      env?: Record<string, string>;
+      env?: BuildStepEnv;
     } = {}
   ): BuildStep {
     const buildStepId = BuildStep.getNewId(id);

--- a/packages/steps/src/BuildFunction.ts
+++ b/packages/steps/src/BuildFunction.ts
@@ -71,12 +71,14 @@ export class BuildFunction {
       callInputs = {},
       workingDirectory,
       shell,
+      env,
     }: {
       id?: string;
       name?: string;
       callInputs?: BuildFunctionCallInputs;
       workingDirectory?: string;
       shell?: string;
+      env?: Record<string, string>;
     } = {}
   ): BuildStep {
     const buildStepId = BuildStep.getNewId(id);
@@ -107,6 +109,7 @@ export class BuildFunction {
       outputs,
       shell,
       supportedRuntimePlatforms: this.supportedRuntimePlatforms,
+      env,
     });
   }
 }

--- a/packages/steps/src/BuildStep.ts
+++ b/packages/steps/src/BuildStep.ts
@@ -63,7 +63,7 @@ export class BuildStep {
   public readonly fn?: BuildStepFunction;
   public readonly shell: string;
   public readonly ctx: BuildStepContext;
-  public readonly env: Record<string, string>;
+  public readonly env: BuildStepEnv;
   public status: BuildStepStatus;
 
   private readonly internalId: string;
@@ -127,7 +127,7 @@ export class BuildStep {
       workingDirectory?: string;
       shell?: string;
       supportedRuntimePlatforms?: BuildRuntimePlatform[];
-      env?: Record<string, string>;
+      env?: BuildStepEnv;
     }
   ) {
     assert(command !== undefined || fn !== undefined, 'Either command or fn must be defined.');

--- a/packages/steps/src/__tests__/BuildConfigParser-test.ts
+++ b/packages/steps/src/__tests__/BuildConfigParser-test.ts
@@ -75,6 +75,7 @@ describe(BuildConfigParser, () => {
       expect(step1.command).toBe('echo "Hi!"');
       expect(step1.ctx.workingDirectory).toBe(ctx.defaultWorkingDirectory);
       expect(step1.shell).toBe(getDefaultShell());
+      expect(step1.env).toMatchObject({});
 
       // - run:
       //     name: Say HELLO
@@ -90,16 +91,24 @@ describe(BuildConfigParser, () => {
       expect(step2.command).toMatchSnapshot();
       expect(step2.ctx.workingDirectory).toBe(ctx.defaultWorkingDirectory);
       expect(step2.shell).toBe(getDefaultShell());
+      expect(step2.env).toMatchObject({});
 
       // - run:
       //     id: id_2137
       //     command: echo "Step with an ID"
+      //     env:
+      //       FOO: bar
+      //       BAR: baz
       const step3 = buildSteps[2];
       expect(step3.id).toBe('id_2137');
       expect(step3.name).toBeUndefined();
       expect(step3.command).toBe('echo "Step with an ID"');
       expect(step3.ctx.workingDirectory).toBe(ctx.defaultWorkingDirectory);
       expect(step3.shell).toBe(getDefaultShell());
+      expect(step3.env).toMatchObject({
+        FOO: 'bar',
+        BAR: 'baz',
+      });
 
       // - run:
       //     name: List files
@@ -113,6 +122,7 @@ describe(BuildConfigParser, () => {
         path.join(ctx.defaultWorkingDirectory, 'relative/path/to/files')
       );
       expect(step4.shell).toBe(getDefaultShell());
+      expect(step4.env).toMatchObject({});
 
       // - run:
       //     name: List files in another directory
@@ -124,6 +134,7 @@ describe(BuildConfigParser, () => {
       expect(step5.command).toBe('ls -la');
       expect(step5.ctx.workingDirectory).toBe('/home/dsokal');
       expect(step5.shell).toBe(getDefaultShell());
+      expect(step5.env).toMatchObject({});
 
       // - run:
       //     name: Use non-default shell
@@ -135,6 +146,7 @@ describe(BuildConfigParser, () => {
       expect(step6.command).toBe('echo 123');
       expect(step6.ctx.workingDirectory).toBe(ctx.defaultWorkingDirectory);
       expect(step6.shell).toBe('/nib/hsab');
+      expect(step6.env).toMatchObject({});
     });
 
     it('parses inputs', async () => {
@@ -241,6 +253,9 @@ describe(BuildConfigParser, () => {
       expect(buildSteps.length).toBe(6);
 
       // - say_hi:
+      //     env:
+      //       ENV1: value1
+      //       ENV2: value2
       //     inputs:
       //       name: Dominik
       const step1 = buildSteps[0];
@@ -252,6 +267,10 @@ describe(BuildConfigParser, () => {
       expect(step1.inputs?.[0].id).toBe('name');
       expect(step1.inputs?.[0].value).toBe('Dominik');
       expect(step1.inputs?.[0].allowedValueTypeName).toBe(BuildStepInputValueTypeName.STRING);
+      expect(step1.env).toMatchObject({
+        ENV1: 'value1',
+        ENV2: 'value2',
+      });
 
       // - say_hi:
       //     name: Hi, Szymon!
@@ -266,6 +285,7 @@ describe(BuildConfigParser, () => {
       expect(step2.inputs?.[0].id).toBe('name');
       expect(step2.inputs?.[0].value).toBe('Szymon');
       expect(step2.inputs?.[0].allowedValueTypeName).toBe(BuildStepInputValueTypeName.STRING);
+      expect(step2.env).toMatchObject({});
 
       // - say_hi_wojtek
       const step3 = buildSteps[2];
@@ -274,6 +294,7 @@ describe(BuildConfigParser, () => {
       expect(step3.command).toBe('echo "Hi, Wojtek!"');
       expect(step3.ctx.workingDirectory).toBe(ctx.defaultWorkingDirectory);
       expect(step3.shell).toBe(getDefaultShell());
+      expect(step3.env).toMatchObject({});
 
       // - random:
       //     id: random_number
@@ -285,6 +306,7 @@ describe(BuildConfigParser, () => {
       expect(step4.shell).toBe(getDefaultShell());
       expect(step4.outputs?.[0].id).toBe('value');
       expect(step4.outputs?.[0].required).toBe(true);
+      expect(step4.env).toMatchObject({});
 
       // - print:
       //     inputs:
@@ -298,6 +320,7 @@ describe(BuildConfigParser, () => {
       expect(step5.inputs?.[0].id).toBe('value');
       expect(step5.inputs?.[0].required).toBe(true);
       expect(step5.inputs?.[0].allowedValueTypeName).toBe(BuildStepInputValueTypeName.STRING);
+      expect(step5.env).toMatchObject({});
 
       // - say_hi_2:
       //     inputs:
@@ -333,6 +356,7 @@ describe(BuildConfigParser, () => {
       expect(step6.inputs?.[3].defaultValue).toBe(undefined);
       expect(step6.inputs?.[3].allowedValues).toEqual(undefined);
       expect(step6.inputs?.[3].allowedValueTypeName).toBe(BuildStepInputValueTypeName.NUMBER);
+      expect(step6.env).toMatchObject({});
 
       const { buildFunctions } = workflow;
       expect(Object.keys(buildFunctions).length).toBe(5);

--- a/packages/steps/src/__tests__/BuildFunction-test.ts
+++ b/packages/steps/src/__tests__/BuildFunction-test.ts
@@ -197,5 +197,25 @@ describe(BuildFunction, () => {
       expect(step.inputs?.[1].value).toBe('def');
       expect(step.inputs?.[2].value).toBe(false);
     });
+    it('passes env to build step', () => {
+      const ctx = createGlobalContextMock();
+      const func = new BuildFunction({
+        id: 'test1',
+        name: 'Test function',
+        command: 'echo ${ inputs.input1 } ${ inputs.input2 }',
+      });
+      const step = func.createBuildStepFromFunctionCall(ctx, {
+        id: 'buildStep1',
+        workingDirectory: ctx.defaultWorkingDirectory,
+        env: {
+          ENV1: 'env1',
+          ENV2: 'env2',
+        },
+      });
+      expect(step.env).toMatchObject({
+        ENV1: 'env1',
+        ENV2: 'env2',
+      });
+    });
   });
 });

--- a/packages/steps/src/__tests__/fixtures/build-with-import.yml
+++ b/packages/steps/src/__tests__/fixtures/build-with-import.yml
@@ -5,6 +5,9 @@ build:
   name: Import!
   steps:
     - say_hi:
+        env:
+          ENV1: value1
+          ENV2: value2
         inputs:
           name: Dominik
     - say_hi_wojtek

--- a/packages/steps/src/__tests__/fixtures/build.yml
+++ b/packages/steps/src/__tests__/fixtures/build.yml
@@ -13,6 +13,9 @@ build:
     - run:
         id: id_2137
         command: echo "Step with an ID"
+        env:
+          FOO: bar
+          BAR: baz
     - run:
         name: List files
         working_directory: relative/path/to/files

--- a/packages/steps/src/__tests__/fixtures/functions.yml
+++ b/packages/steps/src/__tests__/fixtures/functions.yml
@@ -2,6 +2,9 @@ build:
   name: Functions
   steps:
     - say_hi:
+        env:
+          ENV1: value1
+          ENV2: value2
         inputs:
           name: Dominik
     - say_hi:

--- a/packages/steps/src/index.ts
+++ b/packages/steps/src/index.ts
@@ -6,4 +6,5 @@ export { BuildStepInput, BuildStepInputValueTypeName } from './BuildStepInput.js
 export { BuildStepOutput } from './BuildStepOutput.js';
 export { BuildStepGlobalContext, ExternalBuildContextProvider } from './BuildStepContext.js';
 export { BuildWorkflow } from './BuildWorkflow.js';
+export { BuildStepEnv } from './BuildStepEnv.js';
 export * as errors from './errors.js';


### PR DESCRIPTION
# Why

https://linear.app/expo/issue/ENG-9019/add-support-for-envs-in-step-config

# How

Add support for step envs

This step
```yaml
- run:
    id: id123
    command: echo "$FOO $BAR"
    env:
       FOO: bar
       BAR: baz
```
will print `bar baz`

You can also pass envs to function calls
```yaml
- say_hi:
    env:
      ENV1: value1
      ENV2: value2
    inputs:
      name: Dominik
```
# Test Plan

Automated tests
