### PR TITLE
[steps] interpolate with global context even when there are no inputs

### DIFF
--- a/packages/steps/src/BuildStep.ts
+++ b/packages/steps/src/BuildStep.ts
@@ -351,7 +351,7 @@ export class BuildStep extends BuildStepOutputAccessor {
     inputs?: BuildStepInput[]
   ): string {
     if (!inputs) {
-      return command;
+      return this.ctx.global.interpolate(command);
     }
     const vars = inputs.reduce((acc, input) => {
       acc[input.id] =


### PR DESCRIPTION
# Why

@brentvatne reported that when running steps like this
```yml
- run:
        name: Test
        command: echo "foo = ${ eas.job.platform }"
```
we don't interpolate with global context and the user gets an error
<img width="1156" alt="Screenshot 2023-08-08 at 09 31 43" src="https://github.com/expo/eas-build/assets/55145344/d5839bbb-bae1-47cb-8012-69b925a4f104">

# How

If there are no inputs still interpolate with the global context

# Test Plan

Tested manually

<img width="1167" alt="Screenshot 2023-08-08 at 09 32 31" src="https://github.com/expo/eas-build/assets/55145344/db47d269-ebb1-46a6-bccb-0454413a2bd1">

