### PR TITLE
[ENG-10130][build-tools] use `npx expo config` command as a primary way to read app config

### DIFF
--- a/packages/build-tools/src/common/prebuild.ts
+++ b/packages/build-tools/src/common/prebuild.ts
@@ -31,14 +31,16 @@ export async function prebuildAsync<TJob extends Job>(
     },
   };
 
-  const prebuildCommandArgs = getPrebuildCommandArgs(ctx);
+  const prebuildCommandArgs = await getPrebuildCommandArgs(ctx);
   await runExpoCliCommand(ctx, prebuildCommandArgs, spawnOptions, {
     npmVersionAtLeast7: await isAtLeastNpm7Async(),
   });
   await installDependenciesAsync(ctx, { logger, workingDir: resolvePackagerDir(ctx) });
 }
 
-function getPrebuildCommandArgs<TJob extends Job>(ctx: BuildContext<TJob>): string[] {
+async function getPrebuildCommandArgs<TJob extends Job>(
+  ctx: BuildContext<TJob>
+): Promise<string[]> {
   let prebuildCommand =
     ctx.job.experimental?.prebuildCommand ??
     `prebuild --non-interactive --no-install --platform ${ctx.job.platform}`;
@@ -57,7 +59,7 @@ function getPrebuildCommandArgs<TJob extends Job>(ctx: BuildContext<TJob>): stri
   if (prebuildCommand.startsWith(expoCliCommandPrefix)) {
     prebuildCommand = prebuildCommand.substring(expoCliCommandPrefix.length).trim();
   }
-  if (!shouldUseGlobalExpoCli(ctx)) {
+  if (!(await shouldUseGlobalExpoCli(ctx))) {
     prebuildCommand = prebuildCommand.replace(' --non-interactive', '');
   }
   return prebuildCommand.split(' ');

--- a/packages/build-tools/src/common/setup.ts
+++ b/packages/build-tools/src/common/setup.ts
@@ -63,7 +63,7 @@ export async function setupAsync<TJob extends Job>(ctx: BuildContext<TJob>): Pro
   }
 
   await ctx.runBuildPhase(BuildPhase.READ_APP_CONFIG, async () => {
-    const appConfig = ctx.appConfig;
+    const appConfig = await ctx.getAppConfig();
     ctx.logger.info('Using app configuration:');
     ctx.logger.info(JSON.stringify(appConfig, null, 2));
     await validateAppConfigAsync(ctx, appConfig);
@@ -96,7 +96,7 @@ async function runExpoDoctor<TJob extends Job>(ctx: BuildContext<TJob>): Promise
   const isAtLeastNpm7 = await isAtLeastNpm7Async();
   try {
     let promise: SpawnPromise<SpawnResult>;
-    if (!shouldUseGlobalExpoCli(ctx)) {
+    if (!(await shouldUseGlobalExpoCli(ctx))) {
       const argsPrefix = isAtLeastNpm7 ? ['-y'] : [];
       promise = spawn('npx', [...argsPrefix, 'expo-doctor'], {
         cwd: ctx.getReactNativeProjectDirectory(),

--- a/packages/build-tools/src/context.ts
+++ b/packages/build-tools/src/context.ts
@@ -21,6 +21,7 @@ import { PackageManager, resolvePackageManager } from './utils/packageManager';
 import { resolveBuildPhaseErrorAsync } from './buildErrors/detectError';
 import { readAppConfig } from './utils/appConfig';
 import { createTemporaryEnvironmentSecretFile } from './utils/environmentSecrets';
+import { readAppConfigUsingExpoConfigCommandAsync } from './utils/project';
 
 export enum ArtifactType {
   APPLICATION_ARCHIVE = 'APPLICATION_ARCHIVE',
@@ -166,16 +167,6 @@ export class BuildContext<TJob extends Job> {
   public get packageManager(): PackageManager {
     return resolvePackageManager(this.getReactNativeProjectDirectory());
   }
-  public get appConfig(): ExpoConfig {
-    if (!this._appConfig) {
-      this._appConfig = readAppConfig(
-        this.getReactNativeProjectDirectory(),
-        this.env,
-        this.logger
-      ).exp;
-    }
-    return this._appConfig;
-  }
 
   public async runBuildPhase<T>(
     buildPhase: BuildPhase,
@@ -248,6 +239,15 @@ export class BuildContext<TJob extends Job> {
     }
     this._job = { ...job, triggeredBy: this._job.triggeredBy };
     this._metadata = metadata;
+  }
+
+  public async getAppConfig(): Promise<ExpoConfig> {
+    if (!this._appConfig) {
+      this._appConfig =
+        (await readAppConfigUsingExpoConfigCommandAsync(this)) ??
+        readAppConfig(this.getReactNativeProjectDirectory(), this.env, this.logger).exp;
+    }
+    return this._appConfig;
   }
 
   private async handleBuildPhaseErrorAsync(

--- a/packages/build-tools/src/utils/__tests__/project.test.ts
+++ b/packages/build-tools/src/utils/__tests__/project.test.ts
@@ -21,7 +21,7 @@ describe(runExpoCliCommand, () => {
 
       const mockCtx = mock<BuildContext<Android.Job>>();
       when(mockCtx.packageManager).thenReturn(PackageManager.NPM);
-      when(mockCtx.appConfig).thenReturn(expoConfig);
+      when(mockCtx.getAppConfig).thenReturn(async () => expoConfig);
       when(mockCtx.runGlobalExpoCliCommand).thenReturn(jest.fn());
       const ctx = instance(mockCtx);
 
@@ -37,7 +37,7 @@ describe(runExpoCliCommand, () => {
 
       const mockCtx = mock<BuildContext<Android.Job>>();
       when(mockCtx.packageManager).thenReturn(PackageManager.NPM);
-      when(mockCtx.appConfig).thenReturn(expoConfig);
+      when(mockCtx.getAppConfig).thenReturn(async () => expoConfig);
       when(mockCtx.runGlobalExpoCliCommand).thenReturn(jest.fn());
       const ctx = instance(mockCtx);
 
@@ -53,7 +53,7 @@ describe(runExpoCliCommand, () => {
 
       const mockCtx = mock<BuildContext<Android.Job>>();
       when(mockCtx.packageManager).thenReturn(PackageManager.PNPM);
-      when(mockCtx.appConfig).thenReturn(expoConfig);
+      when(mockCtx.getAppConfig).thenReturn(async () => expoConfig);
       when(mockCtx.runGlobalExpoCliCommand).thenReturn(jest.fn());
       const ctx = instance(mockCtx);
 
@@ -69,7 +69,7 @@ describe(runExpoCliCommand, () => {
 
       const mockCtx = mock<BuildContext<Android.Job>>();
       when(mockCtx.packageManager).thenReturn(PackageManager.BUN);
-      when(mockCtx.appConfig).thenReturn(expoConfig);
+      when(mockCtx.getAppConfig).thenReturn(async () => expoConfig);
       when(mockCtx.runGlobalExpoCliCommand).thenReturn(jest.fn());
       const ctx = instance(mockCtx);
 
@@ -85,7 +85,7 @@ describe(runExpoCliCommand, () => {
 
       const mockCtx = mock<BuildContext<Android.Job>>();
       when(mockCtx.packageManager).thenReturn(PackageManager.PNPM);
-      when(mockCtx.appConfig).thenReturn(expoConfig);
+      when(mockCtx.getAppConfig).thenReturn(async () => expoConfig);
       when(mockCtx.runGlobalExpoCliCommand).thenReturn(jest.fn());
       const ctx = instance(mockCtx);
 
@@ -113,7 +113,7 @@ describe(runExpoCliCommand, () => {
       const mockCtx = mock<BuildContext<Android.Job>>();
       when(mockCtx.env).thenReturn({ EXPO_USE_LOCAL_CLI: '0' });
       when(mockCtx.packageManager).thenReturn(PackageManager.PNPM);
-      when(mockCtx.appConfig).thenReturn(expoConfig);
+      when(mockCtx.getAppConfig).thenReturn(async () => expoConfig);
       when(mockCtx.runGlobalExpoCliCommand).thenReturn(jest.fn());
       const ctx = instance(mockCtx);
 
@@ -135,7 +135,7 @@ describe(runExpoCliCommand, () => {
 
       const mockCtx = mock<BuildContext<Android.Job>>();
       when(mockCtx.packageManager).thenReturn(PackageManager.PNPM);
-      when(mockCtx.appConfig).thenReturn(expoConfig);
+      when(mockCtx.getAppConfig).thenReturn(async () => expoConfig);
       when(mockCtx.runGlobalExpoCliCommand).thenReturn(jest.fn());
       const ctx = instance(mockCtx);
 

--- a/packages/build-tools/src/utils/expoUpdates.ts
+++ b/packages/build-tools/src/utils/expoUpdates.ts
@@ -143,7 +143,8 @@ export async function configureExpoUpdatesIfInstalledAsync(ctx: BuildContext<Job
   }
 
   const appConfigRuntimeVersion =
-    ctx.job.version?.runtimeVersion ?? getRuntimeVersionNullable(ctx.appConfig, ctx.job.platform);
+    ctx.job.version?.runtimeVersion ??
+    getRuntimeVersionNullable(await ctx.getAppConfig(), ctx.job.platform);
   if (ctx.metadata?.runtimeVersion && ctx.metadata?.runtimeVersion !== appConfigRuntimeVersion) {
     ctx.markBuildPhaseHasWarnings();
     ctx.logger.warn(
@@ -154,7 +155,7 @@ export async function configureExpoUpdatesIfInstalledAsync(ctx: BuildContext<Job
     );
   }
 
-  if (isEASUpdateConfigured(ctx)) {
+  if (await isEASUpdateConfigured(ctx)) {
     if (ctx.job.updates?.channel !== undefined) {
       await configureEASExpoUpdatesAsync(ctx);
     } else {
@@ -212,8 +213,8 @@ export async function getRuntimeVersionAsync(ctx: BuildContext<Job>): Promise<st
   }
 }
 
-export function isEASUpdateConfigured(ctx: BuildContext<Job>): boolean {
-  const rawUrl = ctx.appConfig.updates?.url;
+export async function isEASUpdateConfigured(ctx: BuildContext<Job>): Promise<boolean> {
+  const rawUrl = (await ctx.getAppConfig()).updates?.url;
   if (!rawUrl) {
     return false;
   }


### PR DESCRIPTION
# Why

https://linear.app/expo/issue/ENG-10130/ensure-that-read-app-config-is-evaluated-in-a-way-that-it-loads-the

# How

Use the `npx expo config --type public --json` command as a primary source of truth regarding reading app config. If it fails fallback to current implementation using `getConfig` function from `@expo/config` package.

# Test Plan

Test locally.
