### PR TITLE
[turtle-spawn] [ENG-10483] Add and pass callback

### DIFF
--- a/packages/turtle-spawn/src/index.ts
+++ b/packages/turtle-spawn/src/index.ts
@@ -7,6 +7,7 @@ import spawnAsync, {
 
 type SpawnOptions = SpawnAsyncOptions & {
   logger?: bunyan;
+  loggerInfoCallbackFn?: () => void;
   lineTransformer?: (line: string) => string | null;
   mode?: PipeMode;
 };
@@ -19,13 +20,13 @@ function spawn(
     cwd: process.cwd(),
   }
 ): SpawnPromise<SpawnResult> {
-  const { logger, ...options } = _options;
+  const { logger, loggerInfoCallbackFn, ...options } = _options;
   if (logger) {
     options.stdio = 'pipe';
   }
   const promise = spawnAsync(command, args, options);
   if (logger && promise.child) {
-    pipeSpawnOutput(logger, promise.child, options);
+    pipeSpawnOutput(logger, promise.child, options, loggerInfoCallbackFn);
   }
   return promise;
 }

--- a/packages/turtle-spawn/src/index.ts
+++ b/packages/turtle-spawn/src/index.ts
@@ -1,16 +1,14 @@
-import { pipeSpawnOutput, bunyan, PipeMode } from '@expo/logger';
+import { pipeSpawnOutput, bunyan, PipeOptions } from '@expo/logger';
 import spawnAsync, {
   SpawnResult,
   SpawnPromise,
   SpawnOptions as SpawnAsyncOptions,
 } from '@expo/spawn-async';
 
-type SpawnOptions = SpawnAsyncOptions & {
-  logger?: bunyan;
-  loggerInfoCallbackFn?: () => void;
-  lineTransformer?: (line: string) => string | null;
-  mode?: PipeMode;
-};
+type SpawnOptions = SpawnAsyncOptions &
+  PipeOptions & {
+    logger?: bunyan;
+  };
 
 function spawn(
   command: string,
@@ -20,13 +18,13 @@ function spawn(
     cwd: process.cwd(),
   }
 ): SpawnPromise<SpawnResult> {
-  const { logger, loggerInfoCallbackFn, ...options } = _options;
+  const { logger, ...options } = _options;
   if (logger) {
     options.stdio = 'pipe';
   }
   const promise = spawnAsync(command, args, options);
   if (logger && promise.child) {
-    pipeSpawnOutput(logger, promise.child, options, loggerInfoCallbackFn);
+    pipeSpawnOutput(logger, promise.child, options);
   }
   return promise;
 }


### PR DESCRIPTION
# Why

https://linear.app/expo/issue/ENG-10483/investigate-why-a-pair-of-builds-froze-during-yarn-install
https://linear.app/expo/issue/ENG-10483/investigate-why-a-pair-of-builds-froze-during-yarn-install#comment-7fa0acad
https://github.com/expo/eas-build/pull/297#pullrequestreview-1751696608

Companion of:
- https://github.com/expo/eas-build/pull/297
- https://github.com/expo/eas-build/pull/298

# How

Added an optional callback to the spawn function. This callback gets passed on to the pipeSpawnOutput function to be executed on each line printed by the logger from the spawn process. In this case it is needed to refresh a timeout so it gets reset after each line from spawn process
TODO: update `@expo/logger` version after release

# Test Plan

Tested by running builds locally with passed callback to reset timeouts and it worked as expected

# Deployment plan

1. `logger`
2. `turtle-spawn`
3. `build-tools`
4. `turtle`

