### PR TITLE
[ENG-10799] drop support for node 14

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v1
         with:
-          node-version: 18
+          node-version: 20
       - name: Setup ncc
         run: npm install -g @vercel/ncc
       - run: yarn install --frozen-lockfile --check-files

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           registry-url: 'https://registry.npmjs.org/'
           scope: 'expo'
-          node-version: 18
+          node-version: 20
       - name: Setup ncc
         run: npm install -g @vercel/ncc
       - name: Install dependencies

--- a/.github/workflows/test-ios.yml
+++ b/.github/workflows/test-ios.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v1
         with:
-          node-version: 18
+          node-version: 20
       - name: Setup ncc
         run: npm install -g @vercel/ncc
       - run: yarn install --frozen-lockfile --check-files

--- a/.github/workflows/test-ios.yml
+++ b/.github/workflows/test-ios.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   test:
     runs-on: macos-latest
-    name: Test with Node 18 on macOS
+    name: Test with Node 20 on macOS
     steps:
       - uses: actions/checkout@v2
       - name: Setup node

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: ['14', '16', '18']
+        node: ['16', '18', '20']
     name: Test with Node ${{ matrix.node }} on Linux
     steps:
       - uses: actions/checkout@v2

--- a/package.json
+++ b/package.json
@@ -12,10 +12,10 @@
     "release": "./scripts/release.sh"
   },
   "engines": {
-    "node": ">=14.0.0"
+    "node": ">=16.0.0"
   },
   "devDependencies": {
-    "@types/node": "^18.11.18",
+    "@types/node": "20.11.0",
     "eslint": "^8.46.0",
     "eslint-config-universe": "^11.3.0",
     "eslint-plugin-import": "^2.28.0",
@@ -28,7 +28,7 @@
     "packages/*"
   ],
   "volta": {
-    "node": "18.13.0",
-    "yarn": "1.22.19"
+    "node": "20.11.0",
+    "yarn": "1.22.21"
   }
 }

--- a/packages/build-tools/package.json
+++ b/packages/build-tools/package.json
@@ -46,7 +46,7 @@
     "@types/fs-extra": "^11.0.1",
     "@types/jest": "^29.5.3",
     "@types/lodash": "^4.14.196",
-    "@types/node": "^18.11.18",
+    "@types/node": "20.11.0",
     "@types/node-forge": "^1.3.1",
     "@types/plist": "^3.0.2",
     "@types/semver": "^7.5.0",
@@ -63,7 +63,7 @@
     "uuid": "^9.0.0"
   },
   "volta": {
-    "node": "18.13.0",
-    "yarn": "1.22.19"
+    "node": "20.11.0",
+    "yarn": "1.22.21"
   }
 }

--- a/packages/create-eas-build-function/package.json
+++ b/packages/create-eas-build-function/package.json
@@ -39,7 +39,7 @@
     "@expo/package-manager": "^1.0.2",
     "@jest/globals": "^29.6.2",
     "@types/jest": "^29.5.3",
-    "@types/node": "^18.11.18",
+    "@types/node": "20.11.0",
     "@types/prompts": "^2.4.4",
     "@vercel/ncc": "^0.38.0",
     "chalk": "4.1.2",
@@ -54,7 +54,7 @@
     "access": "public"
   },
   "volta": {
-    "node": "18.13.0",
-    "yarn": "1.22.19"
+    "node": "20.11.0",
+    "yarn": "1.22.21"
   }
 }

--- a/packages/create-eas-build-function/templates/typescript/package.json
+++ b/packages/create-eas-build-function/templates/typescript/package.json
@@ -10,7 +10,7 @@
   "keywords": [],
   "author": "",
   "devDependencies": {
-    "@types/node": "^18.11.18",
+    "@types/node": "20.11.0",
     "typescript": "^5.1.6",
     "@expo/steps": "^1.0.34"
   }

--- a/packages/downloader/package.json
+++ b/packages/downloader/package.json
@@ -25,13 +25,13 @@
   "devDependencies": {
     "@types/fs-extra": "^11.0.1",
     "@types/jest": "^29.5.3",
-    "@types/node": "^18.11.18",
+    "@types/node": "20.11.0",
     "jest": "^29.6.2",
     "ts-jest": "^29.1.1",
     "typescript": "^5.1.6"
   },
   "volta": {
-    "node": "18.13.0",
-    "yarn": "1.22.19"
+    "node": "20.11.0",
+    "yarn": "1.22.21"
   }
 }

--- a/packages/eas-build-job/package.json
+++ b/packages/eas-build-job/package.json
@@ -20,7 +20,7 @@
   "license": "MIT",
   "devDependencies": {
     "@types/jest": "^29.5.3",
-    "@types/node": "^18.11.18",
+    "@types/node": "20.11.0",
     "jest": "^29.6.2",
     "ts-jest": "^29.1.1",
     "typescript": "^5.1.6"
@@ -30,7 +30,7 @@
     "semver": "^7.5.4"
   },
   "volta": {
-    "node": "18.13.0",
-    "yarn": "1.22.19"
+    "node": "20.11.0",
+    "yarn": "1.22.21"
   }
 }

--- a/packages/local-build-plugin/package.json
+++ b/packages/local-build-plugin/package.json
@@ -18,7 +18,7 @@
     "clean": "rm -rf node_modules dist coverage"
   },
   "engines": {
-    "node": ">=14.0.0"
+    "node": ">=16.0.0"
   },
   "author": "Expo <support@expo.io>",
   "bugs": "https://github.com/expo/eas-build/issues",
@@ -52,7 +52,7 @@
     "typescript": "^5.1.6"
   },
   "volta": {
-    "node": "18.13.0",
-    "yarn": "1.22.19"
+    "node": "20.11.0",
+    "yarn": "1.22.21"
   }
 }

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -24,13 +24,13 @@
   },
   "devDependencies": {
     "@types/jest": "^29.5.3",
-    "@types/node": "^18.11.18",
+    "@types/node": "20.11.0",
     "jest": "^29.6.2",
     "ts-jest": "^29.1.1",
     "typescript": "^5.1.6"
   },
   "volta": {
-    "node": "18.13.0",
-    "yarn": "1.22.19"
+    "node": "20.11.0",
+    "yarn": "1.22.21"
   }
 }

--- a/packages/steps/package.json
+++ b/packages/steps/package.json
@@ -35,7 +35,7 @@
     "@types/jest": "^29.5.3",
     "@types/lodash.clonedeep": "^4.5.7",
     "@types/lodash.get": "^4.4.7",
-    "@types/node": "^18.11.18",
+    "@types/node": "20.11.0",
     "chokidar-cli": "^3.0.0",
     "eslint-plugin-async-protect": "^3.0.0",
     "jest": "^29.6.2",
@@ -45,7 +45,7 @@
     "typescript": "^5.1.6"
   },
   "engines": {
-    "node": ">=14.0.0"
+    "node": ">=16.0.0"
   },
   "dependencies": {
     "@expo/logger": "1.0.52",
@@ -60,7 +60,7 @@
     "yaml": "^2.3.1"
   },
   "volta": {
-    "node": "18.13.0",
-    "yarn": "1.22.19"
+    "node": "20.11.0",
+    "yarn": "1.22.21"
   }
 }

--- a/packages/steps/src/__tests__/fixtures/my-custom-ts-function/package.json
+++ b/packages/steps/src/__tests__/fixtures/my-custom-ts-function/package.json
@@ -11,7 +11,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@types/node": "^20.4.1",
+    "@types/node": "20.11.0",
     "typescript": "^5.1.6"
   },
   "dependencies": {

--- a/packages/template-file/package.json
+++ b/packages/template-file/package.json
@@ -27,13 +27,13 @@
     "@types/jest": "^29.5.3",
     "@types/lodash": "^4.14.196",
     "@types/lodash.template": "^4.5.1",
-    "@types/node": "^18.11.18",
+    "@types/node": "20.11.0",
     "jest": "^29.6.2",
     "ts-jest": "^29.1.1",
     "typescript": "^5.1.6"
   },
   "volta": {
-    "node": "18.13.0",
-    "yarn": "1.22.19"
+    "node": "20.11.0",
+    "yarn": "1.22.21"
   }
 }

--- a/packages/turtle-spawn/package.json
+++ b/packages/turtle-spawn/package.json
@@ -24,13 +24,13 @@
   },
   "devDependencies": {
     "@types/jest": "^29.5.3",
-    "@types/node": "^18.11.18",
+    "@types/node": "20.11.0",
     "jest": "^29.6.2",
     "ts-jest": "^29.1.1",
     "typescript": "^5.1.6"
   },
   "volta": {
-    "node": "18.13.0",
-    "yarn": "1.22.19"
+    "node": "20.11.0",
+    "yarn": "1.22.21"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1730,10 +1730,12 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.37.tgz#a3dd8da4eb84a996c36e331df98d82abd76b516e"
   integrity sha512-XYmBiy+ohOR4Lh5jE379fV2IU+6Jn4g5qASinhitfyO71b/sCo6MKsMLF5tc7Zf2CE8hViVQyYSobJNke8OvUw==
 
-"@types/node@^18.11.18":
-  version "18.11.18"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.11.18.tgz#8dfb97f0da23c2293e554c5a50d61ef134d7697f"
-  integrity sha512-DHQpWGjyQKSHj3ebjFI/wRKcqQcdR+MoFBygntYOZytCqNfkd2ZC4ARDJ2DQqhjH5p85Nnd3jhUJIXrszFX/JA==
+"@types/node@20.11.0":
+  version "20.11.0"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.11.0.tgz#8e0b99e70c0c1ade1a86c4a282f7b7ef87c9552f"
+  integrity sha512-o9bjXmDNcF7GbM4CNQpmi+TutCgap/K3w1JyKgxAjqx41zp9qlIAVFi0IhCNsJcXolEqLWhbFbEeL0PvYm4pcQ==
+  dependencies:
+    undici-types "~5.26.4"
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"
@@ -8548,6 +8550,11 @@ unbox-primitive@^1.0.2:
     has-bigints "^1.0.2"
     has-symbols "^1.0.3"
     which-boxed-primitive "^1.0.2"
+
+undici-types@~5.26.4:
+  version "5.26.5"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-5.26.5.tgz#bcd539893d00b56e964fd2657a4866b221a65617"
+  integrity sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==
 
 unique-filename@^2.0.0:
   version "2.0.1"


### PR DESCRIPTION
# Why

Node 14 is no longer supported and Node 20 is current active

# How

Drop support for Node 14, test against Node 20

# Test Plan

Tests

# Deployment order

It should land after https://github.com/expo/eas-cli/pull/2175 so the explicit breaking change to drop Node 14 support in EAS CLI lands first
