### PR TITLE
[ENG-10412] Add `metadataLocation` to ArchiveSource type

### DIFF
--- a/packages/build-tools/src/ios/credentials/__tests__/manager.test.ios.ts
+++ b/packages/build-tools/src/ios/credentials/__tests__/manager.test.ios.ts
@@ -1,8 +1,8 @@
 import assert from 'assert';
 
-import { createLogger } from '@expo/logger';
-import { Ios, Workflow, ArchiveSourceType, Platform } from '@expo/eas-build-job';
+import { ArchiveSourceType, Ios, Platform, Workflow } from '@expo/eas-build-job';
 import { BuildMode, BuildTrigger } from '@expo/eas-build-job/dist/common';
+import { createLogger } from '@expo/logger';
 
 import { BuildContext } from '../../../context';
 import { distributionCertificate, provisioningProfile } from '../__tests__/fixtures';

--- a/packages/build-tools/src/steps/utils/ios/credentials/__tests__/manager.test.ios.ts
+++ b/packages/build-tools/src/steps/utils/ios/credentials/__tests__/manager.test.ios.ts
@@ -1,8 +1,8 @@
 import assert from 'assert';
 
-import { createLogger } from '@expo/logger';
-import { Ios, Workflow, ArchiveSourceType, Platform } from '@expo/eas-build-job';
+import { ArchiveSourceType, Ios, Platform, Workflow } from '@expo/eas-build-job';
 import { BuildMode, BuildTrigger } from '@expo/eas-build-job/dist/common';
+import { createLogger } from '@expo/logger';
 
 import { distributionCertificate, provisioningProfile } from '../__tests__/fixtures';
 import IosCredentialsManager from '../manager';

--- a/packages/eas-build-job/src/__tests__/android.test.ts
+++ b/packages/eas-build-job/src/__tests__/android.test.ts
@@ -51,6 +51,37 @@ describe('Android.JobSchema', () => {
     expect(error).toBeFalsy();
   });
 
+  test('valid generic job with metadataLocation', () => {
+    const genericJob = {
+      secrets,
+      platform: Platform.ANDROID,
+      type: Workflow.GENERIC,
+      projectArchive: {
+        type: ArchiveSourceType.GCS,
+        bucketKey: 'path/to/file',
+        metadataLocation: 'path/to/metadata',
+      },
+      gradleCommand: ':app:bundleRelease',
+      applicationArchivePath: 'android/app/build/outputs/bundle/release/app-release.aab',
+      projectRootDirectory: '.',
+      releaseChannel: 'default',
+      builderEnvironment: {
+        image: 'default',
+        node: '1.2.3',
+        yarn: '2.3.4',
+        ndk: '4.5.6',
+        bun: '1.0.0',
+        env: {
+          SOME_ENV: '123',
+        },
+      },
+    };
+
+    const { value, error } = Android.JobSchema.validate(genericJob, joiOptions);
+    expect(value).toMatchObject(genericJob);
+    expect(error).toBeFalsy();
+  });
+
   test('invalid generic job', () => {
     const genericJob = {
       secrets,

--- a/packages/eas-build-job/src/__tests__/ios.test.ts
+++ b/packages/eas-build-job/src/__tests__/ios.test.ts
@@ -1,7 +1,7 @@
 import Joi from 'joi';
 
-import * as Ios from '../ios';
 import { ArchiveSourceType, BuildMode, Platform, Workflow } from '../common';
+import * as Ios from '../ios';
 
 const joiOptions: Joi.ValidationOptions = {
   stripUnknown: true,
@@ -74,6 +74,27 @@ describe('Ios.JobSchema', () => {
 
     const { value, error } = Ios.JobSchema.validate(genericJob, joiOptions);
     expect(value).toMatchObject(genericJob);
+    expect(error).toBeFalsy();
+  });
+
+  test('valid custom build job with metadataLocation', () => {
+    const customBuildJob = {
+      mode: BuildMode.CUSTOM,
+      type: Workflow.UNKNOWN,
+      platform: Platform.IOS,
+      projectArchive: {
+        type: ArchiveSourceType.GCS,
+        bucketKey: 'path/to/file',
+        metadataLocation: 'path/to/metadata',
+      },
+      projectRootDirectory: '.',
+      customBuildConfig: {
+        path: 'production.ios.yml',
+      },
+    };
+
+    const { value, error } = Ios.JobSchema.validate(customBuildJob, joiOptions);
+    expect(value).toMatchObject(customBuildJob);
     expect(error).toBeFalsy();
   });
 

--- a/packages/eas-build-job/src/common.ts
+++ b/packages/eas-build-job/src/common.ts
@@ -34,7 +34,7 @@ export enum BuildTrigger {
 
 export type ArchiveSource =
   | { type: ArchiveSourceType.NONE }
-  | { type: ArchiveSourceType.GCS; bucketKey: string }
+  | { type: ArchiveSourceType.GCS; bucketKey: string; metadataLocation?: string }
   | { type: ArchiveSourceType.URL; url: string }
   | { type: ArchiveSourceType.PATH; path: string }
   | {
@@ -59,6 +59,7 @@ export const ArchiveSourceSchema = Joi.object<ArchiveSource>({
     then: Joi.object({
       type: Joi.string().valid(ArchiveSourceType.GCS).required(),
       bucketKey: Joi.string().required(),
+      metadataLocation: Joi.string(),
     }),
   })
   .when(Joi.object({ type: ArchiveSourceType.URL }).unknown(), {


### PR DESCRIPTION
It is used to store location of the project archive metadata file

# Why

[ENG-10412](https://linear.app/expo/issue/ENG-10412/ui-to-inspect-the-contents-of-eas-build-archive-for-a-build)