### PR TITLE
[build-tools] cleanup logs for artifact upload

### DIFF
--- a/packages/build-tools/src/utils/artifacts.ts
+++ b/packages/build-tools/src/utils/artifacts.ts
@@ -62,7 +62,8 @@ export async function maybeFindAndUploadBuildArtifacts(
         )
       )
     ).flat();
-    logger.info(`Uploading build artifacts: ${buildArtifacts.join(', ')}`);
+    logger.info(`Build artifacts: ${buildArtifacts.join(', ')}`);
+    logger.info('Uploading build artifacts...');
     await ctx.uploadArtifacts(ArtifactType.BUILD_ARTIFACTS, buildArtifacts, logger);
   } catch (err: any) {
     logger.error({ err }, 'Failed to upload build artifacts');
@@ -83,5 +84,6 @@ export async function uploadApplicationArchive(
 ): Promise<void> {
   const applicationArchives = await findArtifacts(rootDir, patternOrPath, logger);
   logger.info(`Application archives: ${applicationArchives.join(', ')}`);
+  logger.info('Uploading application archive...');
   await ctx.uploadArtifacts(ArtifactType.APPLICATION_ARCHIVE, applicationArchives, logger);
 }


### PR DESCRIPTION
# Why

For the regular build, we are currently printing list artifacts/archives and ln the worker code there is a log "Uploading build artifacts/application archive..."

In a recent PR I refactored the code to upload concurrently which is printing "Uploading ..." before it starts to upload everything, but those logs from workers still show up.

# How

- Move logs from worker to build-tools (I'll remove them from worker code after this is published)

# Test Plan

not tested