### PR TITLE
[eas-build-job] [ENG-9957] Add simulator flag to metadata

### DIFF
--- a/packages/eas-build-job/src/__tests__/metadata.test.ts
+++ b/packages/eas-build-job/src/__tests__/metadata.test.ts
@@ -24,6 +24,7 @@ describe('MetadataSchema', () => {
       customWorkflowName: 'blah blah',
       developmentClient: true,
       requiredPackageManager: 'yarn',
+      simulator: true,
     };
     const { value, error } = MetadataSchema.validate(metadata, {
       stripUnknown: true,
@@ -55,6 +56,7 @@ describe('MetadataSchema', () => {
       customWorkflowName: 'blah blah',
       developmentClient: true,
       requiredPackageManager: 'yarn',
+      simulator: false,
     };
     const { error } = MetadataSchema.validate(metadata, {
       stripUnknown: true,

--- a/packages/eas-build-job/src/metadata.ts
+++ b/packages/eas-build-job/src/metadata.ts
@@ -74,6 +74,7 @@ export type Metadata = {
   /**
    * Distribution type
    * Indicates whether this is a build for store, internal distribution, or simulator (iOS).
+   * simulator is deprecated, use simulator flag instead
    */
   distribution?: 'store' | 'internal' | 'simulator';
 
@@ -154,6 +155,11 @@ export type Metadata = {
    * Which package manager will be used for the build. Determined based on lockfiles in the project directory.
    */
   requiredPackageManager?: 'npm' | 'pnpm' | 'yarn' | 'bun';
+
+  /**
+   * Indicates if this is an iOS build for a simulator
+   */
+  simulator?: boolean;
 };
 
 export const MetadataSchema = Joi.object({
@@ -186,6 +192,7 @@ export const MetadataSchema = Joi.object({
   customWorkflowName: Joi.string(),
   developmentClient: Joi.boolean(),
   requiredPackageManager: Joi.string().valid('npm', 'pnpm', 'yarn', 'bun'),
+  simulator: Joi.boolean(),
 });
 
 export function sanitizeMetadata(metadata: object): Metadata {


### PR DESCRIPTION
# Why

https://linear.app/expo/issue/ENG-9957/fix-internal-distribution-pages-for-simulator-builds
Discussion: https://github.com/expo/universe/pull/13523#discussion_r1340072623
Companion to
- https://github.com/expo/universe/pull/13523
- https://github.com/expo/universe/pull/13524

# How

Adds optional simulator flag to metadata to use that instead of overwriting the distribution and losing information if the build is local or not

# Test Plan

Updated metadata test
