### PR TITLE
[logger] [ENG-10483] Add callback

### DIFF
--- a/packages/logger/src/index.ts
+++ b/packages/logger/src/index.ts
@@ -1,7 +1,7 @@
 import bunyan from 'bunyan';
 
 import LoggerLevel from './level';
-import { pipe, pipeSpawnOutput, PipeMode } from './pipe';
+import { pipe, pipeSpawnOutput, PipeMode, PipeOptions } from './pipe';
 
 const DEFAULT_LOGGER_NAME = 'expo-logger';
 
@@ -18,5 +18,5 @@ const defaultLogger = createLogger({
 });
 
 export default defaultLogger;
-export { LoggerLevel, createLogger, pipe, pipeSpawnOutput, PipeMode };
+export { LoggerLevel, createLogger, pipe, pipeSpawnOutput, PipeMode, PipeOptions };
 export type { bunyan };

--- a/packages/logger/src/pipe.ts
+++ b/packages/logger/src/pipe.ts
@@ -38,7 +38,8 @@ export enum PipeMode {
 function pipeSpawnOutput(
   logger: bunyan,
   { stdout, stderr }: SpawnOutput = {},
-  { mode = PipeMode.COMBINED, lineTransformer }: PipeOptions = {}
+  { mode = PipeMode.COMBINED, lineTransformer }: PipeOptions = {},
+  infoCallbackFn?: () => void
 ): void {
   if (stdout && [PipeMode.COMBINED, PipeMode.COMBINED_AS_STDOUT].includes(mode)) {
     const stdoutLogger = logger.child({ source: 'stdout' });
@@ -46,6 +47,9 @@ function pipeSpawnOutput(
       stdout,
       (line) => {
         stdoutLogger.info(line);
+        if (infoCallbackFn) {
+          infoCallbackFn();
+        }
       },
       lineTransformer
     );
@@ -60,6 +64,9 @@ function pipeSpawnOutput(
       stderr,
       (line) => {
         stderrLogger.info(line);
+        if (infoCallbackFn) {
+          infoCallbackFn();
+        }
       },
       lineTransformer
     );

--- a/packages/logger/src/pipe.ts
+++ b/packages/logger/src/pipe.ts
@@ -9,7 +9,7 @@ interface SpawnOutput {
   stderr?: Readable | null;
 }
 
-interface PipeOptions {
+export interface PipeOptions {
   mode?: PipeMode;
   lineTransformer?: LineTransformer;
   infoCallbackFn?: () => void;

--- a/packages/logger/src/pipe.ts
+++ b/packages/logger/src/pipe.ts
@@ -12,6 +12,7 @@ interface SpawnOutput {
 interface PipeOptions {
   mode?: PipeMode;
   lineTransformer?: LineTransformer;
+  infoCallbackFn?: () => void;
 }
 
 function pipe(stream: Readable, loggerFn: LineLogger, lineTransformer?: LineTransformer): void {
@@ -38,8 +39,7 @@ export enum PipeMode {
 function pipeSpawnOutput(
   logger: bunyan,
   { stdout, stderr }: SpawnOutput = {},
-  { mode = PipeMode.COMBINED, lineTransformer }: PipeOptions = {},
-  infoCallbackFn?: () => void
+  { mode = PipeMode.COMBINED, lineTransformer, infoCallbackFn }: PipeOptions = {}
 ): void {
   if (stdout && [PipeMode.COMBINED, PipeMode.COMBINED_AS_STDOUT].includes(mode)) {
     const stdoutLogger = logger.child({ source: 'stdout' });

--- a/packages/logger/src/pipe.ts
+++ b/packages/logger/src/pipe.ts
@@ -47,9 +47,7 @@ function pipeSpawnOutput(
       stdout,
       (line) => {
         stdoutLogger.info(line);
-        if (infoCallbackFn) {
-          infoCallbackFn();
-        }
+        infoCallbackFn?.();
       },
       lineTransformer
     );
@@ -64,9 +62,7 @@ function pipeSpawnOutput(
       stderr,
       (line) => {
         stderrLogger.info(line);
-        if (infoCallbackFn) {
-          infoCallbackFn();
-        }
+        infoCallbackFn?.();
       },
       lineTransformer
     );


### PR DESCRIPTION
# Why

https://linear.app/expo/issue/ENG-10483/investigate-why-a-pair-of-builds-froze-during-yarn-install
https://linear.app/expo/issue/ENG-10483/investigate-why-a-pair-of-builds-froze-during-yarn-install#comment-7fa0acad
https://github.com/expo/eas-build/pull/297#pullrequestreview-1751696608

Companion of:
- https://github.com/expo/eas-build/pull/297
- https://github.com/expo/eas-build/pull/299

# How

Added an optional callback to the function piping spawn output into the child logger. This callback gets executed whenever the child logger calls the info() function to print new log line. In this case it is needed to refresh a timeout so it gets reset after each line from spawn process

# Test Plan

Tested by running builds locally with passed callback to reset timeouts and it worked as expected

# Deployment plan

1. `logger`
2. `turtle-spawn`
3. `build-tools`
4. `turtle`
