### PR TITLE
[local-build-plugin] create `temporary-custom-build` directory when starting local build

### DIFF
--- a/packages/local-build-plugin/src/workingdir.ts
+++ b/packages/local-build-plugin/src/workingdir.ts
@@ -16,6 +16,7 @@ export async function prepareWorkingdirAsync(): Promise<string> {
   }
   await fs.mkdirp(path.join(workingdir, 'artifacts'));
   await fs.mkdirp(path.join(workingdir, 'build'));
+  await fs.mkdirp(path.join(workingdir, 'temporary-custom-build'));
   await fs.mkdirp(path.join(workingdir, 'custom-build'));
   await fs.mkdirp(path.join(workingdir, 'env'));
   await fs.mkdirp(path.join(workingdir, 'bin'));


### PR DESCRIPTION
# Why

<img width="920" alt="Screenshot 2023-08-08 at 20 09 27" src="https://github.com/expo/eas-build/assets/55145344/ca695600-e3da-4589-a934-3c05d565581a">


# How

Fix the issue by creating a `temporary-custom-build` directory when starting the local build
