### PR TITLE
[build-tools] add `utils/run_gradle` function

### DIFF
--- a/packages/build-tools/src/steps/easFunctions.ts
+++ b/packages/build-tools/src/steps/easFunctions.ts
@@ -14,6 +14,7 @@ import { createFindAndUploadBuildArtifactsBuildFunction } from './functions/eas/
 import { configureEASUpdateIfInstalledFunction } from './functions/eas/configureExpoUpdatesIfInstalled';
 import { injectAndroidCredentialsFunction } from './functions/utils/injectAndroidCredentials';
 import { configureAndroidVersionFunction } from './functions/utils/configureAndroidVersion';
+import { runGradleFunction } from './functions/utils/runGradle';
 
 export function getEasFunctions(
   ctx: CustomBuildContext,
@@ -30,5 +31,6 @@ export function getEasFunctions(
     configureEASUpdateIfInstalledFunction(),
     injectAndroidCredentialsFunction(),
     configureAndroidVersionFunction(),
+    runGradleFunction(),
   ];
 }

--- a/packages/build-tools/src/steps/functions/utils/runGradle.ts
+++ b/packages/build-tools/src/steps/functions/utils/runGradle.ts
@@ -1,0 +1,34 @@
+import path from 'path';
+import assert from 'assert';
+
+import { BuildFunction, BuildStepInput, BuildStepInputValueTypeName } from '@expo/steps';
+
+import { resolveGradleCommand, runGradleCommand } from '../../utils/android/gradle';
+
+export function runGradleFunction(): BuildFunction {
+  return new BuildFunction({
+    namespace: 'utils',
+    id: 'run_gradle',
+    name: 'Run gradle',
+    inputProviders: [
+      BuildStepInput.createProvider({
+        id: 'command',
+        required: false,
+        allowedValueTypeName: BuildStepInputValueTypeName.STRING,
+      }),
+    ],
+    fn: async (stepCtx, { env, inputs }) => {
+      assert(stepCtx.global.staticContext.job, 'Job is required');
+      const command = resolveGradleCommand(
+        stepCtx.global.staticContext.job,
+        inputs.command.value as string | undefined
+      );
+      await runGradleCommand({
+        logger: stepCtx.logger,
+        gradleCommand: command,
+        androidDir: path.join(stepCtx.workingDirectory, 'android'),
+        env,
+      });
+    },
+  });
+}

--- a/packages/build-tools/src/steps/utils/android/gradle.ts
+++ b/packages/build-tools/src/steps/utils/android/gradle.ts
@@ -1,0 +1,116 @@
+import assert from 'assert';
+
+import fs from 'fs-extra';
+import { bunyan } from '@expo/logger';
+import { BuildStepEnv } from '@expo/steps';
+import spawn, { SpawnPromise, SpawnResult } from '@expo/turtle-spawn';
+import { Android } from '@expo/eas-build-job';
+
+export async function runGradleCommand({
+  logger,
+  gradleCommand,
+  androidDir,
+  env,
+}: {
+  logger: bunyan;
+  gradleCommand: string;
+  androidDir: string;
+  env: BuildStepEnv;
+}): Promise<void> {
+  logger.info(`Running 'gradlew ${gradleCommand}' in ${androidDir}`);
+  const spawnPromise = spawn('bash', ['-c', `sh gradlew ${gradleCommand}`], {
+    cwd: androidDir,
+    logger,
+    lineTransformer: (line?: string) => {
+      if (!line || /^\.+$/.exec(line)) {
+        return null;
+      } else {
+        return line;
+      }
+    },
+    env,
+  });
+  if (env.EAS_BUILD_RUNNER === 'eas-build' && process.platform === 'linux') {
+    adjustOOMScore(spawnPromise, logger);
+  }
+
+  await spawnPromise;
+}
+
+/**
+ * OOM Killer sometimes kills worker server while build is exceeding memory limits.
+ * `oom_score_adj` is a value between -1000 and 1000 and it defaults to 0.
+ * It defines which process is more likely to get killed (higher value more likely).
+ *
+ * This function sets oom_score_adj for Gradle process and all its child processes.
+ */
+function adjustOOMScore(spawnPromise: SpawnPromise<SpawnResult>, logger: bunyan): void {
+  setTimeout(
+    async () => {
+      try {
+        assert(spawnPromise.child.pid);
+        const pids = await getParentAndDescendantProcessPidsAsync(spawnPromise.child.pid);
+        await Promise.all(
+          pids.map(async (pid: number) => {
+            // Value 800 is just a guess here. It's probably higher than most other
+            // process. I didn't want to set it any higher, because I'm not sure if OOM Killer
+            // can start killing processes when there is still enough memory left.
+            const oomScoreOverride = 800;
+            await fs.writeFile(`/proc/${pid}/oom_score_adj`, `${oomScoreOverride}\n`);
+          })
+        );
+      } catch (err: any) {
+        logger.debug({ err, stderr: err?.stderr }, 'Failed to override oom_score_adj');
+      }
+    },
+    // Wait 20 seconds to make sure all child processes are started
+    20000
+  );
+}
+
+async function getChildrenPidsAsync(parentPids: number[]): Promise<number[]> {
+  try {
+    const result = await spawn('pgrep', ['-P', parentPids.join(',')], {
+      stdio: 'pipe',
+    });
+    return result.stdout
+      .toString()
+      .split('\n')
+      .map((i) => Number(i.trim()))
+      .filter((i) => i);
+  } catch {
+    return [];
+  }
+}
+
+async function getParentAndDescendantProcessPidsAsync(ppid: number): Promise<number[]> {
+  const children = new Set<number>([ppid]);
+  let shouldCheckAgain = true;
+  while (shouldCheckAgain) {
+    const pids = await getChildrenPidsAsync([...children]);
+    shouldCheckAgain = false;
+    for (const pid of pids) {
+      if (!children.has(pid)) {
+        shouldCheckAgain = true;
+        children.add(pid);
+      }
+    }
+  }
+  return [...children];
+}
+
+export function resolveGradleCommand(job: Android.Job, command?: string): string {
+  if (command) {
+    return command;
+  } else if (job.gradleCommand) {
+    return job.gradleCommand;
+  } else if (job.developmentClient) {
+    return ':app:assembleDebug';
+  } else if (!job.buildType) {
+    return ':app:bundleRelease';
+  } else if (job.buildType === Android.BuildType.APK) {
+    return ':app:assembleRelease';
+  } else {
+    return ':app:bundleRelease';
+  }
+}


### PR DESCRIPTION
# Why

Add `utils/run_gradle` function

# How

Add the `utils/run_gradle` function. Copy existing logic and make it independent from the old `BuildContext`.

# Test Plan

Test on staging
