### PR TITLE
[build-tools] [ENG-10068]: support bun as preferred package managee for build tools

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -6,6 +6,8 @@
 
 - Install eas-cli (either from npm or use locally cloned repository)
 - Run `yarn && yarn start` in root of the repository
+- Run `npm i -g @vercel/ncc` (compiles the package with dependencies into one file, needed for running tests)
+- Run `yarn build` in the root of the repository (this allows using interdependencies in packages)
 - Test your changes by running build with flag `--local`
 
 You can use the script below to simplify the development process. `./path/to/script build --local`

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -6,7 +6,6 @@
 
 - Install eas-cli (either from npm or use locally cloned repository)
 - Run `yarn && yarn start` in root of the repository
-- Run `npm i -g @vercel/ncc` (compiles the package with dependencies into one file, needed for running tests)
 - Run `yarn build` in the root of the repository (this allows using interdependencies in packages)
 - Test your changes by running build with flag `--local`
 

--- a/packages/build-tools/package.json
+++ b/packages/build-tools/package.json
@@ -26,7 +26,7 @@
     "@expo/downloader": "1.0.37",
     "@expo/eas-build-job": "1.0.43",
     "@expo/logger": "1.0.37",
-    "@expo/package-manager": "^1.0.2",
+    "@expo/package-manager": "1.1.1",
     "@expo/plist": "^0.0.20",
     "@expo/steps": "1.0.37",
     "@expo/template-file": "1.0.37",

--- a/packages/build-tools/src/steps/functions/prebuild.ts
+++ b/packages/build-tools/src/steps/functions/prebuild.ts
@@ -57,6 +57,8 @@ export function createPrebuildBuildFunction(): BuildFunction {
         await spawn('yarn', argsWithExpo, options);
       } else if (packageManager === PackageManager.PNPM) {
         await spawn('pnpm', argsWithExpo, options);
+      } else if (packageManager === PackageManager.BUN) {
+        await spawn('bun', argsWithExpo, options);
       } else {
         throw new Error(`Unsupported package manager: ${packageManager}`);
       }

--- a/packages/build-tools/src/utils/__tests__/project.test.ts
+++ b/packages/build-tools/src/utils/__tests__/project.test.ts
@@ -62,6 +62,22 @@ describe(runExpoCliCommand, () => {
       expect(spawn).toHaveBeenCalledWith('pnpm', ['expo', 'doctor'], expect.any(Object));
     });
 
+    it('spawns expo via "bun" when package manager is bun', () => {
+      const mockExpoConfig = mock<ExpoConfig>();
+      when(mockExpoConfig.sdkVersion).thenReturn('46.0.0');
+      const expoConfig = instance(mockExpoConfig);
+
+      const mockCtx = mock<BuildContext<Android.Job>>();
+      when(mockCtx.packageManager).thenReturn(PackageManager.BUN);
+      when(mockCtx.appConfig).thenReturn(expoConfig);
+      when(mockCtx.runGlobalExpoCliCommand).thenReturn(jest.fn());
+      const ctx = instance(mockCtx);
+
+      void runExpoCliCommand(ctx, ['doctor'], {}, { npmVersionAtLeast7: true });
+      expect(ctx.runGlobalExpoCliCommand).not.toHaveBeenCalled();
+      expect(spawn).toHaveBeenCalledWith('bun', ['expo', 'doctor'], expect.any(Object));
+    });
+
     it('calls ctx.runGlobalExpoCliCommand if forceUseGlobalExpoCli = true', () => {
       const mockExpoConfig = mock<ExpoConfig>();
       when(mockExpoConfig.sdkVersion).thenReturn('46.0.0');

--- a/packages/build-tools/src/utils/packageManager.ts
+++ b/packages/build-tools/src/utils/packageManager.ts
@@ -6,6 +6,7 @@ export enum PackageManager {
   YARN = 'yarn',
   NPM = 'npm',
   PNPM = 'pnpm',
+  BUN = 'bun',
 }
 
 export function resolvePackageManager(directory: string): PackageManager {
@@ -15,6 +16,8 @@ export function resolvePackageManager(directory: string): PackageManager {
       return PackageManager.NPM;
     } else if (manager === 'pnpm') {
       return PackageManager.PNPM;
+    } else if (manager === 'bun') {
+      return PackageManager.BUN;
     } else {
       return PackageManager.YARN;
     }

--- a/packages/build-tools/src/utils/project.ts
+++ b/packages/build-tools/src/utils/project.ts
@@ -36,6 +36,8 @@ export function runExpoCliCommand<TJob extends Job>(
       return spawn('yarn', argsWithExpo, options);
     } else if (ctx.packageManager === PackageManager.PNPM) {
       return spawn('pnpm', argsWithExpo, options);
+    } else if (ctx.packageManager === PackageManager.BUN) {
+      return spawn('bun', argsWithExpo, options);
     } else {
       throw new Error(`Unsupported package manager: ${ctx.packageManager}`);
     }

--- a/packages/create-eas-build-function/package.json
+++ b/packages/create-eas-build-function/package.json
@@ -41,6 +41,7 @@
     "@types/jest": "^29.5.3",
     "@types/node": "^18.11.18",
     "@types/prompts": "^2.4.4",
+    "@vercel/ncc": "^0.38.0",
     "chalk": "4.1.2",
     "fs-extra": "^11.1.1",
     "ora": "^6.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -642,6 +642,23 @@
     json5 "^2.2.2"
     write-file-atomic "^2.3.0"
 
+"@expo/package-manager@1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@expo/package-manager/-/package-manager-1.1.1.tgz#065326c5684c2acfbfdc290d93eabb7a36225507"
+  integrity sha512-NxtfIA25iEiNwMT+s8PEmdKzjyfWd2qkCLJkf6jKZGaH9c06YXyOAi2jvCyM8XuSzJz4pcEH8kz1HkJAInjB7Q==
+  dependencies:
+    "@expo/json-file" "^8.2.37"
+    "@expo/spawn-async" "^1.5.0"
+    ansi-regex "^5.0.0"
+    chalk "^4.0.0"
+    find-up "^5.0.0"
+    find-yarn-workspace-root "~2.0.0"
+    js-yaml "^3.13.1"
+    micromatch "^4.0.2"
+    npm-package-arg "^7.0.0"
+    split "^1.0.1"
+    sudo-prompt "9.1.1"
+
 "@expo/package-manager@^1.0.2":
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/@expo/package-manager/-/package-manager-1.0.2.tgz#6c5fd0ee9b3d28c5523b2484c62c6c7b0c8dbf89"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1929,6 +1929,11 @@
     "@typescript-eslint/types" "5.62.0"
     eslint-visitor-keys "^3.3.0"
 
+"@vercel/ncc@^0.38.0":
+  version "0.38.0"
+  resolved "https://registry.yarnpkg.com/@vercel/ncc/-/ncc-0.38.0.tgz#5210def0dcf0c79640bfaf16eecce54beed58fa6"
+  integrity sha512-B4YKZMm/EqMptKSFyAq4q2SlgJe+VCmEH6Y8gf/E1pTlWbsUJpuH1ymik2Ex3aYO5mCWwV1kaSYHSQOT8+4vHA==
+
 "@xmldom/xmldom@^0.8.8":
   version "0.8.10"
   resolved "https://registry.yarnpkg.com/@xmldom/xmldom/-/xmldom-0.8.10.tgz#a1337ca426aa61cef9fe15b5b28e340a72f6fa99"


### PR DESCRIPTION
# Why

Bun is fast, and people want to use it! https://bun.sh/

# How

Updated `@expo/package-manager` to `1.1.1` which includes bun support, and use `bun` for spawning expo via bun if it is set as the selected package manager.

# Related PRs

1. 👉 `@expo/build-tools`: https://github.com/expo/eas-build/pull/279
2. `scheduler`: https://github.com/expo/turtle-v2/pull/1424
3.  `@expo/eas-json` & `eas-cli` https://github.com/expo/eas-cli/pull/2055
4. `www` https://github.com/expo/universe/pull/13473