### PR TITLE
[ENG-10477][steps][build-tools] use correct default working directory if project wasn't checked out

### DIFF
--- a/packages/build-tools/src/steps/functions/checkout.ts
+++ b/packages/build-tools/src/steps/functions/checkout.ts
@@ -15,6 +15,7 @@ export function createCheckoutBuildFunction(): BuildFunction {
           overwrite: true,
         }
       );
+      stepsCtx.global.markAsCheckedOut();
     },
   });
 }

--- a/packages/steps/src/BuildStepContext.ts
+++ b/packages/steps/src/BuildStepContext.ts
@@ -53,6 +53,7 @@ export class BuildStepGlobalContext {
   public stepsInternalBuildDirectory: string;
   public readonly runtimePlatform: BuildRuntimePlatform;
   public readonly baseLogger: bunyan;
+  private didCheckOut = false;
 
   private stepById: Record<string, BuildStepOutputAccessor> = {};
 
@@ -74,7 +75,7 @@ export class BuildStepGlobalContext {
   }
 
   public get defaultWorkingDirectory(): string {
-    return this.provider.defaultWorkingDirectory;
+    return this.didCheckOut ? this.provider.defaultWorkingDirectory : this.projectTargetDirectory;
   }
 
   public get buildLogsDirectory(): string {
@@ -120,6 +121,10 @@ export class BuildStepGlobalContext {
 
   public stepCtx(options: { logger: bunyan; workingDirectory: string }): BuildStepContext {
     return new BuildStepContext(this, options);
+  }
+
+  public markAsCheckedOut(): void {
+    this.didCheckOut = true;
   }
 
   public serialize(): SerializedBuildStepGlobalContext {

--- a/packages/steps/src/__tests__/BuildStep-test.ts
+++ b/packages/steps/src/__tests__/BuildStep-test.ts
@@ -146,6 +146,7 @@ describe(BuildStep, () => {
 
     it('creates child build context with correct changed working directory', () => {
       const ctx = createGlobalContextMock({ workingDirectory: '/a/b/c' });
+      ctx.markAsCheckedOut();
 
       const id = 'test1';
       const command = 'ls -la';
@@ -162,6 +163,7 @@ describe(BuildStep, () => {
 
     it('creates child build context with unchanged working directory', () => {
       const ctx = createGlobalContextMock({ workingDirectory: '/a/b/c' });
+      ctx.markAsCheckedOut();
 
       const id = 'test1';
       const command = 'ls -la';

--- a/packages/steps/src/__tests__/BuildStepContext-test.ts
+++ b/packages/steps/src/__tests__/BuildStepContext-test.ts
@@ -29,19 +29,38 @@ describe(BuildStepGlobalContext, () => {
     });
   });
   describe('workingDirectory', () => {
-    it('can use the defaultWorkingDirectory returned by BuildContextProvider', () => {
+    it('if not checked out uses project target dir as default working dir', () => {
       const workingDirectory = '/path/to/working/dir';
+      const projectTargetDirectory = '/another/non/existent/path';
       const ctx = new BuildStepGlobalContext(
         new MockContextProvider(
           createMockLogger(),
           BuildRuntimePlatform.LINUX,
           '/non/existent/path',
-          '/another/non/existent/path',
+          projectTargetDirectory,
           workingDirectory,
           '/non/existent/path'
         ),
         false
       );
+      expect(ctx.defaultWorkingDirectory).toBe(projectTargetDirectory);
+    });
+
+    it('if checked out uses default working dir as default working dir', () => {
+      const workingDirectory = '/path/to/working/dir';
+      const projectTargetDirectory = '/another/non/existent/path';
+      const ctx = new BuildStepGlobalContext(
+        new MockContextProvider(
+          createMockLogger(),
+          BuildRuntimePlatform.LINUX,
+          '/non/existent/path',
+          projectTargetDirectory,
+          workingDirectory,
+          '/non/existent/path'
+        ),
+        false
+      );
+      ctx.markAsCheckedOut();
       expect(ctx.defaultWorkingDirectory).toBe(workingDirectory);
     });
   });
@@ -98,6 +117,7 @@ describe(BuildStepGlobalContext, () => {
         },
         createMockLogger()
       );
+      ctx.markAsCheckedOut();
       expect(ctx.stepsInternalBuildDirectory).toBe('/m/n/o');
       expect(ctx.defaultWorkingDirectory).toBe('/g/h/i');
       expect(ctx.runtimePlatform).toBe(BuildRuntimePlatform.DARWIN);


### PR DESCRIPTION
# Why

https://github.com/expo/eas-build/blob/1c3f2019ad05de2c1fc3dda666cc0dcafdd3e492/packages/build-tools/src/customBuildContext.ts#L52

We set the `defaultWorkingDirectory` in our external build context provider as the output of the `getReactNativeProjectDirectory()` function. This function will return `path.join(workingDir, 'build') + relativePathToEasJsonInYourGitRepo`. But unfortunately, if the user didn't call `checkout` this `relativePathToEasJsonInYourGitRepo` might not exist.

# How

Use a boolean value to monitor whether the project was checked out. If it was use the previous defaultWorkingDirectory. If not use project target dir (`workingDir + '/build'`) which always exists and it is the dir when all of the operations should be performed.

# Test Plan

Automated tests
