### PR TITLE
[ENG-9032][ENG-9031][steps] allow JSON inputs and context interpolation

### DIFF
--- a/packages/steps/package.json
+++ b/packages/steps/package.json
@@ -33,6 +33,7 @@
   "devDependencies": {
     "@jest/globals": "^29.4.1",
     "@types/jest": "^29.4.0",
+    "@types/lodash": "^4.14.195",
     "@types/node": "^18.11.18",
     "chokidar-cli": "^3.0.0",
     "eslint-plugin-async-protect": "^3.0.0",
@@ -50,6 +51,7 @@
     "@expo/spawn-async": "^1.7.0",
     "arg": "^5.0.2",
     "joi": "^17.7.0",
+    "lodash": "^4.17.21",
     "this-file": "^2.0.3",
     "uuid": "^9.0.0",
     "yaml": "^2.2.1"

--- a/packages/steps/package.json
+++ b/packages/steps/package.json
@@ -33,7 +33,7 @@
   "devDependencies": {
     "@jest/globals": "^29.4.1",
     "@types/jest": "^29.4.0",
-    "@types/lodash": "^4.14.195",
+    "@types/lodash.get": "^4.4.7",
     "@types/node": "^18.11.18",
     "chokidar-cli": "^3.0.0",
     "eslint-plugin-async-protect": "^3.0.0",
@@ -51,7 +51,7 @@
     "@expo/spawn-async": "^1.7.0",
     "arg": "^5.0.2",
     "joi": "^17.7.0",
-    "lodash": "^4.17.21",
+    "lodash.get": "^4.4.2",
     "this-file": "^2.0.3",
     "uuid": "^9.0.0",
     "yaml": "^2.2.1"

--- a/packages/steps/src/BuildConfig.ts
+++ b/packages/steps/src/BuildConfig.ts
@@ -10,6 +10,7 @@ import { BuildRuntimePlatform } from './BuildRuntimePlatform.js';
 import { BuildFunction } from './BuildFunction.js';
 import { BuildStepInputValueType, BuildStepInputValueTypeName } from './BuildStepInput.js';
 import { BuildStepEnv } from './BuildStepEnv.js';
+import { BUILD_STEP_OR_BUILD_GLOBAL_CONTEXT_REFERENCE_REGEX } from './utils/template.js';
 
 export type BuildFunctions = Record<string, BuildFunctionConfig>;
 
@@ -82,8 +83,6 @@ export type BuildFunctionInputs = (
 )[];
 export type BuildFunctionOutputs = BuildStepOutputs;
 
-export const STEP_OR_CONTEXT_REFERENCE_REGEX = /\${\s*((steps|ctx)\.[\S]+)\s*}/;
-
 const BuildFunctionInputsSchema = Joi.array().items(
   Joi.alternatives().conditional(Joi.ref('.'), {
     is: Joi.string(),
@@ -105,7 +104,7 @@ const BuildFunctionInputsSchema = Joi.array().items(
           then: Joi.alternatives(
             Joi.boolean(),
             Joi.string().pattern(
-              STEP_OR_CONTEXT_REFERENCE_REGEX,
+              BUILD_STEP_OR_BUILD_GLOBAL_CONTEXT_REFERENCE_REGEX,
               'context or output reference regex pattern'
             )
           ).messages({
@@ -118,7 +117,7 @@ const BuildFunctionInputsSchema = Joi.array().items(
           then: Joi.alternatives(
             Joi.number(),
             Joi.string().pattern(
-              STEP_OR_CONTEXT_REFERENCE_REGEX,
+              BUILD_STEP_OR_BUILD_GLOBAL_CONTEXT_REFERENCE_REGEX,
               'context or output reference regex pattern'
             )
           ).messages({
@@ -131,7 +130,7 @@ const BuildFunctionInputsSchema = Joi.array().items(
           then: Joi.alternatives(
             Joi.object(),
             Joi.string().pattern(
-              STEP_OR_CONTEXT_REFERENCE_REGEX,
+              BUILD_STEP_OR_BUILD_GLOBAL_CONTEXT_REFERENCE_REGEX,
               'context or output reference regex pattern'
             )
           ).messages({

--- a/packages/steps/src/BuildConfigParser.ts
+++ b/packages/steps/src/BuildConfigParser.ts
@@ -202,7 +202,10 @@ export class BuildConfigParser {
           stepDisplayName,
           defaultValue: value,
           required: true,
-          allowedValueTypeName: typeof value as BuildStepInputValueTypeName,
+          allowedValueTypeName:
+            typeof value === 'object'
+              ? BuildStepInputValueTypeName.JSON
+              : (typeof value as BuildStepInputValueTypeName),
         })
     );
   }

--- a/packages/steps/src/BuildStep.ts
+++ b/packages/steps/src/BuildStep.ts
@@ -20,11 +20,7 @@ import {
   saveScriptToTemporaryFileAsync,
 } from './BuildTemporaryFiles.js';
 import { spawnAsync } from './utils/shell/spawn.js';
-import {
-  getObjectValueForInterpolation,
-  interpolateWithGlobalContext,
-  interpolateWithInputs,
-} from './utils/template.js';
+import { interpolateWithInputs } from './utils/template.js';
 import { BuildStepRuntimeError } from './errors.js';
 import { BuildStepEnv } from './BuildStepEnv.js';
 import { BuildRuntimePlatform } from './BuildRuntimePlatform.js';
@@ -286,17 +282,7 @@ export class BuildStep {
           : input.value?.toString() ?? '';
       return acc;
     }, {} as Record<string, string>);
-    const valueInterpolatedWithGlobalContext = interpolateWithGlobalContext(command, (path) => {
-      return (
-        getObjectValueForInterpolation(path, {
-          projectSourceDirectory: this.ctx.global.projectSourceDirectory,
-          projectTargetDirectory: this.ctx.global.projectTargetDirectory,
-          defaultWorkingDirectory: this.ctx.global.defaultWorkingDirectory,
-          runtimePlatform: this.ctx.global.runtimePlatform,
-          ...this.ctx.global.staticContext,
-        })?.toString() ?? ''
-      );
-    });
+    const valueInterpolatedWithGlobalContext = this.ctx.global.interpolate(command);
     return interpolateWithInputs(valueInterpolatedWithGlobalContext, vars);
   }
 

--- a/packages/steps/src/BuildStep.ts
+++ b/packages/steps/src/BuildStep.ts
@@ -286,7 +286,7 @@ export class BuildStep {
           : input.value?.toString() ?? '';
       return acc;
     }, {} as Record<string, string>);
-    const interpolatedWithGlobalContext = interpolateWithGlobalContext(command, (path) => {
+    const valueInterpolatedWithGlobalContext = interpolateWithGlobalContext(command, (path) => {
       return (
         getObjectValueForInterpolation(path, {
           projectSourceDirectory: this.ctx.global.projectSourceDirectory,
@@ -297,7 +297,7 @@ export class BuildStep {
         })?.toString() ?? ''
       );
     });
-    return interpolateWithInputs(interpolatedWithGlobalContext, vars);
+    return interpolateWithInputs(valueInterpolatedWithGlobalContext, vars);
   }
 
   private async collectAndValidateOutputsAsync(outputsDir: string): Promise<void> {

--- a/packages/steps/src/BuildStepContext.ts
+++ b/packages/steps/src/BuildStepContext.ts
@@ -83,8 +83,10 @@ export class BuildStepGlobalContext {
     return interpolateWithGlobalContext(value, (path) => {
       return (
         getObjectValueForInterpolation(path, {
-          runtimePlatform: this.runtimePlatform,
-          ...this.staticContext,
+          eas: {
+            runtimePlatform: this.runtimePlatform,
+            ...this.staticContext,
+          },
         })?.toString() ?? ''
       );
     });

--- a/packages/steps/src/BuildStepContext.ts
+++ b/packages/steps/src/BuildStepContext.ts
@@ -55,6 +55,10 @@ export class BuildStepGlobalContext {
     return this.provider.env;
   }
 
+  public get staticContext(): any {
+    return this.provider.staticContext();
+  }
+
   public updateEnv(updatedEnv: BuildStepEnv): void {
     this.provider.updateEnv(updatedEnv);
   }

--- a/packages/steps/src/BuildStepInput.ts
+++ b/packages/steps/src/BuildStepInput.ts
@@ -73,18 +73,17 @@ export class BuildStepInput {
       );
     }
 
-    if (
+    const valueDoesNotRequireInterpolation =
       rawValue === undefined ||
       typeof rawValue === 'boolean' ||
       typeof rawValue === 'number' ||
-      typeof rawValue === 'object'
-    ) {
+      typeof rawValue === 'object';
+    if (valueDoesNotRequireInterpolation) {
+      const isJsonValue =
+        typeof rawValue === 'object' &&
+        this.allowedValueTypeName === BuildStepInputValueTypeName.JSON;
       if (
-        !(
-          typeof rawValue == this.allowedValueTypeName ||
-          (typeof rawValue === 'object' &&
-            this.allowedValueTypeName === BuildStepInputValueTypeName.JSON)
-        ) &&
+        !(typeof rawValue == this.allowedValueTypeName || isJsonValue) &&
         rawValue !== undefined
       ) {
         throw new BuildStepRuntimeError(
@@ -93,7 +92,7 @@ export class BuildStepInput {
       }
       return rawValue;
     } else {
-      const interpolatedWithGlobalContext = interpolateWithGlobalContext(rawValue, (path) => {
+      const valueInterpolatedWithGlobalContext = interpolateWithGlobalContext(rawValue, (path) => {
         return (
           getObjectValueForInterpolation(path, {
             projectSourceDirectory: this.ctx.projectSourceDirectory,
@@ -104,11 +103,13 @@ export class BuildStepInput {
           })?.toString() ?? ''
         );
       });
-      const interpolatedWithOutputsAndGlobalContext = interpolateWithOutputs(
-        interpolatedWithGlobalContext,
+      const valueInterpolatedWithOutputsAndGlobalContext = interpolateWithOutputs(
+        valueInterpolatedWithGlobalContext,
         (path) => this.ctx.getStepOutputValue(path) ?? ''
       );
-      return this.parseInterpolatedInputValueToAllowedType(interpolatedWithOutputsAndGlobalContext);
+      return this.parseInterpolatedInputValueToAllowedType(
+        valueInterpolatedWithOutputsAndGlobalContext
+      );
     }
   }
 

--- a/packages/steps/src/BuildWorkflowValidator.ts
+++ b/packages/steps/src/BuildWorkflowValidator.ts
@@ -1,4 +1,3 @@
-import { STEP_OR_CONTEXT_REFERENCE_REGEX } from './BuildConfig.js';
 import { BuildStep } from './BuildStep.js';
 import { BuildStepInputValueTypeName } from './BuildStepInput.js';
 import { BuildWorkflow } from './BuildWorkflow.js';
@@ -47,19 +46,14 @@ export class BuildWorkflowValidator {
           errors.push(error);
         }
 
-        const isStepOrContextReference =
-          typeof currentStepInput.rawValue === 'string' &&
-          STEP_OR_CONTEXT_REFERENCE_REGEX.exec(currentStepInput.rawValue);
-        const isJson =
-          typeof currentStepInput.rawValue === 'object' &&
-          currentStepInput.allowedValueTypeName === BuildStepInputValueTypeName.JSON;
+        const currentType =
+          typeof currentStepInput.rawValue === 'object'
+            ? BuildStepInputValueTypeName.JSON
+            : typeof currentStepInput.rawValue;
         if (
           currentStepInput.rawValue !== undefined &&
-          !(
-            typeof currentStepInput.rawValue === currentStepInput.allowedValueTypeName ||
-            isStepOrContextReference ||
-            isJson
-          )
+          !currentStepInput.isRawValueStepOrContextReference() &&
+          currentType !== currentStepInput.allowedValueTypeName
         ) {
           const error = new BuildConfigError(
             `Input parameter "${currentStepInput.id}" for step "${
@@ -70,7 +64,7 @@ export class BuildWorkflowValidator {
                 : currentStepInput.rawValue
             }" which is not of type "${
               currentStepInput.allowedValueTypeName
-            }" or is not step or context refference.`
+            }" or is not step or context reference.`
           );
           errors.push(error);
         }

--- a/packages/steps/src/BuildWorkflowValidator.ts
+++ b/packages/steps/src/BuildWorkflowValidator.ts
@@ -1,4 +1,6 @@
+import { STEP_OR_CONTEXT_REFERENCE_REGEX } from './BuildConfig.js';
 import { BuildStep } from './BuildStep.js';
+import { BuildStepInputValueTypeName } from './BuildStepInput.js';
 import { BuildWorkflow } from './BuildWorkflow.js';
 import { BuildConfigError, BuildWorkflowError } from './errors.js';
 import { duplicates } from './utils/expodash/duplicates.js';
@@ -47,10 +49,24 @@ export class BuildWorkflowValidator {
 
         if (
           currentStepInput.rawValue !== undefined &&
-          typeof currentStepInput.rawValue !== currentStepInput.allowedValueTypeName
+          !(
+            typeof currentStepInput.rawValue === currentStepInput.allowedValueTypeName ||
+            (typeof currentStepInput.rawValue === 'string' &&
+              STEP_OR_CONTEXT_REFERENCE_REGEX.exec(currentStepInput.rawValue)) ||
+            (typeof currentStepInput.rawValue === 'object' &&
+              currentStepInput.allowedValueTypeName === BuildStepInputValueTypeName.JSON)
+          )
         ) {
           const error = new BuildConfigError(
-            `Input parameter "${currentStepInput.id}" for step "${currentStep.displayName}" is set to "${currentStepInput.rawValue}" which is not of type "${currentStepInput.allowedValueTypeName}".`
+            `Input parameter "${currentStepInput.id}" for step "${
+              currentStep.displayName
+            }" is set to "${
+              typeof currentStepInput.rawValue === 'object'
+                ? JSON.stringify(currentStepInput.rawValue)
+                : currentStepInput.rawValue
+            }" which is not of type "${
+              currentStepInput.allowedValueTypeName
+            }" or is not step or context refference.`
           );
           errors.push(error);
         }

--- a/packages/steps/src/BuildWorkflowValidator.ts
+++ b/packages/steps/src/BuildWorkflowValidator.ts
@@ -47,14 +47,18 @@ export class BuildWorkflowValidator {
           errors.push(error);
         }
 
+        const isStepOrContextReference =
+          typeof currentStepInput.rawValue === 'string' &&
+          STEP_OR_CONTEXT_REFERENCE_REGEX.exec(currentStepInput.rawValue);
+        const isJson =
+          typeof currentStepInput.rawValue === 'object' &&
+          currentStepInput.allowedValueTypeName === BuildStepInputValueTypeName.JSON;
         if (
           currentStepInput.rawValue !== undefined &&
           !(
             typeof currentStepInput.rawValue === currentStepInput.allowedValueTypeName ||
-            (typeof currentStepInput.rawValue === 'string' &&
-              STEP_OR_CONTEXT_REFERENCE_REGEX.exec(currentStepInput.rawValue)) ||
-            (typeof currentStepInput.rawValue === 'object' &&
-              currentStepInput.allowedValueTypeName === BuildStepInputValueTypeName.JSON)
+            isStepOrContextReference ||
+            isJson
           )
         ) {
           const error = new BuildConfigError(

--- a/packages/steps/src/__tests__/BuildConfig-test.ts
+++ b/packages/steps/src/__tests__/BuildConfig-test.ts
@@ -476,7 +476,7 @@ describe(validateConfig, () => {
                   test_boolean: {
                     inputs: {
                       boolean: true,
-                      boolean2: '${ ctx.job.booleanValue }',
+                      boolean2: '${ eas.job.booleanValue }',
                     },
                   },
                 },
@@ -492,7 +492,7 @@ describe(validateConfig, () => {
                   {
                     name: 'boolean2',
                     type: 'boolean',
-                    defaultValue: '${ ctx.job.booleanValue }',
+                    defaultValue: '${ eas.job.booleanValue }',
                   },
                 ],
                 command: 'echo "${ inputs.boolean }!"',
@@ -707,7 +707,7 @@ describe(validateConfig, () => {
                 },
                 {
                   name: 'i6',
-                  default_value: '${ ctx.job.version.buildNumber }',
+                  default_value: '${ eas.job.version.buildNumber }',
                   type: 'number',
                 },
                 {

--- a/packages/steps/src/__tests__/BuildConfig-test.ts
+++ b/packages/steps/src/__tests__/BuildConfig-test.ts
@@ -120,6 +120,9 @@ describe(readAndValidateBuildFunctionsConfigFileAsync, () => {
     expect(error.message).toMatch(
       /"functions.say_hi.inputs\[0\].allowedValues\[1\]" must be a boolean/
     );
+    expect(error.message).toMatch(
+      /"functions.say_hi.inputs\[1\].defaultValue" with value "\${ wrong.job.platform }" fails to match the context or output reference regex pattern/
+    );
   });
 });
 
@@ -473,6 +476,7 @@ describe(validateConfig, () => {
                   test_boolean: {
                     inputs: {
                       boolean: true,
+                      boolean2: '${ ctx.job.booleanValue }',
                     },
                   },
                 },
@@ -484,6 +488,11 @@ describe(validateConfig, () => {
                   {
                     name: 'boolean',
                     type: 'boolean',
+                  },
+                  {
+                    name: 'boolean2',
+                    type: 'boolean',
+                    defaultValue: '${ ctx.job.booleanValue }',
                   },
                 ],
                 command: 'echo "${ inputs.boolean }!"',
@@ -615,6 +624,16 @@ describe(validateConfig, () => {
                   default_value: true,
                   type: 'number',
                 },
+                {
+                  name: 'i6',
+                  default_value: 'abc',
+                  type: 'boolean',
+                },
+                {
+                  name: 'i7',
+                  default_value: true,
+                  type: 'json',
+                },
               ],
               command: 'echo "${ inputs.i1 } ${ inputs.i2 }"',
             },
@@ -635,9 +654,13 @@ describe(validateConfig, () => {
           /"functions.abc.inputs\[2\].allowedValues\[1\]" must be a string/
         );
         expect(error.message).toMatch(
-          /"functions.abc.inputs\[3\].allowedValueType" must be one of \[string, boolean, number\]/
+          /"functions.abc.inputs\[3\].allowedValueType" must be one of \[string, boolean, number, json\]/
         );
         expect(error.message).toMatch(/"functions.abc.inputs\[4\].defaultValue" must be a number/);
+        expect(error.message).toMatch(
+          /"functions.abc.inputs\[5\].defaultValue" with value "abc" fails to match the context or output reference regex pattern pattern/
+        );
+        expect(error.message).toMatch(/"functions.abc.inputs\[6\].defaultValue" must be a object/);
       });
       test('valid default and allowed values for function inputs', () => {
         const buildConfig = {
@@ -667,6 +690,30 @@ describe(validateConfig, () => {
                   default_value: 1,
                   type: 'number',
                   allowed_values: [1, 2],
+                },
+                {
+                  name: 'i5',
+                  default_value: {
+                    a: 1,
+                    b: {
+                      c: [2, 3],
+                      d: false,
+                      e: {
+                        f: 'hi',
+                      },
+                    },
+                  },
+                  type: 'json',
+                },
+                {
+                  name: 'i6',
+                  default_value: '${ ctx.job.version.buildNumber }',
+                  type: 'number',
+                },
+                {
+                  name: 'i7',
+                  default_value: '${ steps.stepid.someBoolean }',
+                  type: 'boolean',
                 },
               ],
               command: 'echo "${ inputs.i1 } ${ inputs.i2 } ${ inputs.i3 }"',

--- a/packages/steps/src/__tests__/BuildConfigParser-test.ts
+++ b/packages/steps/src/__tests__/BuildConfigParser-test.ts
@@ -270,7 +270,7 @@ describe(BuildConfigParser, () => {
       //       ENV2: value2
       //     inputs:
       //       name: Dominik
-      //       buildNumber: ${ ctx.job.version.buildNumber }
+      //       buildNumber: ${ eas.job.version.buildNumber }
       //        json_input:
       //          property1: value1
       //          property2:
@@ -286,7 +286,7 @@ describe(BuildConfigParser, () => {
       expect(step1.inputs?.[0].value).toBe('Dominik');
       expect(step1.inputs?.[0].allowedValueTypeName).toBe(BuildStepInputValueTypeName.STRING);
       expect(step1.inputs?.[1].id).toBe('build_number');
-      expect(step1.inputs?.[1].rawValue).toBe('${ ctx.job.version.buildNumber }');
+      expect(step1.inputs?.[1].rawValue).toBe('${ eas.job.version.buildNumber }');
       expect(step1.inputs?.[1].allowedValueTypeName).toBe(BuildStepInputValueTypeName.NUMBER);
       expect(step1.inputs?.[2].id).toBe('json_input');
       expect(step1.inputs?.[2].value).toMatchObject({

--- a/packages/steps/src/__tests__/BuildFunction-test.ts
+++ b/packages/steps/src/__tests__/BuildFunction-test.ts
@@ -137,6 +137,16 @@ describe(BuildFunction, () => {
           defaultValue: 1,
           allowedValueTypeName: BuildStepInputValueTypeName.NUMBER,
         }),
+        BuildStepInput.createProvider({
+          id: 'input4',
+          defaultValue: { a: 1 },
+          allowedValueTypeName: BuildStepInputValueTypeName.JSON,
+        }),
+        BuildStepInput.createProvider({
+          id: 'input5',
+          defaultValue: '${ ctx.job.version.buildNumber }',
+          allowedValueTypeName: BuildStepInputValueTypeName.NUMBER,
+        }),
       ];
       const outputProviders: BuildStepOutputProvider[] = [
         BuildStepOutput.createProvider({ id: 'output1' }),
@@ -159,6 +169,8 @@ describe(BuildFunction, () => {
       });
       expect(func.inputProviders?.[0]).toBe(inputProviders[0]);
       expect(func.inputProviders?.[1]).toBe(inputProviders[1]);
+      expect(func.inputProviders?.[2]).toBe(inputProviders[2]);
+      expect(func.inputProviders?.[3]).toBe(inputProviders[3]);
       expect(func.outputProviders?.[0]).toBe(outputProviders[0]);
       expect(func.outputProviders?.[1]).toBe(outputProviders[1]);
       expect(step.inputs?.[0].id).toBe('input1');
@@ -177,6 +189,13 @@ describe(BuildFunction, () => {
           defaultValue: true,
           allowedValueTypeName: BuildStepInputValueTypeName.BOOLEAN,
         }),
+        BuildStepInput.createProvider({
+          id: 'input4',
+          defaultValue: {
+            a: 1,
+          },
+          allowedValueTypeName: BuildStepInputValueTypeName.JSON,
+        }),
       ];
       const func = new BuildFunction({
         id: 'test1',
@@ -190,12 +209,18 @@ describe(BuildFunction, () => {
           input1: 'abc',
           input2: 'def',
           input3: false,
+          input4: {
+            b: 2,
+          },
         },
         workingDirectory: ctx.defaultWorkingDirectory,
       });
       expect(step.inputs?.[0].value).toBe('abc');
       expect(step.inputs?.[1].value).toBe('def');
       expect(step.inputs?.[2].value).toBe(false);
+      expect(step.inputs?.[3].value).toMatchObject({
+        b: 2,
+      });
     });
     it('passes env to build step', () => {
       const ctx = createGlobalContextMock();

--- a/packages/steps/src/__tests__/BuildFunction-test.ts
+++ b/packages/steps/src/__tests__/BuildFunction-test.ts
@@ -144,7 +144,7 @@ describe(BuildFunction, () => {
         }),
         BuildStepInput.createProvider({
           id: 'input5',
-          defaultValue: '${ ctx.job.version.buildNumber }',
+          defaultValue: '${ eas.job.version.buildNumber }',
           allowedValueTypeName: BuildStepInputValueTypeName.NUMBER,
         }),
       ];

--- a/packages/steps/src/__tests__/BuildStep-test.ts
+++ b/packages/steps/src/__tests__/BuildStep-test.ts
@@ -300,7 +300,7 @@ describe(BuildStep, () => {
             new BuildStepInput(baseStepCtx, {
               id: 'foo2',
               stepDisplayName: displayName,
-              defaultValue: '${ ctx.runtimePlatform }',
+              defaultValue: '${ eas.runtimePlatform }',
               allowedValueTypeName: BuildStepInputValueTypeName.STRING,
             }),
             new BuildStepInput(baseStepCtx, {

--- a/packages/steps/src/__tests__/BuildStepContext-test.ts
+++ b/packages/steps/src/__tests__/BuildStepContext-test.ts
@@ -53,7 +53,7 @@ describe(BuildStepGlobalContext, () => {
     it('throws an error if the step output references a non-existent step', () => {
       const ctx = createGlobalContextMock();
       const error = getError<BuildStepRuntimeError>(() => {
-        ctx.getStepOutputValue('abc.def');
+        ctx.getStepOutputValue('steps.abc.def');
       });
       expect(error).toBeInstanceOf(BuildStepRuntimeError);
       expect(error.message).toMatch(/Step "abc" does not exist/);
@@ -67,7 +67,7 @@ describe(BuildStepGlobalContext, () => {
       const step = instance(mockStep);
 
       ctx.registerStep(step);
-      expect(ctx.getStepOutputValue('abc.def')).toBe('ghi');
+      expect(ctx.getStepOutputValue('steps.abc.def')).toBe('ghi');
     });
   });
   describe(BuildStepGlobalContext.prototype.stepCtx, () => {

--- a/packages/steps/src/__tests__/BuildStepInput-test.ts
+++ b/packages/steps/src/__tests__/BuildStepInput-test.ts
@@ -105,6 +105,166 @@ describe(BuildStepInput, () => {
     expect(i.value).toEqual('linux');
   });
 
+  test('context value number', () => {
+    const ctx = createGlobalContextMock({
+      staticContextContent: {
+        foo: {
+          bar: [
+            1,
+            2,
+            3,
+            {
+              baz: 42,
+            },
+          ],
+        },
+      },
+    });
+    const i = new BuildStepInput(ctx, {
+      id: 'foo',
+      stepDisplayName: BuildStep.getDisplayName({ id: 'test1' }),
+      defaultValue: '${ ctx.foo.bar[3].baz }',
+      allowedValueTypeName: BuildStepInputValueTypeName.NUMBER,
+    });
+    expect(i.value).toEqual(42);
+  });
+
+  test('context value boolean', () => {
+    const ctx = createGlobalContextMock({
+      staticContextContent: {
+        foo: {
+          bar: [
+            1,
+            2,
+            3,
+            {
+              baz: {
+                qux: false,
+              },
+            },
+          ],
+        },
+      },
+    });
+    const i = new BuildStepInput(ctx, {
+      id: 'foo',
+      stepDisplayName: BuildStep.getDisplayName({ id: 'test1' }),
+      defaultValue: '${ ctx.foo.bar[3].baz.qux }',
+      allowedValueTypeName: BuildStepInputValueTypeName.BOOLEAN,
+    });
+    expect(i.value).toEqual(false);
+  });
+
+  test('context value JSON', () => {
+    const ctx = createGlobalContextMock({
+      staticContextContent: {
+        foo: {
+          bar: [
+            1,
+            2,
+            3,
+            {
+              baz: {
+                qux: false,
+              },
+            },
+          ],
+        },
+      },
+    });
+    const i = new BuildStepInput(ctx, {
+      id: 'foo',
+      stepDisplayName: BuildStep.getDisplayName({ id: 'test1' }),
+      defaultValue: '${ ctx.foo }',
+      allowedValueTypeName: BuildStepInputValueTypeName.JSON,
+    });
+    expect(i.value).toMatchObject({ bar: [1, 2, 3, { baz: { qux: false } }] });
+  });
+
+  test('invalid context value type number', () => {
+    const ctx = createGlobalContextMock({
+      staticContextContent: {
+        foo: {
+          bar: [
+            1,
+            2,
+            3,
+            {
+              baz: {
+                qux: 'ala ma kota',
+              },
+            },
+          ],
+        },
+      },
+    });
+    const i = new BuildStepInput(ctx, {
+      id: 'foo',
+      stepDisplayName: BuildStep.getDisplayName({ id: 'test1' }),
+      defaultValue: '${ ctx.foo.bar[3].baz.qux }',
+      allowedValueTypeName: BuildStepInputValueTypeName.NUMBER,
+    });
+    expect(() => i.value).toThrowError(
+      'Input parameter "foo" for step "test1" must be of type "number".'
+    );
+  });
+
+  test('invalid context value type boolean', () => {
+    const ctx = createGlobalContextMock({
+      staticContextContent: {
+        foo: {
+          bar: [
+            1,
+            2,
+            3,
+            {
+              baz: {
+                qux: 123,
+              },
+            },
+          ],
+        },
+      },
+    });
+    const i = new BuildStepInput(ctx, {
+      id: 'foo',
+      stepDisplayName: BuildStep.getDisplayName({ id: 'test1' }),
+      defaultValue: '${ ctx.foo.bar[3].baz.qux }',
+      allowedValueTypeName: BuildStepInputValueTypeName.BOOLEAN,
+    });
+    expect(() => i.value).toThrowError(
+      'Input parameter "foo" for step "test1" must be of type "boolean".'
+    );
+  });
+
+  test('invalid context value type JSON', () => {
+    const ctx = createGlobalContextMock({
+      staticContextContent: {
+        foo: {
+          bar: [
+            1,
+            2,
+            3,
+            {
+              baz: {
+                qux: 'ala ma kota',
+              },
+            },
+          ],
+        },
+      },
+    });
+    const i = new BuildStepInput(ctx, {
+      id: 'foo',
+      stepDisplayName: BuildStep.getDisplayName({ id: 'test1' }),
+      defaultValue: '${ ctx.foo.bar[3].baz.qux }',
+      allowedValueTypeName: BuildStepInputValueTypeName.JSON,
+    });
+    expect(() => i.value).toThrowError(
+      'Input parameter "foo" for step "test1" must be of type "json".'
+    );
+  });
+
   test('default value number', () => {
     const ctx = createGlobalContextMock();
     const i = new BuildStepInput(ctx, {

--- a/packages/steps/src/__tests__/BuildStepInput-test.ts
+++ b/packages/steps/src/__tests__/BuildStepInput-test.ts
@@ -100,7 +100,7 @@ describe(BuildStepInput, () => {
     const i = new BuildStepInput(ctx, {
       id: 'foo',
       stepDisplayName: BuildStep.getDisplayName({ id: 'test1' }),
-      defaultValue: '${ ctx.runtimePlatform }',
+      defaultValue: '${ eas.runtimePlatform }',
     });
     expect(i.value).toEqual('linux');
   });
@@ -123,7 +123,7 @@ describe(BuildStepInput, () => {
     const i = new BuildStepInput(ctx, {
       id: 'foo',
       stepDisplayName: BuildStep.getDisplayName({ id: 'test1' }),
-      defaultValue: '${ ctx.foo.bar[3].baz }',
+      defaultValue: '${ eas.foo.bar[3].baz }',
       allowedValueTypeName: BuildStepInputValueTypeName.NUMBER,
     });
     expect(i.value).toEqual(42);
@@ -149,7 +149,7 @@ describe(BuildStepInput, () => {
     const i = new BuildStepInput(ctx, {
       id: 'foo',
       stepDisplayName: BuildStep.getDisplayName({ id: 'test1' }),
-      defaultValue: '${ ctx.foo.bar[3].baz.qux }',
+      defaultValue: '${ eas.foo.bar[3].baz.qux }',
       allowedValueTypeName: BuildStepInputValueTypeName.BOOLEAN,
     });
     expect(i.value).toEqual(false);
@@ -175,7 +175,7 @@ describe(BuildStepInput, () => {
     const i = new BuildStepInput(ctx, {
       id: 'foo',
       stepDisplayName: BuildStep.getDisplayName({ id: 'test1' }),
-      defaultValue: '${ ctx.foo }',
+      defaultValue: '${ eas.foo }',
       allowedValueTypeName: BuildStepInputValueTypeName.JSON,
     });
     expect(i.value).toMatchObject({ bar: [1, 2, 3, { baz: { qux: false } }] });
@@ -201,7 +201,7 @@ describe(BuildStepInput, () => {
     const i = new BuildStepInput(ctx, {
       id: 'foo',
       stepDisplayName: BuildStep.getDisplayName({ id: 'test1' }),
-      defaultValue: '${ ctx.foo.bar[3].baz.qux }',
+      defaultValue: '${ eas.foo.bar[3].baz.qux }',
       allowedValueTypeName: BuildStepInputValueTypeName.NUMBER,
     });
     expect(() => i.value).toThrowError(
@@ -229,7 +229,7 @@ describe(BuildStepInput, () => {
     const i = new BuildStepInput(ctx, {
       id: 'foo',
       stepDisplayName: BuildStep.getDisplayName({ id: 'test1' }),
-      defaultValue: '${ ctx.foo.bar[3].baz.qux }',
+      defaultValue: '${ eas.foo.bar[3].baz.qux }',
       allowedValueTypeName: BuildStepInputValueTypeName.BOOLEAN,
     });
     expect(() => i.value).toThrowError(
@@ -257,7 +257,7 @@ describe(BuildStepInput, () => {
     const i = new BuildStepInput(ctx, {
       id: 'foo',
       stepDisplayName: BuildStep.getDisplayName({ id: 'test1' }),
-      defaultValue: '${ ctx.foo.bar[3].baz.qux }',
+      defaultValue: '${ eas.foo.bar[3].baz.qux }',
       allowedValueTypeName: BuildStepInputValueTypeName.JSON,
     });
     expect(() => i.value).toThrowError(
@@ -318,7 +318,7 @@ describe(BuildStepInput, () => {
       stepDisplayName: BuildStep.getDisplayName({ id: 'test1' }),
       allowedValueTypeName: BuildStepInputValueTypeName.JSON,
     });
-    i.set('${ ctx.runtimePlatform }');
+    i.set('${ eas.runtimePlatform }');
     expect(() => {
       // eslint-disable-next-line @typescript-eslint/no-unused-expressions
       i.value;
@@ -335,7 +335,7 @@ describe(BuildStepInput, () => {
       stepDisplayName: BuildStep.getDisplayName({ id: 'test1' }),
       allowedValueTypeName: BuildStepInputValueTypeName.NUMBER,
     });
-    i.set('${ ctx.runtimePlatform }');
+    i.set('${ eas.runtimePlatform }');
     expect(() => {
       // eslint-disable-next-line @typescript-eslint/no-unused-expressions
       i.value;
@@ -352,7 +352,7 @@ describe(BuildStepInput, () => {
       stepDisplayName: BuildStep.getDisplayName({ id: 'test1' }),
       allowedValueTypeName: BuildStepInputValueTypeName.BOOLEAN,
     });
-    i.set('${ ctx.runtimePlatform }');
+    i.set('${ eas.runtimePlatform }');
     expect(() => {
       // eslint-disable-next-line @typescript-eslint/no-unused-expressions
       i.value;

--- a/packages/steps/src/__tests__/BuildStepInput-test.ts
+++ b/packages/steps/src/__tests__/BuildStepInput-test.ts
@@ -41,6 +41,17 @@ describe(BuildStepInput, () => {
     expect(i.value).toBe(42);
   });
 
+  test('basic case json', () => {
+    const ctx = createGlobalContextMock();
+    const i = new BuildStepInput(ctx, {
+      id: 'foo',
+      stepDisplayName: BuildStep.getDisplayName({ id: 'test1' }),
+      allowedValueTypeName: BuildStepInputValueTypeName.JSON,
+    });
+    i.set({ foo: 'bar' });
+    expect(i.value).toEqual({ foo: 'bar' });
+  });
+
   test('basic case undefined', () => {
     const ctx = createGlobalContextMock();
     const i = new BuildStepInput(ctx, {
@@ -73,6 +84,27 @@ describe(BuildStepInput, () => {
     expect(i.value).toBe(true);
   });
 
+  test('default value json', () => {
+    const ctx = createGlobalContextMock();
+    const i = new BuildStepInput(ctx, {
+      id: 'foo',
+      stepDisplayName: BuildStep.getDisplayName({ id: 'test1' }),
+      defaultValue: { foo: 'bar' },
+      allowedValueTypeName: BuildStepInputValueTypeName.JSON,
+    });
+    expect(i.value).toEqual({ foo: 'bar' });
+  });
+
+  test('context value string', () => {
+    const ctx = createGlobalContextMock();
+    const i = new BuildStepInput(ctx, {
+      id: 'foo',
+      stepDisplayName: BuildStep.getDisplayName({ id: 'test1' }),
+      defaultValue: '${ ctx.runtimePlatform }',
+    });
+    expect(i.value).toEqual('linux');
+  });
+
   test('default value number', () => {
     const ctx = createGlobalContextMock();
     const i = new BuildStepInput(ctx, {
@@ -101,7 +133,7 @@ describe(BuildStepInput, () => {
     );
   });
 
-  test('enforces correct value type when reading a value', () => {
+  test('enforces correct value type when reading a value - basic', () => {
     const ctx = createGlobalContextMock();
     const i = new BuildStepInput(ctx, {
       id: 'foo',
@@ -110,6 +142,57 @@ describe(BuildStepInput, () => {
       allowedValueTypeName: BuildStepInputValueTypeName.BOOLEAN,
     });
     i.set('bar');
+    expect(() => {
+      // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+      i.value;
+    }).toThrowError(
+      new BuildStepRuntimeError('Input parameter "foo" for step "test1" must be of type "boolean".')
+    );
+  });
+
+  test('enforces correct value type when reading a value - reference json', () => {
+    const ctx = createGlobalContextMock();
+    const i = new BuildStepInput(ctx, {
+      id: 'foo',
+      required: true,
+      stepDisplayName: BuildStep.getDisplayName({ id: 'test1' }),
+      allowedValueTypeName: BuildStepInputValueTypeName.JSON,
+    });
+    i.set('${ ctx.runtimePlatform }');
+    expect(() => {
+      // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+      i.value;
+    }).toThrowError(
+      new BuildStepRuntimeError('Input parameter "foo" for step "test1" must be of type "json".')
+    );
+  });
+
+  test('enforces correct value type when reading a value - reference number', () => {
+    const ctx = createGlobalContextMock();
+    const i = new BuildStepInput(ctx, {
+      id: 'foo',
+      required: true,
+      stepDisplayName: BuildStep.getDisplayName({ id: 'test1' }),
+      allowedValueTypeName: BuildStepInputValueTypeName.NUMBER,
+    });
+    i.set('${ ctx.runtimePlatform }');
+    expect(() => {
+      // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+      i.value;
+    }).toThrowError(
+      new BuildStepRuntimeError('Input parameter "foo" for step "test1" must be of type "number".')
+    );
+  });
+
+  test('enforces correct value type when reading a value - reference boolean', () => {
+    const ctx = createGlobalContextMock();
+    const i = new BuildStepInput(ctx, {
+      id: 'foo',
+      required: true,
+      stepDisplayName: BuildStep.getDisplayName({ id: 'test1' }),
+      allowedValueTypeName: BuildStepInputValueTypeName.BOOLEAN,
+    });
+    i.set('${ ctx.runtimePlatform }');
     expect(() => {
       // eslint-disable-next-line @typescript-eslint/no-unused-expressions
       i.value;

--- a/packages/steps/src/__tests__/BuildWorkflowValidator-test.ts
+++ b/packages/steps/src/__tests__/BuildWorkflowValidator-test.ts
@@ -202,16 +202,16 @@ describe(BuildWorkflowValidator, () => {
     });
     expect(error).toBeInstanceOf(BuildWorkflowError);
     expect((error as BuildWorkflowError).errors[0].message).toBe(
-      'Input parameter "id1" for step "step_id" is set to "123" which is not of type "string" or is not step or context refference.'
+      'Input parameter "id1" for step "step_id" is set to "123" which is not of type "string" or is not step or context reference.'
     );
     expect((error as BuildWorkflowError).errors[1].message).toBe(
-      'Input parameter "id2" for step "step_id" is set to "{"a":1,"b":2}" which is not of type "number" or is not step or context refference.'
+      'Input parameter "id2" for step "step_id" is set to "{"a":1,"b":2}" which is not of type "number" or is not step or context reference.'
     );
     expect((error as BuildWorkflowError).errors[2].message).toBe(
-      'Input parameter "id3" for step "step_id" is set to "abc" which is not of type "json" or is not step or context refference.'
+      'Input parameter "id3" for step "step_id" is set to "abc" which is not of type "json" or is not step or context reference.'
     );
     expect((error as BuildWorkflowError).errors[3].message).toBe(
-      'Input parameter "id6" for step "step_id" is set to "${ wrong.aaa }" which is not of type "number" or is not step or context refference.'
+      'Input parameter "id6" for step "step_id" is set to "${ wrong.aaa }" which is not of type "number" or is not step or context reference.'
     );
   });
   test('output from future step', async () => {

--- a/packages/steps/src/__tests__/BuildWorkflowValidator-test.ts
+++ b/packages/steps/src/__tests__/BuildWorkflowValidator-test.ts
@@ -186,7 +186,7 @@ describe(BuildWorkflowValidator, () => {
             },
             id3: 'abc',
             id4: '${ steps.step_id.output1 }',
-            id5: '${ ctx.job.version.buildNumber }',
+            id5: '${ eas.job.version.buildNumber }',
             id6: '${ wrong.aaa }',
           },
         }),

--- a/packages/steps/src/__tests__/fixtures/functions-file-1.yml
+++ b/packages/steps/src/__tests__/fixtures/functions-file-1.yml
@@ -8,4 +8,15 @@ functions:
       - name: name
         type: string
         allowed_values: [Wojtek, Dominik, Szymon, Brent]
+      - name: test
+        type: number
+        default_value: ${ ctx.job.version.buildNumber }
+      - name: json
+        type: json
+        default_value:
+          property1: value1
+          property2:
+            - value2
+            - value3:
+                property3: value4
     command: echo "Hi, ${ inputs.name }!"

--- a/packages/steps/src/__tests__/fixtures/functions-file-1.yml
+++ b/packages/steps/src/__tests__/fixtures/functions-file-1.yml
@@ -10,7 +10,7 @@ functions:
         allowed_values: [Wojtek, Dominik, Szymon, Brent]
       - name: test
         type: number
-        default_value: ${ ctx.job.version.buildNumber }
+        default_value: ${ eas.job.version.buildNumber }
       - name: json
         type: json
         default_value:

--- a/packages/steps/src/__tests__/fixtures/functions-with-platforms-property.yml
+++ b/packages/steps/src/__tests__/fixtures/functions-with-platforms-property.yml
@@ -13,7 +13,7 @@ functions:
         type: string
       - name: test
         type: boolean
-        default_value: ${ ctx.job.platform }
+        default_value: ${ eas.job.platform }
       - name: test2
         type: json
         default_value:

--- a/packages/steps/src/__tests__/fixtures/functions-with-platforms-property.yml
+++ b/packages/steps/src/__tests__/fixtures/functions-with-platforms-property.yml
@@ -11,5 +11,16 @@ functions:
     inputs:
       - name: name
         type: string
+      - name: test
+        type: boolean
+        default_value: ${ ctx.job.platform }
+      - name: test2
+        type: json
+        default_value:
+          property1: value1
+          property2:
+            - value2
+            - value3:
+                property3: value4
     command: echo "Bye, ${ inputs.name }!"
     supported_platforms: [darwin, linux]

--- a/packages/steps/src/__tests__/fixtures/functions.yml
+++ b/packages/steps/src/__tests__/fixtures/functions.yml
@@ -7,10 +7,17 @@ build:
           ENV2: value2
         inputs:
           name: Dominik
+          build_number: ${ ctx.job.version.buildNumber }
+          json_input:
+            property1: value1
+            property2:
+              - aaa
+              - bbb
     - say_hi:
         name: Hi, Szymon!
         inputs:
           name: Szymon
+          build_number: 122
     - say_hi_wojtek
     - random:
         id: random_number
@@ -27,6 +34,16 @@ functions:
     name: Hi!
     inputs:
       - name
+      - name: build_number
+        type: number
+      - name: json_input
+        type: json
+        default_value:
+          property1: value1
+          property2:
+            - value2
+            - value3:
+                property3: value4
     command: echo "Hi, ${ inputs.name }!"
   say_hi_wojtek:
     name: Hi, Wojtek!

--- a/packages/steps/src/__tests__/fixtures/functions.yml
+++ b/packages/steps/src/__tests__/fixtures/functions.yml
@@ -7,7 +7,7 @@ build:
           ENV2: value2
         inputs:
           name: Dominik
-          build_number: ${ ctx.job.version.buildNumber }
+          build_number: ${ eas.job.version.buildNumber }
           json_input:
             property1: value1
             property2:

--- a/packages/steps/src/__tests__/fixtures/inputs.yml
+++ b/packages/steps/src/__tests__/fixtures/inputs.yml
@@ -8,4 +8,10 @@ build:
           country: Poland
           boolean_value: true
           number_value: 123
+          json_value:
+            property1: value1
+            property2:
+              - value2
+              - value3:
+                  property3: value4
         command: echo "Hi, ${ inputs.name }, ${ inputs.boolean_value }!"

--- a/packages/steps/src/__tests__/fixtures/invalid-functions.yml
+++ b/packages/steps/src/__tests__/fixtures/invalid-functions.yml
@@ -8,4 +8,7 @@ functions:
       - name: name
         type: boolean
         allowed_values: [Wojtek, Dominik, Szymon, Brent]
+      - name: test
+        type: boolean
+        default_value: ${ wrong.job.platform }
     command: echo "Hi, ${ inputs.name }!"

--- a/packages/steps/src/__tests__/utils/context.ts
+++ b/packages/steps/src/__tests__/utils/context.ts
@@ -23,7 +23,7 @@ export class MockContextProvider implements ExternalBuildContextProvider {
     public readonly projectSourceDirectory: string,
     public readonly projectTargetDirectory: string,
     public readonly defaultWorkingDirectory: string,
-    public readonly staticContextContent: Record<string, any>
+    public readonly staticContextContent: Record<string, any> = {}
   ) {}
   public get env(): BuildStepEnv {
     return this._env;

--- a/packages/steps/src/__tests__/utils/context.ts
+++ b/packages/steps/src/__tests__/utils/context.ts
@@ -22,13 +22,14 @@ export class MockContextProvider implements ExternalBuildContextProvider {
     public readonly runtimePlatform: BuildRuntimePlatform,
     public readonly projectSourceDirectory: string,
     public readonly projectTargetDirectory: string,
-    public readonly defaultWorkingDirectory: string
+    public readonly defaultWorkingDirectory: string,
+    public readonly staticContextContent: Record<string, any>
   ) {}
   public get env(): BuildStepEnv {
     return this._env;
   }
   public staticContext(): any {
-    return {};
+    return { ...this.staticContextContent };
   }
   public updateEnv(env: BuildStepEnv): void {
     this._env = env;
@@ -43,6 +44,7 @@ interface BuildContextParams {
   projectSourceDirectory?: string;
   projectTargetDirectory?: string;
   workingDirectory?: string;
+  staticContextContent?: Record<string, any>;
 }
 
 export function createStepContextMock({
@@ -53,6 +55,7 @@ export function createStepContextMock({
   projectSourceDirectory,
   projectTargetDirectory,
   workingDirectory,
+  staticContextContent,
 }: BuildContextParams = {}): BuildStepContext {
   const globalCtx = createGlobalContextMock({
     buildId,
@@ -62,6 +65,7 @@ export function createStepContextMock({
     projectSourceDirectory,
     projectTargetDirectory,
     workingDirectory,
+    staticContextContent,
   });
   return new BuildStepContext(globalCtx, {
     logger: logger ?? createMockLogger(),
@@ -76,6 +80,7 @@ export function createGlobalContextMock({
   projectSourceDirectory,
   projectTargetDirectory,
   workingDirectory,
+  staticContextContent,
 }: BuildContextParams = {}): BuildStepGlobalContext {
   const resolvedProjectTargetDirectory =
     projectTargetDirectory ?? path.join(os.tmpdir(), 'eas-build', uuidv4());
@@ -85,7 +90,8 @@ export function createGlobalContextMock({
       runtimePlatform ?? BuildRuntimePlatform.LINUX,
       projectSourceDirectory ?? '/non/existent/dir',
       resolvedProjectTargetDirectory,
-      workingDirectory ?? resolvedProjectTargetDirectory
+      workingDirectory ?? resolvedProjectTargetDirectory,
+      staticContextContent ?? {}
     ),
     skipCleanup ?? false
   );

--- a/packages/steps/src/utils/__tests__/template-test.ts
+++ b/packages/steps/src/utils/__tests__/template-test.ts
@@ -37,11 +37,11 @@ describe(interpolateWithOutputs, () => {
 describe(interpolateWithGlobalContext, () => {
   test('interpolation', () => {
     const result = interpolateWithGlobalContext(
-      'foo${ ctx.prop1.prop2.prop3.value4 }${ ctx.prop1.prop2.prop3.value5 }',
+      'foo${ eas.prop1.prop2.prop3.value4 }${ eas.prop1.prop2.prop3.value5 }',
       (path) => {
-        if (path === 'ctx.prop1.prop2.prop3.value4') {
+        if (path === 'eas.prop1.prop2.prop3.value4') {
           return 'bar';
-        } else if (path === 'ctx.prop1.prop2.prop3.value5') {
+        } else if (path === 'eas.prop1.prop2.prop3.value5') {
           return 'baz';
         } else {
           return 'x';
@@ -91,10 +91,12 @@ describe(parseOutputPath, () => {
 
 describe(getObjectValueForInterpolation, () => {
   it('string property', () => {
-    const result = getObjectValueForInterpolation('ctx.foo.bar.baz', {
-      foo: {
-        bar: {
-          baz: 'qux',
+    const result = getObjectValueForInterpolation('eas.foo.bar.baz', {
+      eas: {
+        foo: {
+          bar: {
+            baz: 'qux',
+          },
         },
       },
     });
@@ -102,10 +104,12 @@ describe(getObjectValueForInterpolation, () => {
   });
 
   it('number property', () => {
-    const result = getObjectValueForInterpolation('ctx.foo.bar.baz[0]', {
-      foo: {
-        bar: {
-          baz: [1, 2, 3],
+    const result = getObjectValueForInterpolation('eas.foo.bar.baz[0]', {
+      eas: {
+        foo: {
+          bar: {
+            baz: [1, 2, 3],
+          },
         },
       },
     });
@@ -113,16 +117,18 @@ describe(getObjectValueForInterpolation, () => {
   });
 
   it('boolean property', () => {
-    const result = getObjectValueForInterpolation('ctx.foo.bar.baz[2].qux', {
-      foo: {
-        bar: {
-          baz: [
-            true,
-            false,
-            {
-              qux: true,
-            },
-          ],
+    const result = getObjectValueForInterpolation('eas.foo.bar.baz[2].qux', {
+      eas: {
+        foo: {
+          bar: {
+            baz: [
+              true,
+              false,
+              {
+                qux: true,
+              },
+            ],
+          },
         },
       },
     });
@@ -131,45 +137,49 @@ describe(getObjectValueForInterpolation, () => {
 
   it('invalid property 1', () => {
     const error = getError<BuildConfigError>(() => {
-      getObjectValueForInterpolation('ctx.bar', {
-        foo: {
-          bar: {
-            baz: [
-              true,
-              false,
-              {
-                qux: true,
-              },
-            ],
+      getObjectValueForInterpolation('eas.bar', {
+        eas: {
+          foo: {
+            bar: {
+              baz: [
+                true,
+                false,
+                {
+                  qux: true,
+                },
+              ],
+            },
           },
         },
       });
     });
     expect(error).toBeInstanceOf(BuildStepRuntimeError);
     expect(error.message).toMatch(
-      /Object field "ctx.bar" does not exist. Ensure you are using the correct field name./
+      /Object field "eas.bar" does not exist. Ensure you are using the correct field name./
     );
   });
 
   it('invalid property 2', () => {
     const error = getError<BuildConfigError>(() => {
-      getObjectValueForInterpolation('ctx.foo.bar.baz[14].qux', {
-        foo: {
-          bar: {
-            baz: [
-              true,
-              false,
-              {
-                qux: true,
-              },
-            ],
+      getObjectValueForInterpolation('eas.foo.bar.baz[14].qux', {
+        eas: {
+          foo: {
+            bar: {
+              baz: [
+                true,
+                false,
+                {
+                  qux: true,
+                },
+              ],
+            },
           },
         },
       });
     });
     expect(error).toBeInstanceOf(BuildStepRuntimeError);
     expect(error.message).toMatch(
-      /Object field "ctx.foo.bar.baz\[14\].qux" does not exist. Ensure you are using the correct field name./
+      /Object field "eas.foo.bar.baz\[14\].qux" does not exist. Ensure you are using the correct field name./
     );
   });
 });

--- a/packages/steps/src/utils/template.ts
+++ b/packages/steps/src/utils/template.ts
@@ -8,6 +8,7 @@ import { nullthrows } from './nullthrows.js';
 export const BUILD_STEP_INPUT_EXPRESSION_REGEXP = /\${\s*(inputs\.[\S]+)\s*}/;
 export const BUILD_STEP_OUTPUT_EXPRESSION_REGEXP = /\${\s*(steps\.[\S]+)\s*}/;
 export const BUILD_GLOBAL_CONTEXT_EXPRESSION_REGEXP = /\${\s*(ctx\.[\S]+)\s*}/;
+export const BUILD_STEP_OR_BUILD_GLOBAL_CONTEXT_REFERENCE_REGEX = /\${\s*((steps|ctx)\.[\S]+)\s*}/;
 
 export function interpolateWithInputs(
   templateString: string,

--- a/packages/steps/src/utils/template.ts
+++ b/packages/steps/src/utils/template.ts
@@ -7,8 +7,8 @@ import { nullthrows } from './nullthrows.js';
 
 export const BUILD_STEP_INPUT_EXPRESSION_REGEXP = /\${\s*(inputs\.[\S]+)\s*}/;
 export const BUILD_STEP_OUTPUT_EXPRESSION_REGEXP = /\${\s*(steps\.[\S]+)\s*}/;
-export const BUILD_GLOBAL_CONTEXT_EXPRESSION_REGEXP = /\${\s*(ctx\.[\S]+)\s*}/;
-export const BUILD_STEP_OR_BUILD_GLOBAL_CONTEXT_REFERENCE_REGEX = /\${\s*((steps|ctx)\.[\S]+)\s*}/;
+export const BUILD_GLOBAL_CONTEXT_EXPRESSION_REGEXP = /\${\s*(eas\.[\S]+)\s*}/;
+export const BUILD_STEP_OR_BUILD_GLOBAL_CONTEXT_REFERENCE_REGEX = /\${\s*((steps|eas)\.[\S]+)\s*}/;
 
 export function interpolateWithInputs(
   templateString: string,
@@ -25,22 +25,20 @@ export function interpolateWithOutputs(
 }
 
 export function getObjectValueForInterpolation(
-  pathWithObjectName: string,
+  path: string,
   obj: Record<string, any>
 ): string | number | boolean | null {
-  const value = get(obj, pathWithObjectName.split('.').slice(1).join('.'));
+  const value = get(obj, path);
 
   if (value === undefined) {
     throw new BuildStepRuntimeError(
-      `Object field "${pathWithObjectName}" does not exist. Ensure you are using the correct field name.`
+      `Object field "${path}" does not exist. Ensure you are using the correct field name.`
     );
   }
 
   if (!isAllowedValueTypeForObjectInterpolation(value)) {
     throw new BuildStepRuntimeError(
-      `EAS context field "${pathWithObjectName}" is not of type ${Object.values(
-        BuildStepInputValueTypeName
-      ).join(
+      `EAS context field "${path}" is not of type ${Object.values(BuildStepInputValueTypeName).join(
         ', '
       )}, or undefined. It is of type "${typeof value}". We currently only support accessing string or undefined values from the EAS context.`
     );

--- a/packages/steps/src/utils/template.ts
+++ b/packages/steps/src/utils/template.ts
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import get from 'lodash.get';
 
 import { BuildStepInputValueTypeName } from '../BuildStepInput.js';
 import { BuildConfigError, BuildStepRuntimeError } from '../errors.js';
@@ -24,23 +24,22 @@ export function interpolateWithOutputs(
 }
 
 export function getObjectValueForInterpolation(
-  path: string,
+  pathWithObjectName: string,
   obj: Record<string, any>
-): string | number | boolean | undefined | null {
-  const arrPath = _.toPath(path.split('.').slice(1).join('.'));
+): string | number | boolean | null {
+  const value = get(obj, pathWithObjectName.split('.').slice(1).join('.'));
 
-  let value = obj as any;
-  for (const key of arrPath) {
-    if (typeof value !== 'object' || (typeof value === 'object' && !(key in value))) {
-      throw new BuildStepRuntimeError(
-        `Object field "${path}" does not exist. Ensure you are using the correct field name.`
-      );
-    }
-    value = value[key];
+  if (value === undefined) {
+    throw new BuildStepRuntimeError(
+      `Object field "${pathWithObjectName}" does not exist. Ensure you are using the correct field name.`
+    );
   }
+
   if (!isAllowedValueTypeForObjectInterpolation(value)) {
     throw new BuildStepRuntimeError(
-      `EAS context field "${path}" is not of type ${Object.values(BuildStepInputValueTypeName).join(
+      `EAS context field "${pathWithObjectName}" is not of type ${Object.values(
+        BuildStepInputValueTypeName
+      ).join(
         ', '
       )}, or undefined. It is of type "${typeof value}". We currently only support accessing string or undefined values from the EAS context.`
     );
@@ -80,10 +79,9 @@ function interpolate(
 
 function isAllowedValueTypeForObjectInterpolation(
   value: any
-): value is string | undefined | number | boolean | object | null {
+): value is string | number | boolean | object | null {
   return (
     typeof value === 'string' ||
-    typeof value === 'undefined' ||
     typeof value === 'number' ||
     typeof value === 'boolean' ||
     typeof value === 'object' ||
@@ -105,11 +103,11 @@ export function findOutputPaths(templateString: string): BuildOutputPath[] {
   return result;
 }
 
-export function parseOutputPath(outputPath: string): BuildOutputPath {
-  const splits = outputPath.split('.').slice(1);
+export function parseOutputPath(outputPathWithObjectName: string): BuildOutputPath {
+  const splits = outputPathWithObjectName.split('.').slice(1);
   if (splits.length !== 2) {
     throw new BuildConfigError(
-      `Step output path must consist of two components joined with a dot, where first is the step ID, and second is the output name, e.g. "step3.output1". Passed: "${outputPath}"`
+      `Step output path must consist of two components joined with a dot, where first is the step ID, and second is the output name, e.g. "step3.output1". Passed: "${outputPathWithObjectName}"`
     );
   }
   const [stepId, outputId] = splits;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2225,6 +2225,13 @@
   dependencies:
     "@types/node" "*"
 
+"@types/lodash.get@^4.4.7":
+  version "4.4.7"
+  resolved "https://registry.yarnpkg.com/@types/lodash.get/-/lodash.get-4.4.7.tgz#1ea63d8b94709f6bc9e231f252b31440abe312cf"
+  integrity sha512-af34Mj+KdDeuzsJBxc/XeTtOx0SZHZNLd+hdrn+PcKGQs0EG2TJTzQAOTCZTgDJCArahlCzLWSy8c2w59JRz7Q==
+  dependencies:
+    "@types/lodash" "*"
+
 "@types/lodash.template@^4.5.1":
   version "4.5.1"
   resolved "https://registry.yarnpkg.com/@types/lodash.template/-/lodash.template-4.5.1.tgz#3a2325e02963ca8aced4a657598ac26816340d83"
@@ -2241,11 +2248,6 @@
   version "4.14.191"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.191.tgz#09511e7f7cba275acd8b419ddac8da9a6a79e2fa"
   integrity sha512-BdZ5BCCvho3EIXw6wUCXHe7rS53AIDPLE+JzwgT+OsJk53oBfbSmZZ7CX4VaRoN78N+TJpFi9QPlfIVNmJYWxQ==
-
-"@types/lodash@^4.14.195":
-  version "4.14.195"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.195.tgz#bafc975b252eb6cea78882ce8a7b6bf22a6de632"
-  integrity sha512-Hwx9EUgdwf2GLarOjQp5ZH8ZmblzcbTBC2wtQWNKARBSxM9ezRIAUpeDTgoQRAFB0+8CNWXVA9+MaSOzOF3nPg==
 
 "@types/minimatch@^3.0.3":
   version "3.0.5"
@@ -6078,6 +6080,11 @@ lodash.debounce@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
   integrity sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==
+
+lodash.get@^4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
+  integrity sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==
 
 lodash.ismatch@^4.4.0:
   version "4.4.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2242,6 +2242,11 @@
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.191.tgz#09511e7f7cba275acd8b419ddac8da9a6a79e2fa"
   integrity sha512-BdZ5BCCvho3EIXw6wUCXHe7rS53AIDPLE+JzwgT+OsJk53oBfbSmZZ7CX4VaRoN78N+TJpFi9QPlfIVNmJYWxQ==
 
+"@types/lodash@^4.14.195":
+  version "4.14.195"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.195.tgz#bafc975b252eb6cea78882ce8a7b6bf22a6de632"
+  integrity sha512-Hwx9EUgdwf2GLarOjQp5ZH8ZmblzcbTBC2wtQWNKARBSxM9ezRIAUpeDTgoQRAFB0+8CNWXVA9+MaSOzOF3nPg==
+
 "@types/minimatch@^3.0.3":
   version "3.0.5"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.5.tgz#1001cc5e6a3704b83c236027e77f2f58ea010f40"


### PR DESCRIPTION
# Why

Add support for `json` input type and inputs.
Add support for interpolating global context into inputs and commands.

# How

Allow for `json` inputs and interpolating global context values.
```yaml
build:
  name: Functions
  steps:
    - say_hi:
        env:
          ENV1: value1
          ENV2: value2
        inputs:
          name: Dominik
          build_number: ${ eas.job.version.buildNumber }
          json_input:
            property1: value1
            property2:
              - aaa
              - bbb

functions:
  say_hi:
    name: Hi!
    inputs:
      - name
      - name: build_number
        type: number
      - name: json_input
        type: json
        default_value:
          property1: value1
          property2:
            - value2
            - value3:
                property3: value4
```

Interpolated context input values are parsed to a correct type specified in the `type` property

# Test Plan

Added automated tests
