### PR TITLE
[ENG-8521][eas-build] Add hardware resource specification

### DIFF
--- a/public/resource-specs/current.json
+++ b/public/resource-specs/current.json
@@ -1,0 +1,112 @@
+{
+    "hardware": {
+        "gcp-n2-standard-4": {
+            "name": "n2-standard-4",
+            "cpu": "4 CPU",
+            "memory": "16 GB RAM",
+            "description": "n2-standard-4 Google Cloud machine type"
+        },
+        "gcp-n2-standard-8": {
+            "name": "n2-standard-8",
+            "cpu": "8 CPU",
+            "memory": "32 GB RAM",
+            "description": "n2-standard-8 Google Cloud machine type"
+        },
+        "apple-intel": {
+            "name": "Apple Intel",
+            "cpu": "Intel(R) Core(TM) i7-8700B CPU",
+            "memory": "64 GB RAM",
+            "description": "6 cores/12 threads"
+        },
+        "apple-m1": {
+            "name": "Apple M1",
+            "cpu": "M1 3.2GHz 8-Core",
+            "memory": "16 GB RAM",
+            "description": "4 performance and 4 efficiency cores"
+        },
+        "apple-m2": {
+            "name": "Apple M2",
+            "cpu": "M2 3.4GHz 12-Core ",
+            "memory": "24 GB RAM",
+            "description": "8 performance and 4 efficiency cores"
+        },
+        "apple-m2-pro": {
+            "name": "Apple M2 Pro",
+            "cpu": "M2 Pro 3.4GHz 10-Core",
+            "memory": "32 GB RAM",
+            "description": "6 performance and 4 efficiency cores"
+        }
+    },
+    "vm": {
+        "apple-0": {
+            "cpu": "3 cores",
+            "memory": "12 GB RAM"
+        },
+        "apple-1": {
+            "cpu": "2 cores",
+            "memory": "8 GB RAM"
+        },
+        "apple-2": {
+            "cpu": "4 cores",
+            "memory": "12 GB RAM"
+        },
+        "apple-3": {
+            "cpu": "4 cores",
+            "memory": "22 GB RAM"
+        }
+    },
+    "resources": {
+        "ios": {
+            "intel-medium": {
+                "name": "Intel Medium",
+                "symbol": "intel-medium",
+                "hardware": {
+                    "apple-intel": {
+                        "vm": "apple-0",
+                        "extra": "2 builder VMs per host"
+                    }
+                }
+            },
+            "medium": {
+                "name": "Medium",
+                "symbol": "m-medium",
+                "hardware": {
+                    "apple-m1": {
+                        "vm": "apple-1",
+                        "extra": "2 builder VMs per host"
+                    }
+                }
+            },
+            "large": {
+                "name": "Large",
+                "symbol": "large",
+                "hardware": {
+                    "apple-m2": {
+                        "vm": "apple-2",
+                        "extra": "2 builder VMs per host"
+                    },
+                    "apple-m2-pro": {
+                        "vm": "apple-3",
+                        "extra": "1 builder VMs per host"
+                    }
+                }
+            }
+        },
+        "android": {
+            "medium": {
+                "name": "Medium",
+                "symbol": "medium",
+                "hardware": {
+                    "gcp-n2-standard-4": {}
+                }
+            },
+            "large": {
+                "name": "Large",
+                "symbol": "large",
+                "hardware": {
+                    "gcp-n2-standard-8": {}
+                }
+            }
+        }
+    }
+}

--- a/public/resource-specs/current.json
+++ b/public/resource-specs/current.json
@@ -26,7 +26,7 @@
         },
         "apple-m2": {
             "name": "Apple M2",
-            "cpu": "M2 3.4GHz 12-Core ",
+            "cpu": "M2 3.4GHz 12-Core",
             "memory": "24 GB RAM",
             "description": "8 performance and 4 efficiency cores"
         },


### PR DESCRIPTION
# Why

We should have one source of truth when defining available hardware resources.

# How

Added public file with JSON specification of available machines.

# Deploy Plan

1. https://github.com/expo/eas-build/pull/250
2. https://github.com/expo/expo/pull/22601
3. https://github.com/expo/universe/pull/12701