### PR TITLE
[build-tools] [ENG-8506] Export properties

### DIFF
--- a/packages/build-tools/src/index.ts
+++ b/packages/build-tools/src/index.ts
@@ -12,3 +12,5 @@ export {
 } from './context';
 
 export { findAndUploadXcodeBuildLogsAsync } from './ios/xcodeBuildLogs';
+
+export { Hook, runHookIfPresent } from './utils/hooks';


### PR DESCRIPTION
Hooks and runHookIfPresent need to be used by the worker, and they need to be exported

See: https://linear.app/expo/issue/ENG-8506/attempt-to-upload-xcode-logs-when-build-fails-for-unexpected-reason-or

# Why

I forgot to export them in the previous PR

# How

Added exports to index.ts

# Test Plan

No tests