### PR TITLE
[ENG-10566][eas-build-job] add `customNodeVersion` to build metadata

### DIFF
--- a/packages/eas-build-job/src/__tests__/metadata.test.ts
+++ b/packages/eas-build-job/src/__tests__/metadata.test.ts
@@ -26,6 +26,7 @@ describe('MetadataSchema', () => {
       requiredPackageManager: 'yarn',
       simulator: true,
       selectedImage: 'default',
+      customNodeVersion: '12.0.0',
     };
     const { value, error } = MetadataSchema.validate(metadata, {
       stripUnknown: true,
@@ -59,6 +60,7 @@ describe('MetadataSchema', () => {
       requiredPackageManager: 'yarn',
       simulator: false,
       selectedImage: 'default',
+      customNodeVersion: '12.0.0',
     };
     const { error } = MetadataSchema.validate(metadata, {
       stripUnknown: true,

--- a/packages/eas-build-job/src/metadata.ts
+++ b/packages/eas-build-job/src/metadata.ts
@@ -165,6 +165,11 @@ export type Metadata = {
    * Image selected by user for the build. If user didn't select any image and wants to use default for the given RN and SDK version it will undefined.
    */
   selectedImage?: string;
+
+  /**
+   * Custom node version selected by user for the build. If user didn't select any node version and wants to use default it will be undefined.
+   */
+  customNodeVersion?: string;
 };
 
 export const MetadataSchema = Joi.object({
@@ -199,6 +204,7 @@ export const MetadataSchema = Joi.object({
   requiredPackageManager: Joi.string().valid('npm', 'pnpm', 'yarn', 'bun'),
   simulator: Joi.boolean(),
   selectedImage: Joi.string(),
+  customNodeVersion: Joi.string(),
 });
 
 export function sanitizeMetadata(metadata: object): Metadata {


### PR DESCRIPTION
# Why

To accomplish https://linear.app/expo/issue/ENG-10566/create-a-banner-that-links-people-to-changelog-on-build-details-pages www needs to know if custom node version was selected by the user to run the build on.

# How

Add the customNodeVersion field to the build's metadata, so we know what value the user put in their eas.json->build->profile->node.

# Test Plan

Automated tests
