### PR TITLE
[eas-build-job] add `developmentClient` field to metadata

### DIFF
--- a/packages/eas-build-job/src/__tests__/metadata.test.ts
+++ b/packages/eas-build-job/src/__tests__/metadata.test.ts
@@ -22,6 +22,7 @@ describe('MetadataSchema', () => {
       runWithNoWaitFlag: true,
       buildMode: 'build',
       customWorkflowName: 'blah blah',
+      developmentClient: true,
     };
     const { value, error } = MetadataSchema.validate(metadata, {
       stripUnknown: true,
@@ -51,6 +52,7 @@ describe('MetadataSchema', () => {
       runWithNoWaitFlag: true,
       buildMode: 'resign',
       customWorkflowName: 'blah blah',
+      developmentClient: true,
     };
     const { error } = MetadataSchema.validate(metadata, {
       stripUnknown: true,

--- a/packages/eas-build-job/src/metadata.ts
+++ b/packages/eas-build-job/src/metadata.ts
@@ -144,6 +144,11 @@ export type Metadata = {
    * Workflow name available for custom builds.
    */
   customWorkflowName?: string;
+
+  /**
+   * Indicates whether this is (likely, we can't be 100% sure) development client build.
+   */
+  developmentClient?: boolean;
 };
 
 export const MetadataSchema = Joi.object({
@@ -174,6 +179,7 @@ export const MetadataSchema = Joi.object({
   runWithNoWaitFlag: Joi.boolean(),
   buildMode: Joi.string().valid('build', 'resign', 'custom'),
   customWorkflowName: Joi.string(),
+  developmentClient: Joi.boolean(),
 });
 
 export function sanitizeMetadata(metadata: object): Metadata {


### PR DESCRIPTION
# Why

Add the `developmentClient` field to the metadata. Companion to https://github.com/expo/universe/pull/13215

# How

Add the `developmentClient` field to the metadata. Alter Joi schema to validate it.

# Test Plan

Add tests
