### PR TITLE
[ENG-9955][eas-build-job] add build phase to external build error

### DIFF
--- a/packages/eas-build-job/src/errors.ts
+++ b/packages/eas-build-job/src/errors.ts
@@ -13,6 +13,7 @@ export interface ExternalBuildError {
   errorCode: string;
   message: string;
   docsUrl?: string;
+  buildPhase?: BuildPhase;
 }
 
 interface BuildErrorDetails {
@@ -46,6 +47,7 @@ export class BuildError extends Error {
       errorCode: this.userFacingErrorCode,
       message: this.userFacingMessage,
       docsUrl: this.docsUrl,
+      buildPhase: this.buildPhase,
     };
   }
 }

--- a/packages/eas-build-job/src/errors.ts
+++ b/packages/eas-build-job/src/errors.ts
@@ -1,4 +1,4 @@
-import { BuildPhase } from './logs';
+import { BuildPhase, buildPhaseDisplayName } from './logs';
 
 export enum ErrorCode {
   UNKNOWN_ERROR = 'UNKNOWN_ERROR',
@@ -59,8 +59,13 @@ export class UserFacingError extends Error {
 }
 
 export class UnknownError extends UserFacingError {
-  constructor() {
-    super(ErrorCode.UNKNOWN_ERROR, 'Unknown error. See logs for more information.');
+  constructor(buildPhase?: BuildPhase) {
+    super(
+      ErrorCode.UNKNOWN_ERROR,
+      buildPhase
+        ? `Unknown error. See logs of the ${buildPhaseDisplayName[buildPhase]} build phase for more information.`
+        : 'Unknown error. See logs for more information.'
+    );
   }
 }
 

--- a/packages/eas-build-job/src/logs.ts
+++ b/packages/eas-build-job/src/logs.ts
@@ -105,6 +105,57 @@ export const buildPhaseDisplayName: Record<BuildPhase, string> = {
   [BuildPhase.PARSE_CUSTOM_WORKFLOW_CONFIG]: 'Parse custom build config',
 };
 
+export const buildPhaseWebsiteId: Record<BuildPhase, string> = {
+  [BuildPhase.UNKNOWN]: 'unknown',
+  [BuildPhase.QUEUE]: 'waiting-to-start',
+  [BuildPhase.SPIN_UP_BUILDER]: 'spin-up-build-environment',
+  [BuildPhase.SET_UP_BUILD_ENVIRONMENT]: 'set-up-build-environment',
+  [BuildPhase.BUILDER_INFO]: 'builder-environment-info',
+  [BuildPhase.START_BUILD]: 'start-build',
+  [BuildPhase.INSTALL_CUSTOM_TOOLS]: 'install-custom-tools',
+  [BuildPhase.PREPARE_PROJECT]: 'prepare-project',
+  [BuildPhase.RESTORE_CACHE]: 'restore-cache',
+  [BuildPhase.INSTALL_DEPENDENCIES]: 'install-dependencies',
+  [BuildPhase.EAS_BUILD_INTERNAL]: 'resolve-build-configuration',
+  [BuildPhase.PREBUILD]: 'prebuild',
+  [BuildPhase.PREPARE_CREDENTIALS]: 'prepare-credentials',
+  [BuildPhase.CONFIGURE_EXPO_UPDATES]: 'configure-expo-updates',
+  [BuildPhase.SAVE_CACHE]: 'save-cache',
+  [BuildPhase.UPLOAD_ARTIFACTS]: 'upload-artifacts',
+  [BuildPhase.UPLOAD_APPLICATION_ARCHIVE]: 'upload-application-archive',
+  [BuildPhase.UPLOAD_BUILD_ARTIFACTS]: 'upload-build-artifacts',
+  [BuildPhase.PREPARE_ARTIFACTS]: 'prepare-artifacts',
+  [BuildPhase.CLEAN_UP_CREDENTIALS]: 'clean-up-credentials',
+  [BuildPhase.COMPLETE_BUILD]: 'complete-build',
+  [BuildPhase.FAIL_BUILD]: 'fail-build',
+  [BuildPhase.READ_APP_CONFIG]: 'read-app-config',
+  [BuildPhase.READ_PACKAGE_JSON]: 'read-package-json',
+  [BuildPhase.RUN_EXPO_DOCTOR]: 'run-expo-doctor',
+  [BuildPhase.DOWNLOAD_APPLICATION_ARCHIVE]: 'download-application-archive',
+
+  // ANDROID
+  [BuildPhase.FIX_GRADLEW]: 'fix-gradlew',
+  [BuildPhase.RUN_GRADLEW]: 'run-gradlew',
+
+  // IOS
+  [BuildPhase.INSTALL_PODS]: 'install-pods',
+  [BuildPhase.CONFIGURE_XCODE_PROJECT]: 'configure-xcode-project',
+  [BuildPhase.RUN_FASTLANE]: 'run-fastlane',
+
+  // HOOKS
+  [BuildPhase.PRE_INSTALL_HOOK]: 'pre-install-hook',
+  [BuildPhase.POST_INSTALL_HOOK]: 'post-install-hook',
+  [BuildPhase.PRE_UPLOAD_ARTIFACTS_HOOK]: 'pre-upload-artifacts-hook',
+  [BuildPhase.ON_BUILD_SUCCESS_HOOK]: 'build-success-hook',
+  [BuildPhase.ON_BUILD_ERROR_HOOK]: 'build-error-hook',
+  [BuildPhase.ON_BUILD_COMPLETE_HOOK]: 'build-complete-hook',
+  [BuildPhase.ON_BUILD_CANCEL_HOOK]: 'build-cancel-hook',
+
+  // CUSTOM
+  [BuildPhase.CUSTOM]: 'custom',
+  [BuildPhase.PARSE_CUSTOM_WORKFLOW_CONFIG]: 'parse-custom-workflow-config',
+};
+
 export enum BuildPhaseResult {
   SUCCESS = 'success',
   FAIL = 'failed',

--- a/packages/eas-build-job/src/logs.ts
+++ b/packages/eas-build-job/src/logs.ts
@@ -156,6 +156,8 @@ export const buildPhaseWebsiteId: Record<BuildPhase, string> = {
   [BuildPhase.PARSE_CUSTOM_WORKFLOW_CONFIG]: 'parse-custom-workflow-config',
 };
 
+export const XCODE_LOGS_BUILD_PHASE_WEBSITE_ID = 'xcode-logs';
+
 export enum BuildPhaseResult {
   SUCCESS = 'success',
   FAIL = 'failed',

--- a/packages/eas-build-job/src/logs.ts
+++ b/packages/eas-build-job/src/logs.ts
@@ -54,6 +54,57 @@ export enum BuildPhase {
   CUSTOM = 'CUSTOM',
 }
 
+export const buildPhaseDisplayName: Record<BuildPhase, string> = {
+  [BuildPhase.UNKNOWN]: 'Unknown build phase',
+  [BuildPhase.QUEUE]: 'Waiting to start',
+  [BuildPhase.SPIN_UP_BUILDER]: 'Spin up build environment',
+  [BuildPhase.SET_UP_BUILD_ENVIRONMENT]: 'Set up build environment',
+  [BuildPhase.BUILDER_INFO]: 'Builder environment info',
+  [BuildPhase.START_BUILD]: 'Start build',
+  [BuildPhase.INSTALL_CUSTOM_TOOLS]: 'Install custom tools',
+  [BuildPhase.PREPARE_PROJECT]: 'Prepare project',
+  [BuildPhase.RESTORE_CACHE]: 'Restore cache',
+  [BuildPhase.INSTALL_DEPENDENCIES]: 'Install dependencies',
+  [BuildPhase.EAS_BUILD_INTERNAL]: 'Resolve build configuration',
+  [BuildPhase.PREBUILD]: 'Prebuild',
+  [BuildPhase.PREPARE_CREDENTIALS]: 'Prepare credentials',
+  [BuildPhase.CONFIGURE_EXPO_UPDATES]: 'Configure expo-updates',
+  [BuildPhase.SAVE_CACHE]: 'Save cache',
+  [BuildPhase.UPLOAD_ARTIFACTS]: 'Upload artifacts',
+  [BuildPhase.UPLOAD_APPLICATION_ARCHIVE]: 'Upload application archive',
+  [BuildPhase.UPLOAD_BUILD_ARTIFACTS]: 'Upload build artifacts',
+  [BuildPhase.PREPARE_ARTIFACTS]: 'Prepare artifacts',
+  [BuildPhase.CLEAN_UP_CREDENTIALS]: 'Clean up credentials',
+  [BuildPhase.COMPLETE_BUILD]: 'Complete build',
+  [BuildPhase.FAIL_BUILD]: 'Fail build',
+  [BuildPhase.READ_APP_CONFIG]: 'Read app config',
+  [BuildPhase.READ_PACKAGE_JSON]: 'Read package.json',
+  [BuildPhase.RUN_EXPO_DOCTOR]: 'Run expo doctor',
+  [BuildPhase.DOWNLOAD_APPLICATION_ARCHIVE]: 'Download application archive',
+
+  // ANDROID
+  [BuildPhase.FIX_GRADLEW]: 'Fix gradlew',
+  [BuildPhase.RUN_GRADLEW]: 'Run gradlew',
+
+  // IOS
+  [BuildPhase.INSTALL_PODS]: 'Install pods',
+  [BuildPhase.CONFIGURE_XCODE_PROJECT]: 'Configure Xcode project',
+  [BuildPhase.RUN_FASTLANE]: 'Run fastlane',
+
+  // HOOKS
+  [BuildPhase.PRE_INSTALL_HOOK]: 'Pre-install hook',
+  [BuildPhase.POST_INSTALL_HOOK]: 'Post-install hook',
+  [BuildPhase.PRE_UPLOAD_ARTIFACTS_HOOK]: 'Pre-upload-artifacts hook',
+  [BuildPhase.ON_BUILD_SUCCESS_HOOK]: 'Build success hook',
+  [BuildPhase.ON_BUILD_ERROR_HOOK]: 'Build error hook',
+  [BuildPhase.ON_BUILD_COMPLETE_HOOK]: 'Build complete hook',
+  [BuildPhase.ON_BUILD_CANCEL_HOOK]: 'Build cancel hook',
+
+  // CUSTOM
+  [BuildPhase.CUSTOM]: 'Unknown build phase',
+  [BuildPhase.PARSE_CUSTOM_WORKFLOW_CONFIG]: 'Parse custom build config',
+};
+
 export enum BuildPhaseResult {
   SUCCESS = 'success',
   FAIL = 'failed',


### PR DESCRIPTION
# Why

https://linear.app/expo/issue/ENG-9955/link-to-build-logs-from-eas-cli-when-build-fails-for-unknown-reason

# How

Add information about the build phase to the `ExternalBuildError` interface. Add mappings from build phase enum to build phase display names and ids so they can be shared between multiple repos using `eas-build-job` package

# Test Plan

Tests
