### PR TITLE
Add `--inline-builds` to Yarn install

### DIFF
--- a/packages/build-tools/src/common/installDependencies.ts
+++ b/packages/build-tools/src/common/installDependencies.ts
@@ -18,7 +18,7 @@ export async function installDependenciesAsync<TJob extends Job>(
   } else if (ctx.packageManager === PackageManager.YARN) {
     const isYarn2 = await isUsingYarn2(ctx.getReactNativeProjectDirectory());
     if (isYarn2) {
-      args = ['install', '--no-immutable'];
+      args = ['install', '--no-immutable', '--inline-builds'];
     }
   }
   logger.info(`Running "${ctx.packageManager} ${args.join(' ')}" in ${workingDir} directory`);

--- a/packages/build-tools/src/steps/functions/installNodeModules.ts
+++ b/packages/build-tools/src/steps/functions/installNodeModules.ts
@@ -33,7 +33,7 @@ export async function installNodeModules(
   } else if (packageManager === PackageManager.YARN) {
     const isYarn2 = await isUsingYarn2(stepCtx.workingDirectory);
     if (isYarn2) {
-      args = ['install', '--no-immutable'];
+      args = ['install', '--no-immutable', '--inline-builds'];
     }
   }
   logger.info(`Running "${packageManager} ${args.join(' ')}" in ${packagerRunDir} directory`);


### PR DESCRIPTION
# Why

`--inline-builds` is an interesting option that may help users and us debug Yarn Install errors. ([source](https://github.com/yarnpkg/berry/issues/3764#issuecomment-974519373), [related](https://exponent-internal.slack.com/archives/C031ZK9UWAC/p1698663231179249?thread_ts=1698430427.434299&cid=C031ZK9UWAC))

<img width="901" alt="Zrzut ekranu 2023-10-30 o 11 56 51" src="https://github.com/expo/eas-build/assets/1151041/253dcb86-2ae1-4583-bf52-9d4694916eef">

The option [first](https://github.com/yarnpkg/berry/pull/160) appeared in Yarn v2.

# How

Added `--inline-builds` to `yarn install` options.

# Test Plan

Ran `yarn install --inline-builds` in an example project of mine on Yarn 4 and Node 18.