### PR TITLE
[steps] fix resolving custom function path

### DIFF
--- a/packages/build-tools/src/builders/custom.ts
+++ b/packages/build-tools/src/builders/custom.ts
@@ -21,10 +21,11 @@ export async function runCustomBuildAsync<T extends Job>(ctx: BuildContext<T>): 
     relativeConfigPath
   );
 
-  const globalContext = new BuildStepGlobalContext(customBuildCtx, false, configPath);
+  const globalContext = new BuildStepGlobalContext(customBuildCtx, false);
   const easFunctions = getEasFunctions(customBuildCtx, ctx);
   const parser = new BuildConfigParser(globalContext, {
     externalFunctions: easFunctions,
+    configPath,
   });
   const workflow = await ctx.runBuildPhase(BuildPhase.PARSE_CUSTOM_WORKFLOW_CONFIG, async () => {
     try {

--- a/packages/steps/src/BuildStepContext.ts
+++ b/packages/steps/src/BuildStepContext.ts
@@ -45,7 +45,6 @@ export interface SerializedBuildStepGlobalContext {
   stepById: Record<string, SerializedBuildStepOutputAccessor>;
   provider: SerializedExternalBuildContextProvider;
   skipCleanup: boolean;
-  configPath: string;
 }
 
 export class BuildStepGlobalContext {
@@ -57,8 +56,7 @@ export class BuildStepGlobalContext {
 
   constructor(
     private readonly provider: ExternalBuildContextProvider,
-    public readonly skipCleanup: boolean,
-    public readonly configPath: string
+    public readonly skipCleanup: boolean
   ) {
     this.stepsInternalBuildDirectory = path.join(os.tmpdir(), 'eas-build', uuidv4());
     this.runtimePlatform = provider.runtimePlatform;
@@ -133,7 +131,6 @@ export class BuildStepGlobalContext {
         env: this.provider.env,
       },
       skipCleanup: this.skipCleanup,
-      configPath: this.configPath,
     };
   }
 
@@ -151,11 +148,7 @@ export class BuildStepGlobalContext {
       env: serialized.provider.env,
       updateEnv: () => {},
     };
-    const ctx = new BuildStepGlobalContext(
-      deserializedProvider,
-      serialized.skipCleanup,
-      serialized.configPath
-    );
+    const ctx = new BuildStepGlobalContext(deserializedProvider, serialized.skipCleanup);
     for (const [id, stepOutputAccessor] of Object.entries(serialized.stepById)) {
       ctx.stepById[id] = BuildStepOutputAccessor.deserialize(stepOutputAccessor);
     }

--- a/packages/steps/src/__tests__/BuildConfigParser-test.ts
+++ b/packages/steps/src/__tests__/BuildConfigParser-test.ts
@@ -19,10 +19,11 @@ const __dirname = url.fileURLToPath(new URL('.', import.meta.url));
 describe(BuildConfigParser, () => {
   describe('constructor', () => {
     it('throws if provided external functions with duplicated IDs', () => {
-      const ctx = createGlobalContextMock({ configPath: './fake.yml' });
+      const ctx = createGlobalContextMock();
       const error = getError<BuildStepRuntimeError>(() => {
         // eslint-disable-next-line no-new
         new BuildConfigParser(ctx, {
+          configPath: './fake.yml',
           externalFunctions: [
             new BuildFunction({ id: 'abc', command: 'echo 123' }),
             new BuildFunction({ id: 'abc', command: 'echo 456' }),
@@ -34,12 +35,11 @@ describe(BuildConfigParser, () => {
     });
 
     it(`doesn't throw if provided external functions don't have duplicated IDs`, () => {
-      const ctx = createGlobalContextMock({
-        configPath: path.join('./fake.yml'),
-      });
+      const ctx = createGlobalContextMock();
       expect(() => {
         // eslint-disable-next-line no-new
         new BuildConfigParser(ctx, {
+          configPath: './fake.yml',
           externalFunctions: [
             new BuildFunction({ namespace: 'a', id: 'abc', command: 'echo 123' }),
             new BuildFunction({ namespace: 'b', id: 'abc', command: 'echo 456' }),
@@ -51,19 +51,19 @@ describe(BuildConfigParser, () => {
 
   describe(BuildConfigParser.prototype.parseAsync, () => {
     it('returns a BuildWorkflow object', async () => {
-      const ctx = createGlobalContextMock({
+      const ctx = createGlobalContextMock();
+      const parser = new BuildConfigParser(ctx, {
         configPath: path.join(__dirname, './fixtures/build.yml'),
       });
-      const parser = new BuildConfigParser(ctx, {});
       const result = await parser.parseAsync();
       expect(result).toBeInstanceOf(BuildWorkflow);
     });
 
     it('parses steps from the build workflow', async () => {
-      const ctx = createGlobalContextMock({
+      const ctx = createGlobalContextMock();
+      const parser = new BuildConfigParser(ctx, {
         configPath: path.join(__dirname, './fixtures/build.yml'),
       });
-      const parser = new BuildConfigParser(ctx, {});
       const workflow = await parser.parseAsync();
       const buildSteps = workflow.buildSteps;
       expect(buildSteps.length).toBe(6);
@@ -150,10 +150,10 @@ describe(BuildConfigParser, () => {
     });
 
     it('parses inputs', async () => {
-      const ctx = createGlobalContextMock({
+      const ctx = createGlobalContextMock();
+      const parser = new BuildConfigParser(ctx, {
         configPath: path.join(__dirname, './fixtures/inputs.yml'),
       });
-      const parser = new BuildConfigParser(ctx, {});
       const workflow = await parser.parseAsync();
       const buildSteps = workflow.buildSteps;
       expect(buildSteps.length).toBe(1);
@@ -200,10 +200,10 @@ describe(BuildConfigParser, () => {
     });
 
     it('parses outputs', async () => {
-      const ctx = createGlobalContextMock({
+      const ctx = createGlobalContextMock();
+      const parser = new BuildConfigParser(ctx, {
         configPath: path.join(__dirname, './fixtures/outputs.yml'),
       });
-      const parser = new BuildConfigParser(ctx, {});
       const workflow = await parser.parseAsync();
       const buildSteps = workflow.buildSteps;
       expect(buildSteps.length).toBe(2);
@@ -255,10 +255,10 @@ describe(BuildConfigParser, () => {
     });
 
     it('parses functions and function calls', async () => {
-      const ctx = createGlobalContextMock({
+      const ctx = createGlobalContextMock();
+      const parser = new BuildConfigParser(ctx, {
         configPath: path.join(__dirname, './fixtures/functions.yml'),
       });
-      const parser = new BuildConfigParser(ctx, {});
       const workflow = await parser.parseAsync();
 
       const { buildSteps } = workflow;
@@ -532,10 +532,10 @@ describe(BuildConfigParser, () => {
     });
 
     it('throws if calling non-existent external functions', async () => {
-      const ctx = createGlobalContextMock({
+      const ctx = createGlobalContextMock();
+      const parser = new BuildConfigParser(ctx, {
         configPath: path.join(__dirname, './fixtures/external-functions.yml'),
       });
-      const parser = new BuildConfigParser(ctx, {});
       const error = await getErrorAsync<BuildConfigError>(async () => {
         await parser.parseAsync();
       });
@@ -546,9 +546,7 @@ describe(BuildConfigParser, () => {
     });
 
     it('works with external functions', async () => {
-      const ctx = createGlobalContextMock({
-        configPath: path.join(__dirname, './fixtures/external-functions.yml'),
-      });
+      const ctx = createGlobalContextMock();
 
       const downloadProjectFn: BuildStepFunction = (ctx) => {
         ctx.logger.info('Downloading project...');
@@ -559,6 +557,7 @@ describe(BuildConfigParser, () => {
       };
 
       const parser = new BuildConfigParser(ctx, {
+        configPath: path.join(__dirname, './fixtures/external-functions.yml'),
         externalFunctions: [
           new BuildFunction({
             namespace: 'eas',

--- a/packages/steps/src/__tests__/BuildStepContext-test.ts
+++ b/packages/steps/src/__tests__/BuildStepContext-test.ts
@@ -22,8 +22,7 @@ describe(BuildStepGlobalContext, () => {
           '/another/non/existent/path',
           '/working/dir/path'
         ),
-        false,
-        './fake.yml'
+        false
       );
       expect(ctx.stepsInternalBuildDirectory.startsWith(os.tmpdir())).toBe(true);
     });
@@ -39,8 +38,7 @@ describe(BuildStepGlobalContext, () => {
           '/another/non/existent/path',
           workingDirectory
         ),
-        false,
-        './fake.yml'
+        false
       );
       expect(ctx.defaultWorkingDirectory).toBe(workingDirectory);
     });
@@ -60,7 +58,6 @@ describe(BuildStepGlobalContext, () => {
         projectTargetDirectory: '/d/e/f',
         workingDirectory: '/g/h/i',
         staticContextContent: { a: 1 },
-        configPath: '/j/k/l',
       });
       expect(ctx.serialize()).toEqual(
         expect.objectContaining({
@@ -75,7 +72,6 @@ describe(BuildStepGlobalContext, () => {
             env: {},
           },
           skipCleanup: true,
-          configPath: '/j/k/l',
         })
       );
     });
@@ -95,7 +91,6 @@ describe(BuildStepGlobalContext, () => {
             env: {},
           },
           skipCleanup: true,
-          configPath: '/j/k/l',
         },
         createMockLogger()
       );
@@ -103,13 +98,11 @@ describe(BuildStepGlobalContext, () => {
       expect(ctx.defaultWorkingDirectory).toBe('/g/h/i');
       expect(ctx.runtimePlatform).toBe(BuildRuntimePlatform.DARWIN);
       expect(ctx.skipCleanup).toBe(true);
-      expect(ctx.configPath).toBe('/j/k/l');
       expect(ctx.projectSourceDirectory).toBe('/a/b/c');
       expect(ctx.projectTargetDirectory).toBe('/d/e/f');
       expect(ctx.staticContext).toEqual({ a: 1 });
       expect(ctx.env).toEqual({});
       expect(ctx.skipCleanup).toBe(true);
-      expect(ctx.configPath).toBe('/j/k/l');
     });
   });
   describe(BuildStepGlobalContext.prototype.getStepOutputValue, () => {

--- a/packages/steps/src/__tests__/utils/context.ts
+++ b/packages/steps/src/__tests__/utils/context.ts
@@ -45,7 +45,6 @@ interface BuildContextParams {
   projectTargetDirectory?: string;
   workingDirectory?: string;
   staticContextContent?: Record<string, any>;
-  configPath?: string;
 }
 
 export function createStepContextMock({
@@ -82,7 +81,6 @@ export function createGlobalContextMock({
   projectTargetDirectory,
   workingDirectory,
   staticContextContent,
-  configPath,
 }: BuildContextParams = {}): BuildStepGlobalContext {
   const resolvedProjectTargetDirectory =
     projectTargetDirectory ?? path.join(os.tmpdir(), 'eas-build', uuidv4());
@@ -95,7 +93,6 @@ export function createGlobalContextMock({
       workingDirectory ?? resolvedProjectTargetDirectory,
       staticContextContent ?? {}
     ),
-    skipCleanup ?? false,
-    configPath ?? './fake.yml'
+    skipCleanup ?? false
   );
 }

--- a/packages/steps/src/cli/cli.ts
+++ b/packages/steps/src/cli/cli.ts
@@ -47,10 +47,11 @@ async function runAsync(
       relativeProjectDirectory,
       relativeProjectDirectory
     ),
-    false,
-    configPath
+    false
   );
-  const parser = new BuildConfigParser(ctx, {});
+  const parser = new BuildConfigParser(ctx, {
+    configPath,
+  });
   const workflow = await parser.parseAsync();
   await workflow.executeAsync();
 }


### PR DESCRIPTION
# Why

The relative function path was resolved always based on a dirname of the main config path, not based on dirname of the imported config file which actually contains the function declaration.

# How

Resolve relative function path based on the path to the config file which actually contains the function

# Test Plan

Tests
