### PR TITLE
[build-tools] migrate find and upload artifacts step

### DIFF
--- a/packages/build-tools/src/customBuildContext.ts
+++ b/packages/build-tools/src/customBuildContext.ts
@@ -12,7 +12,7 @@ const platformToBuildRuntimePlatform: Record<Platform, BuildRuntimePlatform> = {
 };
 
 export interface BuilderRuntimeApi {
-  uploadArtifacts: (type: ArtifactType, paths: string[], logger: bunyan) => Promise<string | null>;
+  uploadArtifacts: (type: ArtifactType, paths: string[], logger: bunyan) => Promise<void>;
 }
 
 export class CustomBuildContext implements ExternalBuildContextProvider {
@@ -46,7 +46,7 @@ export class CustomBuildContext implements ExternalBuildContextProvider {
     this.projectTargetDirectory = path.join(buildCtx.workingdir, 'build');
     this.defaultWorkingDirectory = buildCtx.getReactNativeProjectDirectory();
     this.runtimeApi = {
-      uploadArtifacts: buildCtx['_uploadArtifacts'],
+      uploadArtifacts: (...args) => buildCtx['uploadArtifacts'](...args),
     };
   }
 

--- a/packages/build-tools/src/steps/easFunctions.ts
+++ b/packages/build-tools/src/steps/easFunctions.ts
@@ -25,6 +25,6 @@ export function getEasFunctions(
     createPrebuildBuildFunction(ctx),
     createRunGradleBuildFunction(oldCtx),
     createBuildReactNativeAppBuildFunction(oldCtx),
-    createFindAndUploadBuildArtifactsBuildFunction(oldCtx),
+    createFindAndUploadBuildArtifactsBuildFunction(ctx),
   ];
 }

--- a/packages/build-tools/src/steps/functions/eas/findAndUploadBuildArtifacts.ts
+++ b/packages/build-tools/src/steps/functions/eas/findAndUploadBuildArtifacts.ts
@@ -1,39 +1,101 @@
-import { Ios, Job, Platform } from '@expo/eas-build-job';
+import path from 'path';
+
+import { Ios, Platform } from '@expo/eas-build-job';
 import { BuildFunction } from '@expo/steps';
 
-import { BuildContext } from '../../../context';
-import {
-  maybeFindAndUploadBuildArtifacts,
-  uploadApplicationArchive,
-} from '../../../utils/artifacts';
-import { resolveArtifactPath } from '../../../ios/resolve';
-import { findAndUploadXcodeBuildLogsAsync } from '../../../ios/xcodeBuildLogs';
+import { ArtifactType } from '../../../context';
+import { findArtifacts } from '../../../utils/artifacts';
+import { findXcodeBuildLogsPathAsync } from '../../../ios/xcodeBuildLogs';
+import { CustomBuildContext } from '../../../customBuildContext';
 
-export function createFindAndUploadBuildArtifactsBuildFunction<T extends Job>(
-  ctx: BuildContext<T>
+export function createFindAndUploadBuildArtifactsBuildFunction(
+  ctx: CustomBuildContext
 ): BuildFunction {
   return new BuildFunction({
     namespace: 'eas',
     id: 'find_and_upload_build_artifacts',
     name: 'Find and upload build artifacts',
-    fn: async (stepsCtx) => {
+    fn: async (stepCtx) => {
+      const { logger } = stepCtx;
       const applicationArchivePatternOrPath =
         ctx.job.platform === Platform.ANDROID
           ? ctx.job.applicationArchivePath ?? 'android/app/build/outputs/**/*.{apk,aab}'
-          : resolveArtifactPath(ctx as BuildContext<Ios.Job>);
-      await uploadApplicationArchive(ctx, {
-        logger: stepsCtx.logger,
-        rootDir: stepsCtx.workingDirectory,
-        patternOrPath: applicationArchivePatternOrPath,
-      });
-      await maybeFindAndUploadBuildArtifacts(ctx, {
-        logger: stepsCtx.logger,
-      });
-      if (ctx.job.platform === Platform.IOS) {
-        await findAndUploadXcodeBuildLogsAsync(ctx as BuildContext<Ios.Job>, {
-          logger: stepsCtx.logger,
-        });
+          : resolveIosArtifactPath(ctx.job);
+      const applicationArchives = await findArtifacts(
+        stepCtx.workingDirectory,
+        applicationArchivePatternOrPath,
+        logger
+      );
+      logger.info(
+        `Application archive${
+          applicationArchives.length > 1 ? 's' : ''
+        }: ${applicationArchives.join(', ')}`
+      );
+      const buildArtifacts = (
+        await Promise.all(
+          (ctx.job.buildArtifactPaths ?? []).map((path) =>
+            findArtifacts(ctx.projectTargetDirectory, path, logger)
+          )
+        )
+      ).flat();
+      if (buildArtifacts.length > 0) {
+        logger.info(`Found additional build artifacts: ${buildArtifacts.join(', ')}`);
       }
+
+      logger.info('Uploading...');
+      const [archiveUpload, artifactsUpload, xcodeBuildLogsUpload] = await Promise.allSettled([
+        ctx.runtimeApi.uploadArtifacts(
+          ArtifactType.APPLICATION_ARCHIVE,
+          applicationArchives,
+          logger
+        ),
+        (async () => {
+          if (buildArtifacts.length > 0) {
+            await ctx.runtimeApi.uploadArtifacts(
+              ArtifactType.BUILD_ARTIFACTS,
+              buildArtifacts,
+              logger
+            );
+          }
+        })(),
+        (async () => {
+          if (ctx.job.platform !== Platform.IOS) {
+            return;
+          }
+          const xcodeBuildLogsPath = await findXcodeBuildLogsPathAsync(
+            path.resolve(ctx.projectTargetDirectory, '../logs')
+          );
+          if (xcodeBuildLogsPath) {
+            await ctx.runtimeApi.uploadArtifacts(
+              ArtifactType.XCODE_BUILD_LOGS,
+              [xcodeBuildLogsPath],
+              logger
+            );
+          }
+        })(),
+      ]);
+      if (archiveUpload.status === 'rejected') {
+        logger.error('Failed to upload application archive.');
+        throw archiveUpload.reason;
+      }
+      if (artifactsUpload.status === 'rejected') {
+        logger.error('Failed to upload build artifacts.');
+        throw artifactsUpload.reason;
+      }
+      if (xcodeBuildLogsUpload.status === 'rejected') {
+        logger.error(`Failed to upload Xcode build logs. ${xcodeBuildLogsUpload.reason}`);
+      }
+      logger.info('Upload finished');
     },
   });
+}
+
+function resolveIosArtifactPath(job: Ios.Job): string {
+  if (job.applicationArchivePath) {
+    return job.applicationArchivePath;
+  } else if (job.simulator) {
+    return 'ios/build/Build/Products/*simulator/*.app';
+  } else {
+    return 'ios/build/*.ipa';
+  }
 }


### PR DESCRIPTION
# Why

move next step to stop using old context

# How

- introduce runtime api for communication between worker and custom build
- upload files concurrentlly

# Test Plan

Run build on local www (only tested uploading application archive)
