### PR TITLE
[steps] make generic job workflow always throw first error

### DIFF
--- a/packages/steps/src/BuildWorkflow.ts
+++ b/packages/steps/src/BuildWorkflow.ts
@@ -23,7 +23,9 @@ export class BuildWorkflow {
         try {
           await step.executeAsync();
         } catch (err: any) {
-          maybeError = err;
+          if (!maybeError) {
+            maybeError = err;
+          }
           hasAnyPreviousStepFailed = true;
         }
       } else {

--- a/packages/steps/src/BuildWorkflow.ts
+++ b/packages/steps/src/BuildWorkflow.ts
@@ -23,9 +23,7 @@ export class BuildWorkflow {
         try {
           await step.executeAsync();
         } catch (err: any) {
-          if (!maybeError) {
-            maybeError = err;
-          }
+          maybeError = maybeError ?? err;
           hasAnyPreviousStepFailed = true;
         }
       } else {

--- a/packages/steps/src/__tests__/BuildWorkflow-test.ts
+++ b/packages/steps/src/__tests__/BuildWorkflow-test.ts
@@ -131,7 +131,7 @@ describe(BuildWorkflow, () => {
       verify(mockBuildStep3.executeAsync()).once();
     });
 
-    it('throws always the fist error', async () => {
+    it('throws always the first error', async () => {
       const mockBuildStep1 = mock<BuildStep>();
       const mockBuildStep2 = mock<BuildStep>();
       const mockBuildStep3 = mock<BuildStep>();


### PR DESCRIPTION
# Why

https://github.com/expo/eas-build/pull/292#discussion_r1401027194

# How

Always throw the first error when running generic job workflow

# Test Plan

Add test
