### PR TITLE
Export PackageManager enum

### DIFF
--- a/packages/build-tools/src/index.ts
+++ b/packages/build-tools/src/index.ts
@@ -11,6 +11,8 @@ export {
   SkipNativeBuildError,
 } from './context';
 
+export { PackageManager } from './utils/packageManager';
+
 export { findAndUploadXcodeBuildLogsAsync } from './ios/xcodeBuildLogs';
 
 export { Hook, runHookIfPresent } from './utils/hooks';


### PR DESCRIPTION

# Why

BuildContext contains `packageManager` field, but it can't be used outsidee of build-tools context without this export.
It will be used to fix https://exponent-internal.slack.com/archives/C02123T524U/p1693517365601279

# How

Explicitly export PackageManager in 'index.ts`