### PR TITLE
Chalk v5: Error [ERR_REQUIRE_ESM]: require() of ES Module

### DIFF
--- a/packages/local-build-plugin/package.json
+++ b/packages/local-build-plugin/package.json
@@ -29,7 +29,7 @@
     "@expo/spawn-async": "^1.7.2",
     "@expo/turtle-spawn": "1.0.30",
     "bunyan": "^1.8.15",
-    "chalk": "^5.3.0",
+    "chalk": "^4.1.2",
     "env-paths": "^2.2.1",
     "fs-extra": "^11.1.0",
     "joi": "^17.9.2",


### PR DESCRIPTION
# Why

const chalk_1 = __importDefault(require("chalk"));
                                ^
Error [ERR_REQUIRE_ESM]: require() of ES Module

# How

How did you build this feature or fix this bug and why?

# Test Plan

Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
