### PR TITLE
[ENG-10477][steps][build-tools] actually use correct default working directory if project wasn't checked out

### DIFF
--- a/packages/build-tools/src/steps/functions/checkout.ts
+++ b/packages/build-tools/src/steps/functions/checkout.ts
@@ -15,6 +15,7 @@ export function createCheckoutBuildFunction(): BuildFunction {
           overwrite: true,
         }
       );
+      stepsCtx.global.markAsCheckedOut();
     },
   });
 }

--- a/packages/steps/src/BuildStep.ts
+++ b/packages/steps/src/BuildStep.ts
@@ -223,11 +223,7 @@ export class BuildStep extends BuildStepOutputAccessor {
       buildStepId: this.id,
       buildStepDisplayName: this.displayName,
     });
-    const workingDirectory =
-      maybeWorkingDirectory !== undefined
-        ? path.resolve(ctx.defaultWorkingDirectory, maybeWorkingDirectory)
-        : ctx.defaultWorkingDirectory;
-    this.ctx = ctx.stepCtx({ logger, workingDirectory });
+    this.ctx = ctx.stepCtx({ logger, relativeWorkingDirectory: maybeWorkingDirectory });
     this.env = env ?? {};
 
     ctx.registerStep(this);

--- a/packages/steps/src/BuildStepContext.ts
+++ b/packages/steps/src/BuildStepContext.ts
@@ -53,6 +53,7 @@ export class BuildStepGlobalContext {
   public stepsInternalBuildDirectory: string;
   public readonly runtimePlatform: BuildRuntimePlatform;
   public readonly baseLogger: bunyan;
+  private didCheckOut = false;
 
   private stepById: Record<string, BuildStepOutputAccessor> = {};
 
@@ -74,7 +75,7 @@ export class BuildStepGlobalContext {
   }
 
   public get defaultWorkingDirectory(): string {
-    return this.provider.defaultWorkingDirectory;
+    return this.didCheckOut ? this.provider.defaultWorkingDirectory : this.projectTargetDirectory;
   }
 
   public get buildLogsDirectory(): string {
@@ -120,6 +121,10 @@ export class BuildStepGlobalContext {
 
   public stepCtx(options: { logger: bunyan; workingDirectory: string }): BuildStepContext {
     return new BuildStepContext(this, options);
+  }
+
+  public markAsCheckedOut(): void {
+    this.didCheckOut = true;
   }
 
   public serialize(): SerializedBuildStepGlobalContext {

--- a/packages/steps/src/__tests__/BuildStep-test.ts
+++ b/packages/steps/src/__tests__/BuildStep-test.ts
@@ -145,7 +145,10 @@ describe(BuildStep, () => {
     });
 
     it('creates child build context with correct changed working directory', () => {
-      const ctx = createGlobalContextMock({ workingDirectory: '/a/b/c' });
+      const ctx = createGlobalContextMock({
+        projectTargetDirectory: '/a/b',
+        relativeWorkingDirectory: 'c',
+      });
       ctx.markAsCheckedOut();
 
       const id = 'test1';
@@ -162,7 +165,10 @@ describe(BuildStep, () => {
     });
 
     it('creates child build context with unchanged working directory', () => {
-      const ctx = createGlobalContextMock({ workingDirectory: '/a/b/c' });
+      const ctx = createGlobalContextMock({
+        projectTargetDirectory: '/a/b',
+        relativeWorkingDirectory: 'c',
+      });
       ctx.markAsCheckedOut();
 
       const id = 'test1';

--- a/packages/steps/src/__tests__/BuildStep-test.ts
+++ b/packages/steps/src/__tests__/BuildStep-test.ts
@@ -146,6 +146,7 @@ describe(BuildStep, () => {
 
     it('creates child build context with correct changed working directory', () => {
       const ctx = createGlobalContextMock({ workingDirectory: '/a/b/c' });
+      ctx.markAsCheckedOut();
 
       const id = 'test1';
       const command = 'ls -la';
@@ -162,6 +163,7 @@ describe(BuildStep, () => {
 
     it('creates child build context with unchanged working directory', () => {
       const ctx = createGlobalContextMock({ workingDirectory: '/a/b/c' });
+      ctx.markAsCheckedOut();
 
       const id = 'test1';
       const command = 'ls -la';

--- a/packages/steps/src/__tests__/BuildStepContext-test.ts
+++ b/packages/steps/src/__tests__/BuildStepContext-test.ts
@@ -29,19 +29,38 @@ describe(BuildStepGlobalContext, () => {
     });
   });
   describe('workingDirectory', () => {
-    it('can use the defaultWorkingDirectory returned by BuildContextProvider', () => {
+    it('if not checked out uses project target dir as default working dir', () => {
       const workingDirectory = '/path/to/working/dir';
+      const projectTargetDirectory = '/another/non/existent/path';
       const ctx = new BuildStepGlobalContext(
         new MockContextProvider(
           createMockLogger(),
           BuildRuntimePlatform.LINUX,
           '/non/existent/path',
-          '/another/non/existent/path',
+          projectTargetDirectory,
           workingDirectory,
           '/non/existent/path'
         ),
         false
       );
+      expect(ctx.defaultWorkingDirectory).toBe(projectTargetDirectory);
+    });
+
+    it('if checked out uses default working dir as default working dir', () => {
+      const workingDirectory = '/path/to/working/dir';
+      const projectTargetDirectory = '/another/non/existent/path';
+      const ctx = new BuildStepGlobalContext(
+        new MockContextProvider(
+          createMockLogger(),
+          BuildRuntimePlatform.LINUX,
+          '/non/existent/path',
+          projectTargetDirectory,
+          workingDirectory,
+          '/non/existent/path'
+        ),
+        false
+      );
+      ctx.markAsCheckedOut();
       expect(ctx.defaultWorkingDirectory).toBe(workingDirectory);
     });
   });
@@ -98,6 +117,7 @@ describe(BuildStepGlobalContext, () => {
         },
         createMockLogger()
       );
+      ctx.markAsCheckedOut();
       expect(ctx.stepsInternalBuildDirectory).toBe('/m/n/o');
       expect(ctx.defaultWorkingDirectory).toBe('/g/h/i');
       expect(ctx.runtimePlatform).toBe(BuildRuntimePlatform.DARWIN);

--- a/packages/steps/src/__tests__/BuildStepContext-test.ts
+++ b/packages/steps/src/__tests__/BuildStepContext-test.ts
@@ -77,7 +77,7 @@ describe(BuildStepGlobalContext, () => {
         runtimePlatform: BuildRuntimePlatform.DARWIN,
         projectSourceDirectory: '/a/b/c',
         projectTargetDirectory: '/d/e/f',
-        workingDirectory: '/g/h/i',
+        relativeWorkingDirectory: 'i',
         staticContextContent: { a: 1 },
       });
       expect(ctx.serialize()).toEqual(
@@ -87,7 +87,7 @@ describe(BuildStepGlobalContext, () => {
           provider: {
             projectSourceDirectory: '/a/b/c',
             projectTargetDirectory: '/d/e/f',
-            defaultWorkingDirectory: '/g/h/i',
+            defaultWorkingDirectory: '/d/e/f/i',
             buildLogsDirectory: '/non/existent/dir',
             runtimePlatform: BuildRuntimePlatform.DARWIN,
             staticContext: { a: 1 },
@@ -154,9 +154,7 @@ describe(BuildStepGlobalContext, () => {
   describe(BuildStepGlobalContext.prototype.stepCtx, () => {
     it('returns a BuildStepContext object', () => {
       const ctx = createGlobalContextMock();
-      expect(
-        ctx.stepCtx({ logger: ctx.baseLogger, workingDirectory: ctx.defaultWorkingDirectory })
-      ).toBeInstanceOf(BuildStepContext);
+      expect(ctx.stepCtx({ logger: ctx.baseLogger })).toBeInstanceOf(BuildStepContext);
     });
     it('can override logger', () => {
       const logger1 = createMockLogger();
@@ -164,7 +162,6 @@ describe(BuildStepGlobalContext, () => {
       const ctx = createGlobalContextMock({ logger: logger1 });
       const childCtx = ctx.stepCtx({
         logger: logger2,
-        workingDirectory: ctx.defaultWorkingDirectory,
       });
       expect(ctx.baseLogger).toBe(logger1);
       expect(childCtx.logger).toBe(logger2);
@@ -173,7 +170,7 @@ describe(BuildStepGlobalContext, () => {
       const workingDirectoryOverride = '/d/e/f';
       const ctx = createGlobalContextMock();
       const childCtx = ctx.stepCtx({
-        workingDirectory: workingDirectoryOverride,
+        relativeWorkingDirectory: workingDirectoryOverride,
         logger: ctx.baseLogger,
       });
       expect(ctx.defaultWorkingDirectory).not.toBe(childCtx.workingDirectory);

--- a/packages/steps/src/__tests__/utils/context.ts
+++ b/packages/steps/src/__tests__/utils/context.ts
@@ -44,7 +44,7 @@ interface BuildContextParams {
   runtimePlatform?: BuildRuntimePlatform;
   projectSourceDirectory?: string;
   projectTargetDirectory?: string;
-  workingDirectory?: string;
+  relativeWorkingDirectory?: string;
   staticContextContent?: Record<string, any>;
 }
 
@@ -55,7 +55,7 @@ export function createStepContextMock({
   runtimePlatform,
   projectSourceDirectory,
   projectTargetDirectory,
-  workingDirectory,
+  relativeWorkingDirectory,
   staticContextContent,
 }: BuildContextParams = {}): BuildStepContext {
   const globalCtx = createGlobalContextMock({
@@ -65,12 +65,12 @@ export function createStepContextMock({
     runtimePlatform,
     projectSourceDirectory,
     projectTargetDirectory,
-    workingDirectory,
+    relativeWorkingDirectory,
     staticContextContent,
   });
   return new BuildStepContext(globalCtx, {
     logger: logger ?? createMockLogger(),
-    workingDirectory: workingDirectory ?? globalCtx.projectTargetDirectory,
+    relativeWorkingDirectory,
   });
 }
 
@@ -80,7 +80,7 @@ export function createGlobalContextMock({
   runtimePlatform,
   projectSourceDirectory,
   projectTargetDirectory,
-  workingDirectory,
+  relativeWorkingDirectory,
   staticContextContent,
 }: BuildContextParams = {}): BuildStepGlobalContext {
   const resolvedProjectTargetDirectory =
@@ -91,7 +91,9 @@ export function createGlobalContextMock({
       runtimePlatform ?? BuildRuntimePlatform.LINUX,
       projectSourceDirectory ?? '/non/existent/dir',
       resolvedProjectTargetDirectory,
-      workingDirectory ?? resolvedProjectTargetDirectory,
+      relativeWorkingDirectory
+        ? path.resolve(resolvedProjectTargetDirectory, relativeWorkingDirectory)
+        : resolvedProjectTargetDirectory,
       '/non/existent/dir',
       staticContextContent ?? {}
     ),

--- a/packages/steps/src/scripts/__tests__/runCustomFunction-test.ts
+++ b/packages/steps/src/scripts/__tests__/runCustomFunction-test.ts
@@ -22,7 +22,7 @@ describe('runCustomFunction', () => {
     const projectSourceDirectory = path.join(os.tmpdir(), 'eas-build', uuidv4());
     await fs.mkdir(projectSourceDirectory, { recursive: true });
     const ctx = createStepContextMock({
-      workingDirectory: path.resolve(dirname, '../../__tests__/fixtures'),
+      projectTargetDirectory: path.resolve(dirname, '../../__tests__/fixtures'),
       projectSourceDirectory,
     });
     const outputs = {


### PR DESCRIPTION
# Why

https://github.com/expo/eas-build/pull/291 was reverted because https://github.com/expo/eas-build/pull/296

Actually fix the issue and revert the revert 

# How

The working dir for the step was determined when creating the step (at the beginning of processing custom workflow) so changing the `defaultWorkingDir` during the process wouldn't have any effect.

I made workingDir to be resolved in getter based on defaultWorkingDir every time

# Test Plan

Tests

Run the build which failed on staging locally and see that the path is correct
