### PR TITLE
[eas-build-job] [ENG-10225] add requiredPackageManager to build metadata

### DIFF
--- a/packages/eas-build-job/src/__tests__/metadata.test.ts
+++ b/packages/eas-build-job/src/__tests__/metadata.test.ts
@@ -23,6 +23,7 @@ describe('MetadataSchema', () => {
       buildMode: 'build',
       customWorkflowName: 'blah blah',
       developmentClient: true,
+      requiredPackageManager: 'yarn',
     };
     const { value, error } = MetadataSchema.validate(metadata, {
       stripUnknown: true,
@@ -53,6 +54,7 @@ describe('MetadataSchema', () => {
       buildMode: 'resign',
       customWorkflowName: 'blah blah',
       developmentClient: true,
+      requiredPackageManager: 'yarn',
     };
     const { error } = MetadataSchema.validate(metadata, {
       stripUnknown: true,

--- a/packages/eas-build-job/src/metadata.ts
+++ b/packages/eas-build-job/src/metadata.ts
@@ -149,6 +149,11 @@ export type Metadata = {
    * Indicates whether this is (likely, we can't be 100% sure) development client build.
    */
   developmentClient?: boolean;
+
+  /**
+   * Which package manager will be used for the build. Determined based on lockfiles in the project directory.
+   */
+  requiredPackageManager?: 'npm' | 'pnpm' | 'yarn' | 'bun';
 };
 
 export const MetadataSchema = Joi.object({
@@ -180,6 +185,7 @@ export const MetadataSchema = Joi.object({
   buildMode: Joi.string().valid('build', 'resign', 'custom'),
   customWorkflowName: Joi.string(),
   developmentClient: Joi.boolean(),
+  requiredPackageManager: Joi.string().valid('npm', 'pnpm', 'yarn', 'bun'),
 });
 
 export function sanitizeMetadata(metadata: object): Metadata {


### PR DESCRIPTION
# Why

We want to know what the user's package manager is going to be at the "install custom tools" step of the build process, so we're determining it based on the user's lockfiles and adding it to build metadata.

1. 👉  `eas-build-job` https://github.com/expo/eas-build/pull/281
2. `www` https://github.com/expo/universe/pull/13522
3. `eas-cli` https://github.com/expo/eas-cli/pull/2067

# How

Added the field.

# Test Plan

Unit tests and building locally.
