### PR TITLE
[build-tools] start using build phase in unknown error constructor

### DIFF
--- a/packages/build-tools/src/buildErrors/detectError.ts
+++ b/packages/build-tools/src/buildErrors/detectError.ts
@@ -77,7 +77,7 @@ export async function resolveBuildPhaseErrorAsync(
     error instanceof errors.UserFacingError
       ? error
       : resolveError(userErrorHandlers, logLines, errorContext, xcodeBuildLogs) ??
-        new errors.UnknownError();
+        new errors.UnknownError(errorContext.phase);
   const buildError = resolveError(buildErrorHandlers, logLines, errorContext, xcodeBuildLogs);
 
   const isUnknownUserError =


### PR DESCRIPTION
# Why

Use the build phase in the unknown error constructor modified in https://github.com/expo/eas-build/pull/274.

# How

Use the build phase in the unknown error constructor

# Test Plan

Tests
