### PR TITLE
[steps] make `null` build step invalid in Joi schema

### DIFF
--- a/packages/steps/src/BuildConfig.ts
+++ b/packages/steps/src/BuildConfig.ts
@@ -391,15 +391,15 @@ export function mergeConfigWithImportedFunctions(
 }
 
 export function isBuildStepCommandRun(step: BuildStepConfig): step is BuildStepCommandRun {
-  return step !== null && typeof step === 'object' && typeof step.run === 'object';
+  return Boolean(step) && typeof step === 'object' && typeof step.run === 'object';
 }
 
 export function isBuildStepBareCommandRun(step: BuildStepConfig): step is BuildStepBareCommandRun {
-  return step !== null && typeof step === 'object' && typeof step.run === 'string';
+  return Boolean(step) && typeof step === 'object' && typeof step.run === 'string';
 }
 
 export function isBuildStepFunctionCall(step: BuildStepConfig): step is BuildStepFunctionCall {
-  return step !== null && typeof step === 'object' && !('run' in step);
+  return Boolean(step) && typeof step === 'object' && !('run' in step);
 }
 
 export function isBuildStepBareFunctionCall(

--- a/packages/steps/src/BuildConfig.ts
+++ b/packages/steps/src/BuildConfig.ts
@@ -194,6 +194,7 @@ const BuildFunctionCallSchema = Joi.object({
 }).rename('working_directory', 'workingDirectory');
 
 const BuildStepConfigSchema = Joi.any<BuildStepConfig>()
+  .invalid(null)
   .when(
     Joi.object().pattern(
       Joi.string().disallow('run').required(),
@@ -390,15 +391,15 @@ export function mergeConfigWithImportedFunctions(
 }
 
 export function isBuildStepCommandRun(step: BuildStepConfig): step is BuildStepCommandRun {
-  return typeof step === 'object' && typeof step.run === 'object';
+  return step !== null && typeof step === 'object' && typeof step.run === 'object';
 }
 
 export function isBuildStepBareCommandRun(step: BuildStepConfig): step is BuildStepBareCommandRun {
-  return typeof step === 'object' && typeof step.run === 'string';
+  return step !== null && typeof step === 'object' && typeof step.run === 'string';
 }
 
 export function isBuildStepFunctionCall(step: BuildStepConfig): step is BuildStepFunctionCall {
-  return typeof step === 'object' && !('run' in step);
+  return step !== null && typeof step === 'object' && !('run' in step);
 }
 
 export function isBuildStepBareFunctionCall(
@@ -415,7 +416,7 @@ export function validateAllFunctionsExist(
   for (const step of config.build.steps) {
     if (typeof step === 'string') {
       calledFunctionsSet.add(step);
-    } else if (!('run' in step)) {
+    } else if (step !== null && !('run' in step)) {
       const keys = Object.keys(step);
       assert(
         keys.length === 1,

--- a/packages/steps/src/BuildConfigParser.ts
+++ b/packages/steps/src/BuildConfigParser.ts
@@ -28,7 +28,7 @@ import { BuildStepGlobalContext } from './BuildStepContext.js';
 import { BuildStepOutput, BuildStepOutputProvider } from './BuildStepOutput.js';
 import { BuildWorkflow } from './BuildWorkflow.js';
 import { BuildWorkflowValidator } from './BuildWorkflowValidator.js';
-import { BuildStepRuntimeError } from './errors.js';
+import { BuildConfigError } from './errors.js';
 import { duplicates } from './utils/expodash/duplicates.js';
 import { uniq } from './utils/expodash/uniq.js';
 
@@ -73,8 +73,12 @@ export class BuildConfigParser {
       return this.createBuildStepFromBuildStepBareCommandRun(buildStepConfig);
     } else if (isBuildStepBareFunctionCall(buildStepConfig)) {
       return this.createBuildStepFromBuildStepBareFunctionCall(buildFunctions, buildStepConfig);
-    } else {
+    } else if (buildStepConfig !== null) {
       return this.createBuildStepFromBuildStepFunctionCall(buildFunctions, buildStepConfig);
+    } else {
+      throw new BuildConfigError(
+        'Invalid build step configuration detected. Build step cannot be empty.'
+      );
     }
   }
 
@@ -284,7 +288,7 @@ export class BuildConfigParser {
     if (duplicatedExternalFunctionIds.length === 0) {
       return;
     }
-    throw new BuildStepRuntimeError(
+    throw new BuildConfigError(
       `Provided external functions with duplicated IDs: ${duplicatedExternalFunctionIds
         .map((id) => `"${id}"`)
         .join(', ')}`

--- a/packages/steps/src/__tests__/BuildConfigParser-test.ts
+++ b/packages/steps/src/__tests__/BuildConfigParser-test.ts
@@ -30,7 +30,7 @@ describe(BuildConfigParser, () => {
           ],
         });
       });
-      expect(error).toBeInstanceOf(BuildStepRuntimeError);
+      expect(error).toBeInstanceOf(BuildConfigError);
       expect(error.message).toMatch(/Provided external functions with duplicated IDs/);
     });
 


### PR DESCRIPTION
# Why

If you had config like
```yml
build:
  name: Demo
  steps:
    - eas/checkout
    -
```

In CLI you would get 
<img width="973" alt="Screenshot 2023-11-21 at 16 44 14" src="https://github.com/expo/eas-build/assets/55145344/1b64d93f-485c-494a-96c9-3017f0b4cda4">


# How

Make `null` invalid.

# Test Plan

<img width="973" alt="Screenshot 2023-11-21 at 17 03 44" src="https://github.com/expo/eas-build/assets/55145344/f1cbc4b0-00bb-4a09-93da-3a9f084d10c8">


