### PR TITLE
Remove support for S3 archive type

### DIFF
--- a/packages/build-tools/src/common/projectSources.ts
+++ b/packages/build-tools/src/common/projectSources.ts
@@ -12,8 +12,8 @@ export async function prepareProjectSourcesAsync<TJob extends Job>(
   ctx: BuildContext<TJob>,
   destinationDirectory = ctx.buildDirectory
 ): Promise<void> {
-  if ([ArchiveSourceType.S3, ArchiveSourceType.GCS].includes(ctx.job.projectArchive.type)) {
-    throw new Error('GCS and S3 project sources should be resolved earlier to url');
+  if (ctx.job.projectArchive.type === ArchiveSourceType.GCS) {
+    throw new Error('GCS project sources should be resolved earlier to url');
   } else if (ctx.job.projectArchive.type === ArchiveSourceType.PATH) {
     await prepareProjectSourcesLocallyAsync(ctx, ctx.job.projectArchive.path, destinationDirectory); // used in eas build --local
   } else if (ctx.job.projectArchive.type === ArchiveSourceType.URL) {

--- a/packages/eas-build-job/src/common.ts
+++ b/packages/eas-build-job/src/common.ts
@@ -21,7 +21,6 @@ export enum Platform {
 
 export enum ArchiveSourceType {
   NONE = 'NONE',
-  S3 = 'S3',
   URL = 'URL',
   PATH = 'PATH',
   GCS = 'GCS',
@@ -35,7 +34,6 @@ export enum BuildTrigger {
 
 export type ArchiveSource =
   | { type: ArchiveSourceType.NONE }
-  | { type: ArchiveSourceType.S3; bucketKey: string }
   | { type: ArchiveSourceType.GCS; bucketKey: string }
   | { type: ArchiveSourceType.URL; url: string }
   | { type: ArchiveSourceType.PATH; path: string }
@@ -60,12 +58,6 @@ export const ArchiveSourceSchema = Joi.object<ArchiveSource>({
   .when(Joi.object({ type: ArchiveSourceType.GCS }).unknown(), {
     then: Joi.object({
       type: Joi.string().valid(ArchiveSourceType.GCS).required(),
-      bucketKey: Joi.string().required(),
-    }),
-  })
-  .when(Joi.object({ type: ArchiveSourceType.S3 }).unknown(), {
-    then: Joi.object({
-      type: Joi.string().valid(ArchiveSourceType.S3).required(),
       bucketKey: Joi.string().required(),
     }),
   })


### PR DESCRIPTION
# Why

Since https://github.com/expo/universe/pull/14139 we don't support uploading projects to S3.

# How

Removed `ArchiveSourceType.S3` and its dependents.

# Test Plan

`yarn build` in root passed.