### PR TITLE
[ENG-10602][build-tools] make logs more consistent in `prepare credentials` phase

### DIFF
--- a/packages/build-tools/src/ios/credentials/manager.ts
+++ b/packages/build-tools/src/ios/credentials/manager.ts
@@ -138,7 +138,7 @@ export default class IosCredentialsManager<TJob extends Ios.Job> {
       await provisioningProfile.init();
 
       this.ctx.logger.info(
-        'Validating whether distribution certificate has been imported successfully'
+        'Validating whether the distribution certificate has been imported successfully'
       );
       await this.keychain.ensureCertificateImported(
         provisioningProfile.data.teamId,


### PR DESCRIPTION
# Why

https://linear.app/expo/issue/ENG-10602/tiny-wording-consistency-nit-in-the-prepare-credentials-step

# How

Make logs more consistent.
