### PR TITLE
[ENG-10566][eas-build-job] add `selectedImage` to build metadata

### DIFF
--- a/packages/eas-build-job/src/__tests__/metadata.test.ts
+++ b/packages/eas-build-job/src/__tests__/metadata.test.ts
@@ -25,6 +25,7 @@ describe('MetadataSchema', () => {
       developmentClient: true,
       requiredPackageManager: 'yarn',
       simulator: true,
+      selectedImage: 'default',
     };
     const { value, error } = MetadataSchema.validate(metadata, {
       stripUnknown: true,
@@ -57,6 +58,7 @@ describe('MetadataSchema', () => {
       developmentClient: true,
       requiredPackageManager: 'yarn',
       simulator: false,
+      selectedImage: 'default',
     };
     const { error } = MetadataSchema.validate(metadata, {
       stripUnknown: true,

--- a/packages/eas-build-job/src/metadata.ts
+++ b/packages/eas-build-job/src/metadata.ts
@@ -160,6 +160,11 @@ export type Metadata = {
    * Indicates if this is an iOS build for a simulator
    */
   simulator?: boolean;
+
+  /**
+   * Image selected by user for the build. If user didn't select any image and wants to use default for the given RN and SDK version it will undefined.
+   */
+  selectedImage?: string;
 };
 
 export const MetadataSchema = Joi.object({
@@ -193,6 +198,7 @@ export const MetadataSchema = Joi.object({
   developmentClient: Joi.boolean(),
   requiredPackageManager: Joi.string().valid('npm', 'pnpm', 'yarn', 'bun'),
   simulator: Joi.boolean(),
+  selectedImage: Joi.string(),
 });
 
 export function sanitizeMetadata(metadata: object): Metadata {


### PR DESCRIPTION
# Why

To accomplish https://linear.app/expo/issue/ENG-10566/create-a-banner-that-links-people-to-changelog-on-build-details-pages www needs to know which image was selected by the user to run the build on.

Companion to https://github.com/expo/eas-cli/pull/2113

# How

Add the `selectedImage` field to the build's metadata, so we know what value the user put in their `eas.json->build->profile->platform->image`.

# Test Plan

Automated tests
