### PR TITLE
[ENG-9010][steps] create step to install dependencies and compile custom function modules

### DIFF
--- a/packages/steps/package.json
+++ b/packages/steps/package.json
@@ -49,6 +49,7 @@
   },
   "dependencies": {
     "@expo/logger": "1.0.21",
+    "@expo/package-manager": "^1.0.2",
     "@expo/spawn-async": "^1.7.0",
     "arg": "^5.0.2",
     "fs-extra": "^11.1.1",

--- a/packages/steps/src/BuildConfigParser.ts
+++ b/packages/steps/src/BuildConfigParser.ts
@@ -32,6 +32,12 @@ import { BuildWorkflowValidator } from './BuildWorkflowValidator.js';
 import { BuildStepRuntimeError } from './errors.js';
 import { duplicates } from './utils/expodash/duplicates.js';
 import { uniq } from './utils/expodash/uniq.js';
+import {
+  INSTALL_DEPENDENCIES_AND_COMPILE_CUSTOM_FUNCTION_MODULES_ID,
+  INSTALL_DEPENDENCIES_AND_COMPILE_CUSTOM_FUNCTION_MODULES_NAME,
+  INSTALL_DEPENDENCIES_AND_COMPILE_CUSTOM_FUNCTION_MODULES_NAMESPACE,
+  createBuildFunctionToInstallDependenciesAndCompileCustomFunctionModules,
+} from './utils/customFunction.js';
 
 export class BuildConfigParser {
   private readonly externalFunctions?: BuildFunction[];
@@ -59,6 +65,12 @@ export class BuildConfigParser {
     );
     const workflow = new BuildWorkflow(this.ctx, { buildSteps, buildFunctions });
     await new BuildWorkflowValidator(workflow).validateAsync();
+
+    const maybeInstallDependenciesAndCompileCustomFunctionModulesStep =
+      this.maybeCreateInstallDependenciesAndCompileCustomFunctionModulesStep(workflow);
+    if (maybeInstallDependenciesAndCompileCustomFunctionModulesStep) {
+      workflow.buildSteps.unshift(maybeInstallDependenciesAndCompileCustomFunctionModulesStep);
+    }
     return workflow;
   }
 
@@ -301,5 +313,33 @@ export class BuildConfigParser {
     }
     const ids = this.externalFunctions.map((f) => f.getFullId());
     return uniq(ids);
+  }
+
+  private maybeCreateInstallDependenciesAndCompileCustomFunctionModulesStep(
+    workflow: BuildWorkflow
+  ): BuildStep | undefined {
+    const customFunctions: BuildFunction[] = [];
+    for (const buildFunction of Object.values(workflow.buildFunctions)) {
+      if (buildFunction.customFunctionModulePath) {
+        customFunctions.push(buildFunction);
+      }
+    }
+
+    if (customFunctions.length === 0) {
+      return undefined;
+    }
+
+    const installDependenciesAndCompileCustomFunctionModulesFunctionBuildFunction =
+      createBuildFunctionToInstallDependenciesAndCompileCustomFunctionModules(customFunctions);
+
+    return installDependenciesAndCompileCustomFunctionModulesFunctionBuildFunction.createBuildStepFromFunctionCall(
+      this.ctx,
+      {
+        id: `${INSTALL_DEPENDENCIES_AND_COMPILE_CUSTOM_FUNCTION_MODULES_NAMESPACE}/${INSTALL_DEPENDENCIES_AND_COMPILE_CUSTOM_FUNCTION_MODULES_ID}`,
+        name: INSTALL_DEPENDENCIES_AND_COMPILE_CUSTOM_FUNCTION_MODULES_NAME,
+        callInputs: {},
+        workingDirectory: this.ctx.defaultWorkingDirectory,
+      }
+    );
   }
 }

--- a/packages/steps/src/__tests__/BuildConfigParser-test.ts
+++ b/packages/steps/src/__tests__/BuildConfigParser-test.ts
@@ -9,6 +9,11 @@ import { BuildConfigError, BuildStepRuntimeError } from '../errors.js';
 import { getDefaultShell } from '../utils/shell/command.js';
 import { BuildRuntimePlatform } from '../BuildRuntimePlatform.js';
 import { BuildStepInputValueTypeName } from '../BuildStepInput.js';
+import {
+  INSTALL_DEPENDENCIES_AND_COMPILE_CUSTOM_FUNCTION_MODULES_ID,
+  INSTALL_DEPENDENCIES_AND_COMPILE_CUSTOM_FUNCTION_MODULES_NAME,
+  INSTALL_DEPENDENCIES_AND_COMPILE_CUSTOM_FUNCTION_MODULES_NAMESPACE,
+} from '../utils/customFunction.js';
 
 import { createGlobalContextMock } from './utils/context.js';
 import { getError, getErrorAsync } from './utils/error.js';
@@ -262,7 +267,16 @@ describe(BuildConfigParser, () => {
       const workflow = await parser.parseAsync();
 
       const { buildSteps } = workflow;
-      expect(buildSteps.length).toBe(7);
+      expect(buildSteps.length).toBe(8); // 7 steps + 1 step for installing custom function dependencies
+
+      // step to install custom function dependencies
+      const step0 = buildSteps[0];
+      expect(step0.id).toMatch(
+        `${INSTALL_DEPENDENCIES_AND_COMPILE_CUSTOM_FUNCTION_MODULES_NAMESPACE}/${INSTALL_DEPENDENCIES_AND_COMPILE_CUSTOM_FUNCTION_MODULES_ID}`
+      );
+      expect(step0.name).toBe(INSTALL_DEPENDENCIES_AND_COMPILE_CUSTOM_FUNCTION_MODULES_NAME);
+      expect(step0.command).toBeUndefined();
+      expect(step0.fn).not.toBeUndefined();
 
       // - say_hi:
       //     env:
@@ -276,7 +290,7 @@ describe(BuildConfigParser, () => {
       //          property2:
       //            - aaa
       //            - bbb
-      const step1 = buildSteps[0];
+      const step1 = buildSteps[1];
       expect(step1.id).toMatch(UUID_REGEX);
       expect(step1.name).toBe('Hi!');
       expect(step1.command).toBe('echo "Hi, ${ inputs.name }!"');
@@ -304,7 +318,7 @@ describe(BuildConfigParser, () => {
       //     inputs:
       //       name: Szymon
       //       build_number: 122
-      const step2 = buildSteps[1];
+      const step2 = buildSteps[2];
       expect(step2.id).toMatch(UUID_REGEX);
       expect(step2.name).toBe('Hi, Szymon!');
       expect(step2.command).toBe('echo "Hi, ${ inputs.name }!"');
@@ -325,7 +339,7 @@ describe(BuildConfigParser, () => {
       expect(step2.env).toMatchObject({});
 
       // - say_hi_wojtek
-      const step3 = buildSteps[2];
+      const step3 = buildSteps[3];
       expect(step3.id).toMatch(UUID_REGEX);
       expect(step3.name).toBe('Hi, Wojtek!');
       expect(step3.command).toBe('echo "Hi, Wojtek!"');
@@ -335,7 +349,7 @@ describe(BuildConfigParser, () => {
 
       // - random:
       //     id: random_number
-      const step4 = buildSteps[3];
+      const step4 = buildSteps[4];
       expect(step4.id).toMatch('random_number');
       expect(step4.name).toBe('Generate random number');
       expect(step4.command).toBe('set-output value 6');
@@ -348,7 +362,7 @@ describe(BuildConfigParser, () => {
       // - print:
       //     inputs:
       //       value: ${ steps.random_number.value }
-      const step5 = buildSteps[4];
+      const step5 = buildSteps[5];
       expect(step5.id).toMatch(UUID_REGEX);
       expect(step5.name).toBe(undefined);
       expect(step5.command).toBe('echo "${ inputs.value }"');
@@ -363,7 +377,7 @@ describe(BuildConfigParser, () => {
       //     inputs:
       //       greeting: Hello
       //       num: 123
-      const step6 = buildSteps[5];
+      const step6 = buildSteps[6];
       expect(step6.id).toMatch(UUID_REGEX);
       expect(step6.name).toBe('Hi!');
       expect(step6.command).toBe('echo "${ inputs.greeting }, ${ inputs.name }!"');

--- a/packages/steps/src/utils/customFunction.ts
+++ b/packages/steps/src/utils/customFunction.ts
@@ -1,12 +1,15 @@
 import path from 'path';
+import assert from 'assert';
 
 import { createContext } from 'this-file';
+import { resolvePackageManager } from '@expo/package-manager';
 
 import { BuildStepFunction } from '../BuildStep.js';
 import { BuildStepEnv } from '../BuildStepEnv.js';
 import { SerializedBuildStepInput } from '../BuildStepInput.js';
 import { SerializedBuildStepOutput } from '../BuildStepOutput.js';
 import { SerializedBuildStepContext } from '../BuildStepContext.js';
+import { BuildFunction } from '../BuildFunction.js';
 
 import { spawnAsync } from './shell/spawn.js';
 
@@ -47,4 +50,68 @@ export function createCustomFunctionCall(customFunctionModulePath: string): Buil
       }
     );
   };
+}
+
+export const INSTALL_DEPENDENCIES_AND_COMPILE_CUSTOM_FUNCTION_MODULES_ID =
+  'install_dependencies_and_compile_custom_function_modules';
+export const INSTALL_DEPENDENCIES_AND_COMPILE_CUSTOM_FUNCTION_MODULES_NAMESPACE = 'internal';
+export const INSTALL_DEPENDENCIES_AND_COMPILE_CUSTOM_FUNCTION_MODULES_NAME =
+  'Install dependencies and compile custom function modules';
+
+export function createBuildFunctionToInstallDependenciesAndCompileCustomFunctionModules(
+  customFunctions: BuildFunction[]
+): BuildFunction {
+  return new BuildFunction({
+    namespace: INSTALL_DEPENDENCIES_AND_COMPILE_CUSTOM_FUNCTION_MODULES_NAMESPACE,
+    id: INSTALL_DEPENDENCIES_AND_COMPILE_CUSTOM_FUNCTION_MODULES_ID,
+    name: INSTALL_DEPENDENCIES_AND_COMPILE_CUSTOM_FUNCTION_MODULES_NAME,
+    // eslint-disable-next-line async-protect/async-suffix
+    fn: async (ctx, { env }) => {
+      for (const customFunction of customFunctions) {
+        assert(customFunction.customFunctionModulePath, 'customFunctionModulePath');
+        const packageManager = resolvePackageManagerForCustomFunction(
+          customFunction.customFunctionModulePath
+        );
+        ctx.logger.info(
+          `Detected package manager ${packageManager} for custom function ${customFunction.id}`
+        );
+
+        ctx.logger.info(`Installing dependencies for custom function ${customFunction.id}...`);
+        await spawnAsync(packageManager, ['install'], {
+          cwd: customFunction.customFunctionModulePath,
+          logger: ctx.logger,
+          env,
+        });
+
+        ctx.logger.info(`Compiling custom function ${customFunction.id}...`);
+        await spawnAsync(packageManager, ['run', 'build'], {
+          cwd: customFunction.customFunctionModulePath,
+          logger: ctx.logger,
+          env,
+        });
+      }
+    },
+  });
+}
+
+enum PackageManager {
+  YARN = 'yarn',
+  NPM = 'npm',
+  PNPM = 'pnpm',
+}
+
+function resolvePackageManagerForCustomFunction(customFunctionModulePath: string): PackageManager {
+  try {
+    const manager = resolvePackageManager(customFunctionModulePath);
+
+    if (manager === 'npm') {
+      return PackageManager.NPM;
+    } else if (manager === 'pnpm') {
+      return PackageManager.PNPM;
+    } else {
+      return PackageManager.YARN;
+    }
+  } catch {
+    return PackageManager.YARN;
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -620,6 +620,15 @@
     json5 "^1.0.1"
     write-file-atomic "^2.3.0"
 
+"@expo/json-file@^8.2.37":
+  version "8.2.37"
+  resolved "https://registry.yarnpkg.com/@expo/json-file/-/json-file-8.2.37.tgz#9c02d3b42134907c69cc0a027b18671b69344049"
+  integrity sha512-YaH6rVg11JoTS2P6LsW7ybS2CULjf40AbnAHw2F1eDPuheprNjARZMnyHFPkKv7GuxCy+B9GPcbOKgc4cgA80Q==
+  dependencies:
+    "@babel/code-frame" "~7.10.4"
+    json5 "^2.2.2"
+    write-file-atomic "^2.3.0"
+
 "@expo/package-manager@^0.0.57":
   version "0.0.57"
   resolved "https://registry.yarnpkg.com/@expo/package-manager/-/package-manager-0.0.57.tgz#1cd71da0632c52a9a001b45e5d0d7e1e16de97d3"
@@ -633,6 +642,23 @@
     find-yarn-workspace-root "~2.0.0"
     npm-package-arg "^7.0.0"
     rimraf "^3.0.2"
+    split "^1.0.1"
+    sudo-prompt "9.1.1"
+
+"@expo/package-manager@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@expo/package-manager/-/package-manager-1.0.2.tgz#6c5fd0ee9b3d28c5523b2484c62c6c7b0c8dbf89"
+  integrity sha512-dlUp6o8qs1mi3/+l3y7cY3oMoqQVVzvH18cUTi6+t4ob8XwTpaeP2SwOP+obwZN29dMg9YzZAv4eQz+mshAbQA==
+  dependencies:
+    "@expo/json-file" "^8.2.37"
+    "@expo/spawn-async" "^1.5.0"
+    ansi-regex "^5.0.0"
+    chalk "^4.0.0"
+    find-up "^5.0.0"
+    find-yarn-workspace-root "~2.0.0"
+    js-yaml "^3.13.1"
+    micromatch "^4.0.2"
+    npm-package-arg "^7.0.0"
     split "^1.0.1"
     sudo-prompt "9.1.1"
 


### PR DESCRIPTION
# Why

Follow up to https://github.com/expo/eas-build/pull/252

We want to install dependencies and compile custom JS/TS function modules before running them

# How

If build functions with a path to a custom function module exists add a new step to the build config which runs `packageManager install` and `packageManager run build` for every such function.

# Test Plan

Build with custom functions:
<img width="805" alt="Screenshot 2023-07-27 at 13 58 48" src="https://github.com/expo/eas-build/assets/55145344/b1f5ecca-0da8-43f3-808c-6231d94aa814">

Build without custom functions:
<img width="799" alt="Screenshot 2023-07-27 at 14 01 23" src="https://github.com/expo/eas-build/assets/55145344/b07a53d7-4c38-4610-8071-5196ea764e67">


Add automated tests
