### PR TITLE
Revert "[ENG-10477][steps][build-tools] use correct default working directory if project wasn't checked out"

### DIFF
--- a/packages/build-tools/src/steps/functions/checkout.ts
+++ b/packages/build-tools/src/steps/functions/checkout.ts
@@ -15,7 +15,6 @@ export function createCheckoutBuildFunction(): BuildFunction {
           overwrite: true,
         }
       );
-      stepsCtx.global.markAsCheckedOut();
     },
   });
 }

--- a/packages/steps/src/BuildStepContext.ts
+++ b/packages/steps/src/BuildStepContext.ts
@@ -53,7 +53,6 @@ export class BuildStepGlobalContext {
   public stepsInternalBuildDirectory: string;
   public readonly runtimePlatform: BuildRuntimePlatform;
   public readonly baseLogger: bunyan;
-  private didCheckOut = false;
 
   private stepById: Record<string, BuildStepOutputAccessor> = {};
 
@@ -75,7 +74,7 @@ export class BuildStepGlobalContext {
   }
 
   public get defaultWorkingDirectory(): string {
-    return this.didCheckOut ? this.provider.defaultWorkingDirectory : this.projectTargetDirectory;
+    return this.provider.defaultWorkingDirectory;
   }
 
   public get buildLogsDirectory(): string {
@@ -121,10 +120,6 @@ export class BuildStepGlobalContext {
 
   public stepCtx(options: { logger: bunyan; workingDirectory: string }): BuildStepContext {
     return new BuildStepContext(this, options);
-  }
-
-  public markAsCheckedOut(): void {
-    this.didCheckOut = true;
   }
 
   public serialize(): SerializedBuildStepGlobalContext {

--- a/packages/steps/src/__tests__/BuildStep-test.ts
+++ b/packages/steps/src/__tests__/BuildStep-test.ts
@@ -146,7 +146,6 @@ describe(BuildStep, () => {
 
     it('creates child build context with correct changed working directory', () => {
       const ctx = createGlobalContextMock({ workingDirectory: '/a/b/c' });
-      ctx.markAsCheckedOut();
 
       const id = 'test1';
       const command = 'ls -la';
@@ -163,7 +162,6 @@ describe(BuildStep, () => {
 
     it('creates child build context with unchanged working directory', () => {
       const ctx = createGlobalContextMock({ workingDirectory: '/a/b/c' });
-      ctx.markAsCheckedOut();
 
       const id = 'test1';
       const command = 'ls -la';

--- a/packages/steps/src/__tests__/BuildStepContext-test.ts
+++ b/packages/steps/src/__tests__/BuildStepContext-test.ts
@@ -29,38 +29,19 @@ describe(BuildStepGlobalContext, () => {
     });
   });
   describe('workingDirectory', () => {
-    it('if not checked out uses project target dir as default working dir', () => {
+    it('can use the defaultWorkingDirectory returned by BuildContextProvider', () => {
       const workingDirectory = '/path/to/working/dir';
-      const projectTargetDirectory = '/another/non/existent/path';
       const ctx = new BuildStepGlobalContext(
         new MockContextProvider(
           createMockLogger(),
           BuildRuntimePlatform.LINUX,
           '/non/existent/path',
-          projectTargetDirectory,
+          '/another/non/existent/path',
           workingDirectory,
           '/non/existent/path'
         ),
         false
       );
-      expect(ctx.defaultWorkingDirectory).toBe(projectTargetDirectory);
-    });
-
-    it('if checked out uses default working dir as default working dir', () => {
-      const workingDirectory = '/path/to/working/dir';
-      const projectTargetDirectory = '/another/non/existent/path';
-      const ctx = new BuildStepGlobalContext(
-        new MockContextProvider(
-          createMockLogger(),
-          BuildRuntimePlatform.LINUX,
-          '/non/existent/path',
-          projectTargetDirectory,
-          workingDirectory,
-          '/non/existent/path'
-        ),
-        false
-      );
-      ctx.markAsCheckedOut();
       expect(ctx.defaultWorkingDirectory).toBe(workingDirectory);
     });
   });
@@ -117,7 +98,6 @@ describe(BuildStepGlobalContext, () => {
         },
         createMockLogger()
       );
-      ctx.markAsCheckedOut();
       expect(ctx.stepsInternalBuildDirectory).toBe('/m/n/o');
       expect(ctx.defaultWorkingDirectory).toBe('/g/h/i');
       expect(ctx.runtimePlatform).toBe(BuildRuntimePlatform.DARWIN);


### PR DESCRIPTION
It seems like it broke custom builds. Reverting. Will investigate it afterwards

https://staging.expo.dev/accounts/expo-turtle-system-tests/projects/custom-system-test/builds/4d1be4aa-108f-4062-a6a3-0b6c21ee81d8