### PR TITLE
[ENG-10130][build-tools] use env vars from `.env` files when resolving app config same way expo CLI does

### DIFF
--- a/packages/build-tools/package.json
+++ b/packages/build-tools/package.json
@@ -25,6 +25,7 @@
     "@expo/config-plugins": "^7.2.4",
     "@expo/downloader": "1.0.37",
     "@expo/eas-build-job": "1.0.50",
+    "@expo/env": "^0.0.5",
     "@expo/logger": "1.0.52",
     "@expo/package-manager": "1.1.2",
     "@expo/plist": "^0.0.20",

--- a/packages/build-tools/src/context.ts
+++ b/packages/build-tools/src/context.ts
@@ -168,11 +168,12 @@ export class BuildContext<TJob extends Job> {
   }
   public get appConfig(): ExpoConfig {
     if (!this._appConfig) {
-      this._appConfig = readAppConfig(
-        this.getReactNativeProjectDirectory(),
-        this.env,
-        this.logger
-      ).exp;
+      this._appConfig = readAppConfig({
+        projectDir: this.getReactNativeProjectDirectory(),
+        env: this.env,
+        logger: this.logger,
+        sdkVersion: this.metadata?.sdkVersion,
+      }).exp;
     }
     return this._appConfig;
   }

--- a/packages/build-tools/src/customBuildContext.ts
+++ b/packages/build-tools/src/customBuildContext.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 
-import { BuildPhase, Env, Job, Platform } from '@expo/eas-build-job';
+import { BuildPhase, Env, Job, Metadata, Platform } from '@expo/eas-build-job';
 import { bunyan } from '@expo/logger';
 import { ExternalBuildContextProvider, BuildRuntimePlatform } from '@expo/steps';
 
@@ -39,12 +39,14 @@ export class CustomBuildContext implements ExternalBuildContextProvider {
   public readonly logger: bunyan;
   public readonly runtimeApi: BuilderRuntimeApi;
   public readonly job: Job;
+  public readonly metadata?: Metadata;
 
   private _env: Env;
 
   constructor(buildCtx: BuildContext<Job>) {
     this._env = buildCtx.env;
     this.job = buildCtx.job;
+    this.metadata = buildCtx.metadata;
 
     this.logger = buildCtx.logger.child({ phase: BuildPhase.CUSTOM });
     this.projectSourceDirectory = path.join(buildCtx.workingdir, 'temporary-custom-build');
@@ -67,6 +69,7 @@ export class CustomBuildContext implements ExternalBuildContextProvider {
   public staticContext(): any {
     return {
       job: this.job,
+      metadata: this.metadata,
     };
   }
 

--- a/packages/build-tools/src/steps/functions/configureEASUpdateIfInstalled.ts
+++ b/packages/build-tools/src/steps/functions/configureEASUpdateIfInstalled.ts
@@ -1,7 +1,7 @@
 import assert from 'assert';
 
 import { BuildFunction, BuildStepInput, BuildStepInputValueTypeName } from '@expo/steps';
-import { Job } from '@expo/eas-build-job';
+import { Job, Metadata } from '@expo/eas-build-job';
 import semver from 'semver';
 
 import { configureEASUpdateIfInstalledAsync } from '../utils/expoUpdates';
@@ -27,15 +27,17 @@ export function configureEASUpdateIfInstalledFunction(): BuildFunction {
     fn: async (stepCtx, { env, inputs }) => {
       assert(stepCtx.global.staticContext.job, 'Job is not defined');
       const job = stepCtx.global.staticContext.job as Job;
+      const metadata = stepCtx.global.staticContext.metadata as Metadata | undefined;
 
-      const appConfig = readAppConfig(
-        stepCtx.workingDirectory,
-        Object.keys(env).reduce((acc, key) => {
+      const appConfig = readAppConfig({
+        projectDir: stepCtx.workingDirectory,
+        env: Object.keys(env).reduce((acc, key) => {
           acc[key] = env[key] ?? '';
           return acc;
         }, {} as Record<string, string>),
-        stepCtx.logger
-      ).exp;
+        logger: stepCtx.logger,
+        sdkVersion: metadata?.sdkVersion,
+      }).exp;
 
       const releaseChannelInput = inputs.channel.value as string | undefined;
       const runtimeVersionInput = inputs.runtime_version.value as string | undefined;

--- a/packages/build-tools/src/utils/appConfig.ts
+++ b/packages/build-tools/src/utils/appConfig.ts
@@ -19,11 +19,12 @@ export function readAppConfig({
   const originalProcessCwd = process.cwd;
   const originalStdoutWrite = process.stdout.write;
   const originalStderrWrite = process.stderr.write;
+  const originalProcessEnv = process.env;
 
   const stdoutStore: { text: string; level: LoggerLevel }[] = [];
   const shouldLoadEnvVarsFromDotenvFile = sdkVersion && semver.satisfies(sdkVersion, '>=49');
   const envVarsFromDotenvFile = shouldLoadEnvVarsFromDotenvFile ? load(projectDir) : {};
-  const newEnvsToUse = { ...envVarsFromDotenvFile, ...env };
+  const newEnvsToUse = { ...env, ...envVarsFromDotenvFile };
   try {
     for (const [key, value] of Object.entries(newEnvsToUse)) {
       process.env[key] = value;
@@ -54,6 +55,9 @@ export function readAppConfig({
   } finally {
     for (const [key] of Object.entries(newEnvsToUse)) {
       delete process.env[key];
+    }
+    for (const [key, value] of Object.entries(originalProcessEnv)) {
+      process.env[key] = value;
     }
     process.exit = originalProcessExit;
     process.cwd = originalProcessCwd;

--- a/packages/build-tools/src/utils/appConfig.ts
+++ b/packages/build-tools/src/utils/appConfig.ts
@@ -1,6 +1,7 @@
 import { getConfig, ProjectConfig } from '@expo/config';
 import { Env } from '@expo/eas-build-job';
 import { bunyan, LoggerLevel } from '@expo/logger';
+import { load } from '@expo/env';
 
 export function readAppConfig(projectDir: string, env: Env, logger: bunyan): ProjectConfig {
   const originalProcessEnv: NodeJS.ProcessEnv = process.env;
@@ -11,7 +12,7 @@ export function readAppConfig(projectDir: string, env: Env, logger: bunyan): Pro
 
   const stdoutStore: { text: string; level: LoggerLevel }[] = [];
   try {
-    process.env = { ...env };
+    process.env = { ...env, ...load(projectDir) };
     process.exit = () => {
       throw new Error('Failed to evaluate app config file');
     };

--- a/yarn.lock
+++ b/yarn.lock
@@ -633,6 +633,17 @@
     slugify "^1.3.4"
     sucrase "^3.20.0"
 
+"@expo/env@^0.0.5":
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/@expo/env/-/env-0.0.5.tgz#86526ed5c966fc39b2644341f7a10f4b855e59b8"
+  integrity sha512-UXuKAqyXfhMQC3gP0OyjXmFX08Z1fkVWiGBN7bYzfoX8LHatjeHrDtI6w5nDvd8XPxPvmqaZoEDw1lW3+dz3oQ==
+  dependencies:
+    chalk "^4.0.0"
+    debug "^4.3.4"
+    dotenv "~16.0.3"
+    dotenv-expand "~10.0.0"
+    getenv "^1.0.0"
+
 "@expo/json-file@^8.2.37", "@expo/json-file@~8.2.37":
   version "8.2.37"
   resolved "https://registry.yarnpkg.com/@expo/json-file/-/json-file-8.2.37.tgz#9c02d3b42134907c69cc0a027b18671b69344049"
@@ -3197,10 +3208,20 @@ dot-prop@^5.1.0:
   dependencies:
     is-obj "^2.0.0"
 
+dotenv-expand@~10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/dotenv-expand/-/dotenv-expand-10.0.0.tgz#12605d00fb0af6d0a592e6558585784032e4ef37"
+  integrity sha512-GopVGCpVS1UKH75VKHGuQFqS1Gusej0z4FyQkPdwjil2gNIv+LNsqBlboOzpJFZKVT95GkCyWJbBSdFEFUWI2A==
+
 dotenv@~10.0.0:
   version "10.0.0"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-10.0.0.tgz#3d4227b8fb95f81096cdd2b66653fb2c7085ba81"
   integrity sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==
+
+dotenv@~16.0.3:
+  version "16.0.3"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.0.3.tgz#115aec42bac5053db3c456db30cc243a5a836a07"
+  integrity sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==
 
 dtrace-provider@~0.8:
   version "0.8.8"


### PR DESCRIPTION
# Why

https://linear.app/expo/issue/ENG-10130/ensure-that-read-app-config-is-evaluated-in-a-way-that-it-loads-the

Currently, if the `.env` file is present in project files in the EAS Build and we have `VAL1` both present in the `.env` file and in project secrets, the value used during the app compilation, by prebuild command, and by the `npx expo config --type public` command will be the one from the `.env` file. However, our internal function to read app config won't see the value from the `.env` file and will use the value from secrets. 

It confuses our users because in the `Read app config` build phase they will see the app config resolved by us using our internal function which doesn't use `.env` files, but in some cases if the same envs are present as both secret and in `.env` file it might be different for what actually will be used during prebuild and compilation. These phases will see the envs in the `.env` file and use them when they clash with envs as secrets.

# How

Install `@expo/env` as a project dependency. Use the `load` function from `@expo/env` to load values from the `.env` file when resolving app config.

# Test Plan

Run builds locally and see which value will be used.

`VAL1` is present in both the project secret and in the `.env` file

`.env` file:
```
VAL1=notsosecret
```

project secrets:
```
VAL1=secretvalue (masked)
```

Before:
![Screenshot 2023-11-14 at 17 02 17](https://github.com/expo/eas-build/assets/55145344/d4dd8f0b-9e02-4e29-8859-e4eb61fbe0c4)

After:
![Screenshot 2023-11-14 at 17 02 58](https://github.com/expo/eas-build/assets/55145344/32f75e90-fb05-446a-bf31-4ced71d9a70e)

It matches the output of the `npx expo config --type public` command.
