### PR TITLE
Add `NVM_NODEJS_ORG_MIRROR` which will be part of `turtle-v2`

### DIFF
--- a/packages/local-build-plugin/src/build.ts
+++ b/packages/local-build-plugin/src/build.ts
@@ -25,8 +25,8 @@ export async function buildAsync(job: Job, metadata: Metadata): Promise<void> {
     const unfilteredEnv: Record<string, string | undefined> = {
       ...process.env,
       ...job.builderEnvironment?.env,
-      // We don't use Node.js mirror locally
-      NVM_NODEJS_ORG_MIRROR: undefined,
+      // We don't use Node.js mirror locally, but a user might
+      NVM_NODEJS_ORG_MIRROR: process.env.NVM_NODEJS_ORG_MIRROR,
       EAS_BUILD: '1',
       EAS_BUILD_RUNNER: 'local-build-plugin',
       EAS_BUILD_PLATFORM: job.platform,

--- a/packages/local-build-plugin/src/build.ts
+++ b/packages/local-build-plugin/src/build.ts
@@ -25,6 +25,8 @@ export async function buildAsync(job: Job, metadata: Metadata): Promise<void> {
     const unfilteredEnv: Record<string, string | undefined> = {
       ...process.env,
       ...job.builderEnvironment?.env,
+      // We don't use Node.js mirror locally
+      NVM_NODEJS_ORG_MIRROR: undefined,
       EAS_BUILD: '1',
       EAS_BUILD_RUNNER: 'local-build-plugin',
       EAS_BUILD_PLATFORM: job.platform,


### PR DESCRIPTION
# Why

Counterpart to https://github.com/expo/turtle-v2/pull/1448.

# How

Add `NVM_NODEJS_ORG_MIRROR` which we'll soon use in the real Turtle.

# Test Plan

None.