### PR TITLE
[ENG-9477][build-tools] implement `eas/configure-eas-update-if-installed` function

### DIFF
--- a/packages/build-tools/src/steps/easFunctions.ts
+++ b/packages/build-tools/src/steps/easFunctions.ts
@@ -12,6 +12,7 @@ import { createRunGradleBuildFunction } from './functions/utils/runGradle';
 import { createPrebuildBuildFunction } from './functions/eas/prebuild';
 import { createBuildReactNativeAppBuildFunction } from './functions/eas/buildReactNativeApp';
 import { createFindAndUploadBuildArtifactsBuildFunction } from './functions/eas/findAndUploadBuildArtifacts';
+import { configureExpoUpdatesIfInstalledFunction } from './functions/eas/configureExpoUpdatesIfInstalled';
 
 export function getEasFunctions(
   ctx: CustomBuildContext,
@@ -26,5 +27,6 @@ export function getEasFunctions(
     createRunGradleBuildFunction(oldCtx),
     createBuildReactNativeAppBuildFunction(oldCtx),
     createFindAndUploadBuildArtifactsBuildFunction(ctx),
+    configureExpoUpdatesIfInstalledFunction(),
   ];
 }

--- a/packages/build-tools/src/steps/easFunctions.ts
+++ b/packages/build-tools/src/steps/easFunctions.ts
@@ -12,7 +12,7 @@ import { createRunGradleBuildFunction } from './functions/utils/runGradle';
 import { createPrebuildBuildFunction } from './functions/eas/prebuild';
 import { createBuildReactNativeAppBuildFunction } from './functions/eas/buildReactNativeApp';
 import { createFindAndUploadBuildArtifactsBuildFunction } from './functions/eas/findAndUploadBuildArtifacts';
-import { configureExpoUpdatesIfInstalledFunction } from './functions/eas/configureExpoUpdatesIfInstalled';
+import { configureEASUpdateIfInstalledFunction } from './functions/eas/configureExpoUpdatesIfInstalled';
 
 export function getEasFunctions(
   ctx: CustomBuildContext,
@@ -27,6 +27,6 @@ export function getEasFunctions(
     createRunGradleBuildFunction(oldCtx),
     createBuildReactNativeAppBuildFunction(oldCtx),
     createFindAndUploadBuildArtifactsBuildFunction(ctx),
-    configureExpoUpdatesIfInstalledFunction(),
+    configureEASUpdateIfInstalledFunction(),
   ];
 }

--- a/packages/build-tools/src/steps/functions/eas/configureExpoUpdatesIfInstalled.ts
+++ b/packages/build-tools/src/steps/functions/eas/configureExpoUpdatesIfInstalled.ts
@@ -5,13 +5,13 @@ import { Job } from '@expo/eas-build-job';
 import semver from 'semver';
 
 import { readAppConfig } from '../../../utils/appConfig';
-import { configureExpoUpdatesIfInstalledAsync } from '../../utils/expoUpdates';
+import { configureEASUpdateIfInstalledAsync } from '../../utils/expoUpdates';
 
-export function configureExpoUpdatesIfInstalledFunction(): BuildFunction {
+export function configureEASUpdateIfInstalledFunction(): BuildFunction {
   return new BuildFunction({
     namespace: 'eas',
-    id: 'configure_expo_updates_if_installed',
-    name: 'Configure Expo Updates if installed',
+    id: 'configure_eas_update_if_installed',
+    name: 'Configure EAS Update if installed',
     inputProviders: [
       BuildStepInput.createProvider({
         id: 'runtime_version',
@@ -45,7 +45,7 @@ export function configureExpoUpdatesIfInstalledFunction(): BuildFunction {
         );
       }
 
-      await configureExpoUpdatesIfInstalledAsync({
+      await configureEASUpdateIfInstalledAsync({
         job,
         workingDirectory: stepCtx.workingDirectory,
         logger: stepCtx.logger,

--- a/packages/build-tools/src/steps/functions/eas/configureExpoUpdatesIfInstalled.ts
+++ b/packages/build-tools/src/steps/functions/eas/configureExpoUpdatesIfInstalled.ts
@@ -1,0 +1,60 @@
+import assert from 'assert';
+
+import { BuildFunction, BuildStepInput, BuildStepInputValueTypeName } from '@expo/steps';
+import { Job } from '@expo/eas-build-job';
+import semver from 'semver';
+
+import { readAppConfig } from '../../../utils/appConfig';
+import { configureExpoUpdatesIfInstalledAsync } from '../../utils/expoUpdates';
+
+export function configureExpoUpdatesIfInstalledFunction(): BuildFunction {
+  return new BuildFunction({
+    namespace: 'eas',
+    id: 'configure_expo_updates_if_installed',
+    name: 'Configure Expo Updates if installed',
+    inputProviders: [
+      BuildStepInput.createProvider({
+        id: 'runtime_version',
+        required: false,
+        allowedValueTypeName: BuildStepInputValueTypeName.STRING,
+      }),
+      BuildStepInput.createProvider({
+        id: 'channel',
+        required: false,
+        allowedValueTypeName: BuildStepInputValueTypeName.STRING,
+      }),
+    ],
+    fn: async (stepCtx, { env, inputs }) => {
+      assert(stepCtx.global.staticContext.job, 'Job is not defined');
+      const job = stepCtx.global.staticContext.job as Job;
+
+      const appConfig = readAppConfig(
+        stepCtx.workingDirectory,
+        Object.keys(env).reduce((acc, key) => {
+          acc[key] = env[key] ?? '';
+          return acc;
+        }, {} as Record<string, string>),
+        stepCtx.logger
+      ).exp;
+
+      const releaseChannelInput = inputs.channel.value as string | undefined;
+      const runtimeVersionInput = inputs.runtime_version.value as string | undefined;
+      if (runtimeVersionInput && !semver.valid(runtimeVersionInput)) {
+        throw new Error(
+          `Runtime version provided by the "runtime_version" input is not a valid semver version: ${releaseChannelInput}`
+        );
+      }
+
+      await configureExpoUpdatesIfInstalledAsync({
+        job,
+        workingDirectory: stepCtx.workingDirectory,
+        logger: stepCtx.logger,
+        appConfig,
+        inputs: {
+          runtimeVersion: runtimeVersionInput,
+          channel: releaseChannelInput,
+        },
+      });
+    },
+  });
+}

--- a/packages/build-tools/src/steps/utils/__tests__/expoUpdates.test.ts
+++ b/packages/build-tools/src/steps/utils/__tests__/expoUpdates.test.ts
@@ -1,0 +1,132 @@
+import { Platform, Job } from '@expo/eas-build-job';
+import { createLogger } from '@expo/logger';
+import { ExpoConfig } from '@expo/config';
+
+import { configureExpoUpdatesIfInstalledAsync } from '../expoUpdates';
+import isExpoUpdatesInstalledAsync from '../../../utils/isExpoUpdatesInstalled';
+import { androidSetChannelNativelyAsync } from '../android/expoUpdates';
+import { iosSetChannelNativelyAsync } from '../ios/expoUpdates';
+
+jest.mock('../../../utils/isExpoUpdatesInstalled', () => jest.fn());
+jest.mock('../ios/expoUpdates');
+jest.mock('../android/expoUpdates');
+jest.mock('fs');
+
+describe(configureExpoUpdatesIfInstalledAsync, () => {
+  beforeAll(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('aborts if expo-updates is not installed', async () => {
+    (isExpoUpdatesInstalledAsync as jest.Mock).mockReturnValue(false);
+
+    await configureExpoUpdatesIfInstalledAsync({
+      job: { platform: Platform.IOS } as unknown as Job,
+      workingDirectory: '/app',
+      logger: createLogger({
+        name: 'test',
+      }),
+      appConfig: {} as unknown as ExpoConfig,
+      inputs: {},
+    });
+
+    expect(androidSetChannelNativelyAsync).not.toBeCalled();
+    expect(iosSetChannelNativelyAsync).not.toBeCalled();
+    expect(isExpoUpdatesInstalledAsync).toBeCalledTimes(1);
+  });
+
+  it('aborts if updates.url (app config) is set but updates.channel (eas.json) is not', async () => {
+    (isExpoUpdatesInstalledAsync as jest.Mock).mockReturnValue(true);
+
+    await configureExpoUpdatesIfInstalledAsync({
+      job: { platform: Platform.IOS } as unknown as Job,
+      workingDirectory: '/app',
+      logger: createLogger({
+        name: 'test',
+      }),
+      appConfig: {
+        updates: {
+          url: 'https://u.expo.dev/blahblah',
+        },
+      } as unknown as ExpoConfig,
+      inputs: {},
+    });
+
+    expect(androidSetChannelNativelyAsync).not.toBeCalled();
+    expect(iosSetChannelNativelyAsync).not.toBeCalled();
+    expect(isExpoUpdatesInstalledAsync).toBeCalledTimes(1);
+  });
+
+  it('configures for EAS if updates.channel (eas.json) and updates.url (app config) are set', async () => {
+    (isExpoUpdatesInstalledAsync as jest.Mock).mockReturnValue(true);
+
+    await configureExpoUpdatesIfInstalledAsync({
+      job: {
+        updates: {
+          channel: 'main',
+        },
+        platform: Platform.IOS,
+      } as unknown as Job,
+      workingDirectory: '/app',
+      logger: createLogger({
+        name: 'test',
+      }),
+      appConfig: {
+        updates: {
+          url: 'https://u.expo.dev/blahblah',
+        },
+      } as unknown as ExpoConfig,
+      inputs: {},
+    });
+
+    expect(androidSetChannelNativelyAsync).not.toBeCalled();
+    expect(iosSetChannelNativelyAsync).toBeCalledTimes(1);
+    expect(isExpoUpdatesInstalledAsync).toBeCalledTimes(1);
+  });
+
+  it('configures for EAS if the updates.channel and releaseChannel are both set', async () => {
+    (isExpoUpdatesInstalledAsync as jest.Mock).mockReturnValue(true);
+
+    await configureExpoUpdatesIfInstalledAsync({
+      job: {
+        updates: { channel: 'main' },
+        releaseChannel: 'default',
+        platform: Platform.IOS,
+      } as unknown as Job,
+      workingDirectory: '/app',
+      logger: createLogger({
+        name: 'test',
+      }),
+      appConfig: {
+        updates: {
+          url: 'https://u.expo.dev/blahblah',
+        },
+      } as unknown as ExpoConfig,
+      inputs: {},
+    });
+
+    expect(androidSetChannelNativelyAsync).not.toBeCalled();
+    expect(iosSetChannelNativelyAsync).toBeCalledTimes(1);
+    expect(isExpoUpdatesInstalledAsync).toBeCalledTimes(1);
+  });
+
+  it('configures for classic updates if the updates.channel and releaseChannel fields (eas.json) are not set, and updates.url (app config) is not set', async () => {
+    (isExpoUpdatesInstalledAsync as jest.Mock).mockReturnValue(true);
+
+    await configureExpoUpdatesIfInstalledAsync({
+      job: { platform: Platform.IOS } as unknown as Job,
+      workingDirectory: '/app',
+      logger: createLogger({
+        name: 'test',
+      }),
+      appConfig: {
+        updates: {},
+      } as unknown as ExpoConfig,
+      inputs: {},
+    });
+
+    expect(androidSetChannelNativelyAsync).not.toBeCalled();
+    expect(iosSetChannelNativelyAsync).not.toBeCalled();
+    expect(isExpoUpdatesInstalledAsync).toBeCalledTimes(1);
+  });
+});

--- a/packages/build-tools/src/steps/utils/__tests__/expoUpdates.test.ts
+++ b/packages/build-tools/src/steps/utils/__tests__/expoUpdates.test.ts
@@ -2,7 +2,7 @@ import { Platform, Job } from '@expo/eas-build-job';
 import { createLogger } from '@expo/logger';
 import { ExpoConfig } from '@expo/config';
 
-import { configureExpoUpdatesIfInstalledAsync } from '../expoUpdates';
+import { configureEASUpdateIfInstalledAsync } from '../expoUpdates';
 import isExpoUpdatesInstalledAsync from '../../../utils/isExpoUpdatesInstalled';
 import { androidSetChannelNativelyAsync } from '../android/expoUpdates';
 import { iosSetChannelNativelyAsync } from '../ios/expoUpdates';
@@ -12,7 +12,7 @@ jest.mock('../ios/expoUpdates');
 jest.mock('../android/expoUpdates');
 jest.mock('fs');
 
-describe(configureExpoUpdatesIfInstalledAsync, () => {
+describe(configureEASUpdateIfInstalledAsync, () => {
   beforeAll(() => {
     jest.restoreAllMocks();
   });
@@ -20,7 +20,7 @@ describe(configureExpoUpdatesIfInstalledAsync, () => {
   it('aborts if expo-updates is not installed', async () => {
     (isExpoUpdatesInstalledAsync as jest.Mock).mockReturnValue(false);
 
-    await configureExpoUpdatesIfInstalledAsync({
+    await configureEASUpdateIfInstalledAsync({
       job: { platform: Platform.IOS } as unknown as Job,
       workingDirectory: '/app',
       logger: createLogger({
@@ -38,7 +38,7 @@ describe(configureExpoUpdatesIfInstalledAsync, () => {
   it('aborts if updates.url (app config) is set but updates.channel (eas.json) is not', async () => {
     (isExpoUpdatesInstalledAsync as jest.Mock).mockReturnValue(true);
 
-    await configureExpoUpdatesIfInstalledAsync({
+    await configureEASUpdateIfInstalledAsync({
       job: { platform: Platform.IOS } as unknown as Job,
       workingDirectory: '/app',
       logger: createLogger({
@@ -60,7 +60,7 @@ describe(configureExpoUpdatesIfInstalledAsync, () => {
   it('configures for EAS if updates.channel (eas.json) and updates.url (app config) are set', async () => {
     (isExpoUpdatesInstalledAsync as jest.Mock).mockReturnValue(true);
 
-    await configureExpoUpdatesIfInstalledAsync({
+    await configureEASUpdateIfInstalledAsync({
       job: {
         updates: {
           channel: 'main',
@@ -87,7 +87,7 @@ describe(configureExpoUpdatesIfInstalledAsync, () => {
   it('configures for EAS if the updates.channel and releaseChannel are both set', async () => {
     (isExpoUpdatesInstalledAsync as jest.Mock).mockReturnValue(true);
 
-    await configureExpoUpdatesIfInstalledAsync({
+    await configureEASUpdateIfInstalledAsync({
       job: {
         updates: { channel: 'main' },
         releaseChannel: 'default',
@@ -113,7 +113,7 @@ describe(configureExpoUpdatesIfInstalledAsync, () => {
   it('configures for classic updates if the updates.channel and releaseChannel fields (eas.json) are not set, and updates.url (app config) is not set', async () => {
     (isExpoUpdatesInstalledAsync as jest.Mock).mockReturnValue(true);
 
-    await configureExpoUpdatesIfInstalledAsync({
+    await configureEASUpdateIfInstalledAsync({
       job: { platform: Platform.IOS } as unknown as Job,
       workingDirectory: '/app',
       logger: createLogger({

--- a/packages/build-tools/src/steps/utils/android/__tests__/expoUpdates.test.ts
+++ b/packages/build-tools/src/steps/utils/android/__tests__/expoUpdates.test.ts
@@ -1,0 +1,104 @@
+import path from 'path';
+
+import { vol } from 'memfs';
+import { AndroidConfig } from '@expo/config-plugins';
+
+import {
+  AndroidMetadataName,
+  androidSetChannelNativelyAsync,
+  androidGetNativelyDefinedChannelAsync,
+  androidSetRuntimeVersionNativelyAsync,
+} from '../expoUpdates';
+
+jest.mock('fs');
+const originalFs = jest.requireActual('fs');
+
+const channel = 'easupdatechannel';
+const manifestPath = '/app/android/app/src/main/AndroidManifest.xml';
+
+afterEach(() => {
+  vol.reset();
+});
+
+describe(androidSetChannelNativelyAsync, () => {
+  it('sets the channel', async () => {
+    vol.fromJSON(
+      {
+        'android/app/src/main/AndroidManifest.xml': originalFs.readFileSync(
+          path.join(__dirname, 'fixtures/NoMetadataAndroidManifest.xml'),
+          'utf-8'
+        ),
+      },
+      '/app'
+    );
+
+    await androidSetChannelNativelyAsync(channel, '/app');
+
+    const newAndroidManifest = await AndroidConfig.Manifest.readAndroidManifestAsync(manifestPath);
+    const newValue = AndroidConfig.Manifest.getMainApplicationMetaDataValue(
+      newAndroidManifest,
+      AndroidMetadataName.UPDATES_CONFIGURATION_REQUEST_HEADERS_KEY
+    );
+    expect(newValue).toBeDefined();
+    expect(JSON.parse(newValue!)).toEqual({ 'expo-channel-name': channel });
+  });
+});
+
+describe(androidGetNativelyDefinedChannelAsync, () => {
+  it('gets the channel', async () => {
+    vol.fromJSON(
+      {
+        'android/app/src/main/AndroidManifest.xml': originalFs.readFileSync(
+          path.join(__dirname, 'fixtures/AndroidManifestWithChannel.xml'),
+          'utf-8'
+        ),
+      },
+      '/app'
+    );
+
+    await expect(androidGetNativelyDefinedChannelAsync('/app')).resolves.toBe('staging-123');
+  });
+});
+
+describe(androidSetRuntimeVersionNativelyAsync, () => {
+  it('sets the runtime version when nothing is set natively', async () => {
+    vol.fromJSON(
+      {
+        'android/app/src/main/AndroidManifest.xml': originalFs.readFileSync(
+          path.join(__dirname, 'fixtures/NoMetadataAndroidManifest.xml'),
+          'utf-8'
+        ),
+      },
+      '/app'
+    );
+
+    await androidSetRuntimeVersionNativelyAsync('1.2.3', '/app');
+
+    const newAndroidManifest = await AndroidConfig.Manifest.readAndroidManifestAsync(manifestPath);
+    const newValue = AndroidConfig.Manifest.getMainApplicationMetaDataValue(
+      newAndroidManifest,
+      AndroidMetadataName.RUNTIME_VERSION
+    );
+    expect(newValue).toBe('1.2.3');
+  });
+  it('updates the runtime version when value is already set natively', async () => {
+    vol.fromJSON(
+      {
+        'android/app/src/main/AndroidManifest.xml': originalFs.readFileSync(
+          path.join(__dirname, 'fixtures/AndroidManifestWithRuntimeVersion.xml'),
+          'utf-8'
+        ),
+      },
+      '/app'
+    );
+
+    await androidSetRuntimeVersionNativelyAsync('1.2.3', '/app');
+
+    const newAndroidManifest = await AndroidConfig.Manifest.readAndroidManifestAsync(manifestPath);
+    const newValue = AndroidConfig.Manifest.getMainApplicationMetaDataValue(
+      newAndroidManifest,
+      AndroidMetadataName.RUNTIME_VERSION
+    );
+    expect(newValue).toBe('1.2.3');
+  });
+});

--- a/packages/build-tools/src/steps/utils/android/__tests__/fixtures/AndroidManifestWithChannel.xml
+++ b/packages/build-tools/src/steps/utils/android/__tests__/fixtures/AndroidManifestWithChannel.xml
@@ -1,0 +1,14 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.expo.mycoolapp">
+    <uses-permission android:name="android.permission.INTERNET"/>
+    <application android:name=".MainApplication" android:label="@string/app_name" android:icon="@mipmap/ic_launcher" android:roundIcon="@mipmap/ic_launcher_round" android:allowBackup="true" android:theme="@style/AppTheme">
+        <activity android:name=".MainActivity" android:launchMode="singleTask" android:label="@string/app_name" android:configChanges="keyboard|keyboardHidden|orientation|screenSize" android:windowSoftInputMode="adjustResize">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN"/>
+                <category android:name="android.intent.category.LAUNCHER"/>
+            </intent-filter>
+        </activity>
+        <activity android:name="com.facebook.react.devsupport.DevSettingsActivity"/>
+        <meta-data android:name="expo.modules.updates.EXPO_RELEASE_CHANNEL" android:value="default"/>
+        <meta-data android:name="expo.modules.updates.UPDATES_CONFIGURATION_REQUEST_HEADERS_KEY"  android:value="{&quot;expo-channel-name&quot;:&quot;staging-123&quot;}"/>
+    </application>
+</manifest>

--- a/packages/build-tools/src/steps/utils/android/__tests__/fixtures/AndroidManifestWithRuntimeVersion.xml
+++ b/packages/build-tools/src/steps/utils/android/__tests__/fixtures/AndroidManifestWithRuntimeVersion.xml
@@ -1,0 +1,14 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.expo.mycoolapp">
+    <uses-permission android:name="android.permission.INTERNET"/>
+    <application android:name=".MainApplication" android:label="@string/app_name" android:icon="@mipmap/ic_launcher" android:roundIcon="@mipmap/ic_launcher_round" android:allowBackup="true" android:theme="@style/AppTheme">
+        <activity android:name=".MainActivity" android:launchMode="singleTask" android:label="@string/app_name" android:configChanges="keyboard|keyboardHidden|orientation|screenSize" android:windowSoftInputMode="adjustResize">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN"/>
+                <category android:name="android.intent.category.LAUNCHER"/>
+            </intent-filter>
+        </activity>
+        <activity android:name="com.facebook.react.devsupport.DevSettingsActivity"/>
+        <meta-data android:name="expo.modules.updates.EXPO_RELEASE_CHANNEL" android:value="default"/>
+        <meta-data android:name="expo.modules.updates.EXPO_RUNTIME_VERSION" android:value="exampleruntimeversion"/>
+    </application>
+</manifest>

--- a/packages/build-tools/src/steps/utils/android/__tests__/fixtures/NoMetadataAndroidManifest.xml
+++ b/packages/build-tools/src/steps/utils/android/__tests__/fixtures/NoMetadataAndroidManifest.xml
@@ -1,0 +1,27 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+  package="com.expo.mycoolapp">
+
+    <uses-permission android:name="android.permission.INTERNET" />
+
+    <application
+      android:name=".MainApplication"
+      android:label="@string/app_name"
+      android:icon="@mipmap/ic_launcher"
+      android:roundIcon="@mipmap/ic_launcher_round"
+      android:allowBackup="true"
+      android:theme="@style/AppTheme">
+      <activity
+        android:name=".MainActivity"
+        android:launchMode="singleTask"
+        android:label="@string/app_name"
+        android:configChanges="keyboard|keyboardHidden|orientation|screenSize"
+        android:windowSoftInputMode="adjustResize">
+        <intent-filter>
+            <action android:name="android.intent.action.MAIN" />
+            <category android:name="android.intent.category.LAUNCHER" />
+        </intent-filter>
+      </activity>
+      <activity android:name="com.facebook.react.devsupport.DevSettingsActivity" />
+    </application>
+
+</manifest>

--- a/packages/build-tools/src/steps/utils/android/expoUpdates.ts
+++ b/packages/build-tools/src/steps/utils/android/expoUpdates.ts
@@ -1,0 +1,81 @@
+import { AndroidConfig } from '@expo/config-plugins';
+import fs from 'fs-extra';
+
+export enum AndroidMetadataName {
+  UPDATES_CONFIGURATION_REQUEST_HEADERS_KEY = 'expo.modules.updates.UPDATES_CONFIGURATION_REQUEST_HEADERS_KEY',
+  RELEASE_CHANNEL = 'expo.modules.updates.EXPO_RELEASE_CHANNEL',
+  RUNTIME_VERSION = 'expo.modules.updates.EXPO_RUNTIME_VERSION',
+}
+
+export async function androidSetChannelNativelyAsync(
+  channel: string,
+  workingDirectory: string
+): Promise<void> {
+  const manifestPath = await AndroidConfig.Paths.getAndroidManifestAsync(workingDirectory);
+
+  if (!(await fs.pathExists(manifestPath))) {
+    throw new Error(`Couldn't find Android manifest at ${manifestPath}`);
+  }
+
+  const androidManifest = await AndroidConfig.Manifest.readAndroidManifestAsync(manifestPath);
+  const mainApp = AndroidConfig.Manifest.getMainApplicationOrThrow(androidManifest);
+  const stringifiedUpdatesRequestHeaders = AndroidConfig.Manifest.getMainApplicationMetaDataValue(
+    androidManifest,
+    AndroidMetadataName.UPDATES_CONFIGURATION_REQUEST_HEADERS_KEY
+  );
+  AndroidConfig.Manifest.addMetaDataItemToMainApplication(
+    mainApp,
+    AndroidMetadataName.UPDATES_CONFIGURATION_REQUEST_HEADERS_KEY,
+    JSON.stringify({
+      ...JSON.parse(stringifiedUpdatesRequestHeaders ?? '{}'),
+      'expo-channel-name': channel,
+    }),
+    'value'
+  );
+  await AndroidConfig.Manifest.writeAndroidManifestAsync(manifestPath, androidManifest);
+}
+
+export async function androidSetRuntimeVersionNativelyAsync(
+  runtimeVersion: string,
+  workingDirectory: string
+): Promise<void> {
+  const manifestPath = await AndroidConfig.Paths.getAndroidManifestAsync(workingDirectory);
+
+  if (!(await fs.pathExists(manifestPath))) {
+    throw new Error(`Couldn't find Android manifest at ${manifestPath}`);
+  }
+
+  const androidManifest = await AndroidConfig.Manifest.readAndroidManifestAsync(manifestPath);
+  const mainApp = AndroidConfig.Manifest.getMainApplicationOrThrow(androidManifest);
+  AndroidConfig.Manifest.addMetaDataItemToMainApplication(
+    mainApp,
+    AndroidMetadataName.RUNTIME_VERSION,
+    runtimeVersion,
+    'value'
+  );
+  await AndroidConfig.Manifest.writeAndroidManifestAsync(manifestPath, androidManifest);
+}
+
+export async function androidGetNativelyDefinedChannelAsync(
+  workingDirectory: string
+): Promise<string | null> {
+  const manifestPath = await AndroidConfig.Paths.getAndroidManifestAsync(workingDirectory);
+
+  if (!(await fs.pathExists(manifestPath))) {
+    return null;
+  }
+
+  const androidManifest = await AndroidConfig.Manifest.readAndroidManifestAsync(manifestPath);
+  const stringifiedUpdatesRequestHeaders = AndroidConfig.Manifest.getMainApplicationMetaDataValue(
+    androidManifest,
+    AndroidMetadataName.UPDATES_CONFIGURATION_REQUEST_HEADERS_KEY
+  );
+  try {
+    const updatesRequestHeaders = JSON.parse(stringifiedUpdatesRequestHeaders ?? '{}');
+    return updatesRequestHeaders['expo-channel-name'] ?? null;
+  } catch (err: any) {
+    throw new Error(
+      `Failed to parse ${AndroidMetadataName.UPDATES_CONFIGURATION_REQUEST_HEADERS_KEY} from AndroidManifest.xml: ${err.message}`
+    );
+  }
+}

--- a/packages/build-tools/src/steps/utils/expoUpdates.ts
+++ b/packages/build-tools/src/steps/utils/expoUpdates.ts
@@ -1,0 +1,147 @@
+import { Job, Platform } from '@expo/eas-build-job';
+import { bunyan } from '@expo/logger';
+import { ExpoConfig } from '@expo/config';
+import { getRuntimeVersionNullable } from '@expo/config-plugins/build/utils/Updates';
+
+import isExpoUpdatesInstalledAsync from '../../utils/isExpoUpdatesInstalled';
+
+import {
+  iosGetNativelyDefinedChannelAsync,
+  iosSetChannelNativelyAsync,
+  iosSetRuntimeVersionNativelyAsync,
+} from './ios/expoUpdates';
+import {
+  androidGetNativelyDefinedChannelAsync,
+  androidSetChannelNativelyAsync,
+  androidSetRuntimeVersionNativelyAsync,
+} from './android/expoUpdates';
+
+export async function configureExpoUpdatesIfInstalledAsync({
+  job,
+  workingDirectory,
+  logger,
+  inputs,
+  appConfig,
+}: {
+  job: Job;
+  workingDirectory: string;
+  logger: bunyan;
+  inputs: {
+    runtimeVersion?: string;
+    channel?: string;
+  };
+  appConfig: ExpoConfig;
+}): Promise<void> {
+  if (!(await isExpoUpdatesInstalledAsync(workingDirectory))) {
+    logger.info('Expo Updates is not installed, skipping configuring Expo Updates.');
+  }
+
+  const runtimeVersion =
+    inputs.channel ??
+    job.version?.runtimeVersion ??
+    getRuntimeVersionNullable(appConfig, job.platform);
+
+  const jobOrInputChannel = inputs.runtimeVersion ?? job.updates?.channel;
+
+  if (isEASUpdateConfigured(appConfig, logger)) {
+    const channel = jobOrInputChannel ?? (await getChannelAsync(job, workingDirectory));
+    if (channel) {
+      await configureEASExpoUpdatesAsync(job, logger, channel, workingDirectory);
+    } else {
+      if (job.releaseChannel !== undefined) {
+        logger.warn(
+          `This build is configured with EAS Update however has a Classic Updates releaseChannel set instead of having an EAS Update channel.`
+        );
+      } else {
+        logger.warn(
+          `This build is configured to query EAS Update for updates, however no channel is set.`
+        );
+      }
+    }
+  } else {
+    logger.info(`Expo Updates is not configured, skipping configuring Expo Updates.`);
+  }
+
+  if (runtimeVersion) {
+    logger.info('Updating runtimeVersion in Expo.plist');
+    await setRuntimeVersionNativelyAsync(job, runtimeVersion, workingDirectory);
+  }
+}
+
+export function isEASUpdateConfigured(appConfig: ExpoConfig, logger: bunyan): boolean {
+  const rawUrl = appConfig.updates?.url;
+  if (!rawUrl) {
+    return false;
+  }
+  try {
+    const url = new URL(rawUrl);
+    return ['u.expo.dev', 'staging-u.expo.dev'].includes(url.hostname);
+  } catch (err) {
+    logger.error({ err }, `Cannot parse expo.updates.url = ${rawUrl} as URL`);
+    logger.error(`Assuming EAS Update is not configured`);
+    return false;
+  }
+}
+
+async function configureEASExpoUpdatesAsync(
+  job: Job,
+  logger: bunyan,
+  channel: string,
+  workingDirectory: string
+): Promise<void> {
+  const newUpdateRequestHeaders: Record<string, string> = {
+    'expo-channel-name': channel,
+  };
+
+  const configFile = job.platform === Platform.ANDROID ? 'AndroidManifest.xml' : 'Expo.plist';
+  logger.info(
+    `Setting the update request headers in '${configFile}' to '${JSON.stringify(
+      newUpdateRequestHeaders
+    )}'`
+  );
+
+  switch (job.platform) {
+    case Platform.ANDROID: {
+      await androidSetChannelNativelyAsync(channel, workingDirectory);
+      return;
+    }
+    case Platform.IOS: {
+      await iosSetChannelNativelyAsync(channel, workingDirectory);
+      return;
+    }
+    default:
+      throw new Error(`Platform is not supported.`);
+  }
+}
+
+async function getChannelAsync(job: Job, workingDirectory: string): Promise<string | null> {
+  switch (job.platform) {
+    case Platform.ANDROID: {
+      return await androidGetNativelyDefinedChannelAsync(workingDirectory);
+    }
+    case Platform.IOS: {
+      return await iosGetNativelyDefinedChannelAsync(workingDirectory);
+    }
+    default:
+      throw new Error(`Platform is not supported.`);
+  }
+}
+
+async function setRuntimeVersionNativelyAsync(
+  job: Job,
+  runtimeVersion: string,
+  workingDirectory: string
+): Promise<void> {
+  switch (job.platform) {
+    case Platform.ANDROID: {
+      await androidSetRuntimeVersionNativelyAsync(runtimeVersion, workingDirectory);
+      return;
+    }
+    case Platform.IOS: {
+      await iosSetRuntimeVersionNativelyAsync(runtimeVersion, workingDirectory);
+      return;
+    }
+    default:
+      throw new Error(`Platform is not supported.`);
+  }
+}

--- a/packages/build-tools/src/steps/utils/expoUpdates.ts
+++ b/packages/build-tools/src/steps/utils/expoUpdates.ts
@@ -16,7 +16,7 @@ import {
   androidSetRuntimeVersionNativelyAsync,
 } from './android/expoUpdates';
 
-export async function configureExpoUpdatesIfInstalledAsync({
+export async function configureEASUpdateIfInstalledAsync({
   job,
   workingDirectory,
   logger,
@@ -46,7 +46,7 @@ export async function configureExpoUpdatesIfInstalledAsync({
   if (isEASUpdateConfigured(appConfig, logger)) {
     const channel = jobOrInputChannel ?? (await getChannelAsync(job, workingDirectory));
     if (channel) {
-      await configureEASExpoUpdatesAsync(job, logger, channel, workingDirectory);
+      await configureEASUpdate(job, logger, channel, workingDirectory);
     } else {
       if (job.releaseChannel !== undefined) {
         logger.warn(
@@ -83,7 +83,7 @@ export function isEASUpdateConfigured(appConfig: ExpoConfig, logger: bunyan): bo
   }
 }
 
-async function configureEASExpoUpdatesAsync(
+async function configureEASUpdate(
   job: Job,
   logger: bunyan,
   channel: string,

--- a/packages/build-tools/src/steps/utils/ios/__tests__/expoUpdates.test.ts
+++ b/packages/build-tools/src/steps/utils/ios/__tests__/expoUpdates.test.ts
@@ -1,0 +1,118 @@
+import fs from 'fs-extra';
+import plist from '@expo/plist';
+import { vol } from 'memfs';
+
+import {
+  IosMetadataName,
+  iosSetChannelNativelyAsync,
+  iosGetNativelyDefinedChannelAsync,
+  iosSetRuntimeVersionNativelyAsync,
+} from '../../ios/expoUpdates';
+
+jest.mock('fs');
+
+const expoPlistPath = '/app/ios/testapp/Supporting/Expo.plist';
+const noItemsExpoPlist = `
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+  </dict>
+</plist>`;
+const channel = 'easupdatechannel';
+
+afterEach(() => {
+  vol.reset();
+});
+
+describe(iosSetChannelNativelyAsync, () => {
+  it('sets the channel', async () => {
+    vol.fromJSON(
+      {
+        'ios/testapp/Supporting/Expo.plist': noItemsExpoPlist,
+        'ios/testapp.xcodeproj/project.pbxproj': 'placeholder',
+        'ios/testapp/AppDelegate.m': 'placeholder',
+      },
+      '/app'
+    );
+
+    await iosSetChannelNativelyAsync(channel, '/app');
+
+    const newExpoPlist = await fs.readFile(expoPlistPath, 'utf8');
+    expect(
+      plist.parse(newExpoPlist)[IosMetadataName.UPDATES_CONFIGURATION_REQUEST_HEADERS_KEY]
+    ).toEqual({ 'expo-channel-name': channel });
+  });
+});
+
+describe(iosGetNativelyDefinedChannelAsync, () => {
+  it('gets the channel', async () => {
+    const expoPlist = `
+      <?xml version="1.0" encoding="UTF-8"?>
+      <!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+      <plist version="1.0">
+        <dict>
+          <key>EXUpdatesRequestHeaders</key>
+          <dict>
+            <key>expo-channel-name</key>
+            <string>staging-123</string>
+          </dict>
+        </dict>
+      </plist>
+    `;
+
+    vol.fromJSON(
+      {
+        'ios/testapp/Supporting/Expo.plist': expoPlist,
+        'ios/testapp.xcodeproj/project.pbxproj': 'placeholder',
+        'ios/testapp/AppDelegate.m': 'placeholder',
+      },
+      '/app'
+    );
+
+    await expect(iosGetNativelyDefinedChannelAsync('/app')).resolves.toBe('staging-123');
+  });
+});
+
+describe(iosSetRuntimeVersionNativelyAsync, () => {
+  it("sets runtime version if it's not specified", async () => {
+    vol.fromJSON(
+      {
+        'ios/testapp/Supporting/Expo.plist': noItemsExpoPlist,
+        'ios/testapp.xcodeproj/project.pbxproj': 'placeholder',
+        'ios/testapp/AppDelegate.m': 'placeholder',
+      },
+      '/app'
+    );
+
+    await iosSetRuntimeVersionNativelyAsync('1.2.3', '/app');
+
+    const newExpoPlist = await fs.readFile(expoPlistPath, 'utf8');
+    expect(plist.parse(newExpoPlist)[IosMetadataName.RUNTIME_VERSION]).toEqual('1.2.3');
+  });
+  it("updates runtime version if it's already defined", async () => {
+    const expoPlist = `
+    <?xml version="1.0" encoding="UTF-8"?>
+    <!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+    <plist version="1.0">
+      <dict>
+        <key>RELEASE_CHANNEL</key>
+        <string>examplereleasechannel</string>
+      </dict>
+    </plist>`;
+
+    vol.fromJSON(
+      {
+        'ios/testapp/Supporting/Expo.plist': expoPlist,
+        'ios/testapp.xcodeproj/project.pbxproj': 'placeholder',
+        'ios/testapp/AppDelegate.m': 'placeholder',
+      },
+      '/app'
+    );
+
+    await iosSetRuntimeVersionNativelyAsync('1.2.3', '/app');
+
+    const newExpoPlist = await fs.readFile(expoPlistPath, 'utf8');
+    expect(plist.parse(newExpoPlist)[IosMetadataName.RUNTIME_VERSION]).toEqual('1.2.3');
+  });
+});

--- a/packages/build-tools/src/steps/utils/ios/expoUpdates.ts
+++ b/packages/build-tools/src/steps/utils/ios/expoUpdates.ts
@@ -1,0 +1,74 @@
+import { IOSConfig } from '@expo/config-plugins';
+import fs from 'fs-extra';
+import plist from '@expo/plist';
+
+export enum IosMetadataName {
+  UPDATES_CONFIGURATION_REQUEST_HEADERS_KEY = 'EXUpdatesRequestHeaders',
+  RELEASE_CHANNEL = 'EXUpdatesReleaseChannel',
+  RUNTIME_VERSION = 'EXUpdatesRuntimeVersion',
+}
+
+export async function iosSetChannelNativelyAsync(
+  channel: string,
+  workingDirectory: string
+): Promise<void> {
+  const expoPlistPath = IOSConfig.Paths.getExpoPlistPath(workingDirectory);
+
+  if (!(await fs.pathExists(expoPlistPath))) {
+    throw new Error(`${expoPlistPath} does not exist`);
+  }
+
+  const expoPlistContents = await fs.readFile(expoPlistPath, 'utf8');
+  const items: Record<string, string | Record<string, string>> = plist.parse(expoPlistContents);
+  items[IosMetadataName.UPDATES_CONFIGURATION_REQUEST_HEADERS_KEY] = {
+    ...((items[IosMetadataName.UPDATES_CONFIGURATION_REQUEST_HEADERS_KEY] as Record<
+      string,
+      string
+    >) ?? {}),
+    'expo-channel-name': channel,
+  };
+  const updatedExpoPlistContents = plist.build(items);
+
+  await fs.writeFile(expoPlistPath, updatedExpoPlistContents);
+}
+
+export async function iosSetRuntimeVersionNativelyAsync(
+  runtimeVersion: string,
+  workingDirectory: string
+): Promise<void> {
+  const expoPlistPath = IOSConfig.Paths.getExpoPlistPath(workingDirectory);
+
+  if (!(await fs.pathExists(expoPlistPath))) {
+    throw new Error(`${expoPlistPath} does not exist`);
+  }
+
+  const expoPlistContents = await fs.readFile(expoPlistPath, 'utf8');
+  const items = plist.parse(expoPlistContents);
+  items[IosMetadataName.RUNTIME_VERSION] = runtimeVersion;
+  const updatedExpoPlistContents = plist.build(items);
+
+  await fs.writeFile(expoPlistPath, updatedExpoPlistContents);
+}
+
+export async function iosGetNativelyDefinedChannelAsync(
+  workingDirectory: string
+): Promise<string | null> {
+  const expoPlistPath = IOSConfig.Paths.getExpoPlistPath(workingDirectory);
+
+  if (!(await fs.pathExists(expoPlistPath))) {
+    return null;
+  }
+
+  const expoPlistContents = await fs.readFile(expoPlistPath, 'utf8');
+  try {
+    const items: Record<string, string | Record<string, string>> = plist.parse(expoPlistContents);
+    const updatesRequestHeaders = (items[
+      IosMetadataName.UPDATES_CONFIGURATION_REQUEST_HEADERS_KEY
+    ] ?? {}) as Record<string, string>;
+    return updatesRequestHeaders['expo-channel-name'] ?? null;
+  } catch (err: any) {
+    throw new Error(
+      `Failed to parse ${IosMetadataName.UPDATES_CONFIGURATION_REQUEST_HEADERS_KEY} from Expo.plist: ${err.message}`
+    );
+  }
+}


### PR DESCRIPTION
# Why

https://linear.app/expo/issue/ENG-9477/implement-easconfigure-expo-updates-if-installed

The next step towards making custom builds public

# How

Reimplement [currently existing logic](https://github.com/expo/eas-build/blob/34a9ba17497281793d3fa1f31808911b666dadb6/packages/build-tools/src/utils/expoUpdates.ts#L140-L187) to configure EAS update during the build process

Drop support for classic updates in the new implementation

# Test Plan

Add tests
