### PR TITLE
[ci] fix licence update workflow

### DIFF
--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -1,7 +1,8 @@
 name: License
 on:
-  schedule:
-    - cron: '0 0 1 1-12/3 *' # Run every three months
+  push:
+    branches:
+      - '@szdziedzic/fix-licence-bump-workflow'
 
 jobs:
   test:

--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -1,7 +1,7 @@
 name: License
 on:
   schedule:
-    - cron: '0 0 1 1-12/3 *'  # Run every three months
+    - cron: '0 0 1 1-12/3 *' # Run every three months
 
 jobs:
   test:
@@ -9,6 +9,8 @@ jobs:
     name: Update BSL change date
     steps:
       - uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.EXPO_BOT_PAT }}
       - name: Check last commit date
         run: |
           # The date in the license

--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -1,8 +1,7 @@
 name: License
 on:
-  push:
-    branches:
-      - '@szdziedzic/fix-licence-bump-workflow'
+  schedule:
+    - cron: '0 0 1 1-12/3 *' # Run every three months
 
 jobs:
   test:


### PR DESCRIPTION
# Why

https://github.com/expo/eas-build/actions/runs/5428081654/job/14701165896

This workflow broke because of the new branch protection rules we introduced for this repo. 

# How

Use Expo Bot PAT to authorize the update commit. Make an exception in the branch protection rules for Expo Bot (the same way as Dominik did for the `eas-cli` repo some time ago).

# Test Plan

Run workflow.
