### PR TITLE
Refactor uploading artifacts

### DIFF
--- a/packages/build-tools/src/builders/ios.ts
+++ b/packages/build-tools/src/builders/ios.ts
@@ -175,11 +175,11 @@ async function resignAsync(ctx: BuildContext<Ios.Job>): Promise<Artifacts> {
 
   await ctx.runBuildPhase(BuildPhase.UPLOAD_APPLICATION_ARCHIVE, async () => {
     ctx.logger.info(`Application archive: ${applicationArchivePath}`);
-    await ctx.uploadArtifacts(
-      ManagedArtifactType.APPLICATION_ARCHIVE,
-      [applicationArchivePath],
-      ctx.logger
-    );
+    await ctx.uploadArtifacts({
+      type: ManagedArtifactType.APPLICATION_ARCHIVE,
+      paths: [applicationArchivePath],
+      logger: ctx.logger,
+    });
   });
 
   if (!ctx.artifacts.APPLICATION_ARCHIVE) {

--- a/packages/build-tools/src/builders/ios.ts
+++ b/packages/build-tools/src/builders/ios.ts
@@ -1,10 +1,10 @@
 import plist from '@expo/plist';
 import { IOSConfig } from '@expo/config-plugins';
-import { BuildMode, BuildPhase, Ios, Workflow } from '@expo/eas-build-job';
+import { ManagedArtifactType, BuildMode, BuildPhase, Ios, Workflow } from '@expo/eas-build-job';
 import fs from 'fs-extra';
 import nullthrows from 'nullthrows';
 
-import { Artifacts, ArtifactType, BuildContext } from '../context';
+import { Artifacts, BuildContext } from '../context';
 import { configureExpoUpdatesIfInstalledAsync } from '../utils/expoUpdates';
 import { uploadApplicationArchive } from '../utils/artifacts';
 import { Hook, runHookIfPresent } from '../utils/hooks';
@@ -176,7 +176,7 @@ async function resignAsync(ctx: BuildContext<Ios.Job>): Promise<Artifacts> {
   await ctx.runBuildPhase(BuildPhase.UPLOAD_APPLICATION_ARCHIVE, async () => {
     ctx.logger.info(`Application archive: ${applicationArchivePath}`);
     await ctx.uploadArtifacts(
-      ArtifactType.APPLICATION_ARCHIVE,
+      ManagedArtifactType.APPLICATION_ARCHIVE,
       [applicationArchivePath],
       ctx.logger
     );

--- a/packages/build-tools/src/customBuildContext.ts
+++ b/packages/build-tools/src/customBuildContext.ts
@@ -1,10 +1,10 @@
 import path from 'path';
 
-import { ManagedArtifactType, BuildPhase, Env, Job, Metadata, Platform } from '@expo/eas-build-job';
+import { BuildPhase, Env, Job, Metadata, Platform } from '@expo/eas-build-job';
 import { bunyan } from '@expo/logger';
 import { ExternalBuildContextProvider, BuildRuntimePlatform } from '@expo/steps';
 
-import { BuildContext } from './context';
+import { ArtifactToUpload, BuildContext } from './context';
 
 const platformToBuildRuntimePlatform: Record<Platform, BuildRuntimePlatform> = {
   [Platform.ANDROID]: BuildRuntimePlatform.LINUX,
@@ -12,15 +12,7 @@ const platformToBuildRuntimePlatform: Record<Platform, BuildRuntimePlatform> = {
 };
 
 export interface BuilderRuntimeApi {
-  uploadArtifacts: ({
-    type,
-    paths,
-    logger,
-  }: {
-    type: ManagedArtifactType;
-    paths: string[];
-    logger: bunyan;
-  }) => Promise<void>;
+  uploadArtifacts: (artifact: ArtifactToUpload) => Promise<void>;
 }
 
 export class CustomBuildContext implements ExternalBuildContextProvider {
@@ -62,7 +54,7 @@ export class CustomBuildContext implements ExternalBuildContextProvider {
     this.defaultWorkingDirectory = buildCtx.getReactNativeProjectDirectory();
     this.buildLogsDirectory = path.join(buildCtx.workingdir, 'logs');
     this.runtimeApi = {
-      uploadArtifacts: (spec) => buildCtx['uploadArtifacts'](spec.type, spec.paths, spec.logger),
+      uploadArtifacts: (artifact) => buildCtx['uploadArtifacts'](artifact),
     };
   }
 

--- a/packages/build-tools/src/customBuildContext.ts
+++ b/packages/build-tools/src/customBuildContext.ts
@@ -1,10 +1,10 @@
 import path from 'path';
 
-import { BuildPhase, Env, Job, Metadata, Platform } from '@expo/eas-build-job';
+import { ManagedArtifactType, BuildPhase, Env, Job, Metadata, Platform } from '@expo/eas-build-job';
 import { bunyan } from '@expo/logger';
 import { ExternalBuildContextProvider, BuildRuntimePlatform } from '@expo/steps';
 
-import { ArtifactType, BuildContext } from './context';
+import { BuildContext } from './context';
 
 const platformToBuildRuntimePlatform: Record<Platform, BuildRuntimePlatform> = {
   [Platform.ANDROID]: BuildRuntimePlatform.LINUX,
@@ -12,7 +12,15 @@ const platformToBuildRuntimePlatform: Record<Platform, BuildRuntimePlatform> = {
 };
 
 export interface BuilderRuntimeApi {
-  uploadArtifacts: (type: ArtifactType, paths: string[], logger: bunyan) => Promise<void>;
+  uploadArtifacts: ({
+    type,
+    paths,
+    logger,
+  }: {
+    type: ManagedArtifactType;
+    paths: string[];
+    logger: bunyan;
+  }) => Promise<void>;
 }
 
 export class CustomBuildContext implements ExternalBuildContextProvider {
@@ -54,7 +62,7 @@ export class CustomBuildContext implements ExternalBuildContextProvider {
     this.defaultWorkingDirectory = buildCtx.getReactNativeProjectDirectory();
     this.buildLogsDirectory = path.join(buildCtx.workingdir, 'logs');
     this.runtimeApi = {
-      uploadArtifacts: (...args) => buildCtx['uploadArtifacts'](...args),
+      uploadArtifacts: (spec) => buildCtx['uploadArtifacts'](spec.type, spec.paths, spec.logger),
     };
   }
 

--- a/packages/build-tools/src/index.ts
+++ b/packages/build-tools/src/index.ts
@@ -2,7 +2,15 @@ import * as Builders from './builders';
 
 export { Builders };
 
-export { Artifacts, BuildContext, CacheManager, LogBuffer, SkipNativeBuildError } from './context';
+export {
+  ArtifactToUpload,
+  Artifacts,
+  BuildContext,
+  BuildContextOptions,
+  CacheManager,
+  LogBuffer,
+  SkipNativeBuildError,
+} from './context';
 
 export { PackageManager } from './utils/packageManager';
 

--- a/packages/build-tools/src/index.ts
+++ b/packages/build-tools/src/index.ts
@@ -2,14 +2,7 @@ import * as Builders from './builders';
 
 export { Builders };
 
-export {
-  Artifacts,
-  ArtifactType,
-  BuildContext,
-  CacheManager,
-  LogBuffer,
-  SkipNativeBuildError,
-} from './context';
+export { Artifacts, BuildContext, CacheManager, LogBuffer, SkipNativeBuildError } from './context';
 
 export { PackageManager } from './utils/packageManager';
 

--- a/packages/build-tools/src/ios/xcodeBuildLogs.ts
+++ b/packages/build-tools/src/ios/xcodeBuildLogs.ts
@@ -14,7 +14,11 @@ export async function findAndUploadXcodeBuildLogsAsync(
   try {
     const xcodeBuildLogsPath = await findXcodeBuildLogsPathAsync(ctx.buildLogsDirectory);
     if (xcodeBuildLogsPath) {
-      await ctx.uploadArtifacts(ManagedArtifactType.XCODE_BUILD_LOGS, [xcodeBuildLogsPath], logger);
+      await ctx.uploadArtifacts({
+        type: ManagedArtifactType.XCODE_BUILD_LOGS,
+        paths: [xcodeBuildLogsPath],
+        logger,
+      });
     }
   } catch (err: any) {
     logger.debug({ err }, 'Failed to upload Xcode build logs');

--- a/packages/build-tools/src/ios/xcodeBuildLogs.ts
+++ b/packages/build-tools/src/ios/xcodeBuildLogs.ts
@@ -1,11 +1,11 @@
 import os from 'os';
 import path from 'path';
 
-import { Ios } from '@expo/eas-build-job';
+import { ManagedArtifactType, Ios } from '@expo/eas-build-job';
 import fg from 'fast-glob';
 import { bunyan } from '@expo/logger';
 
-import { ArtifactType, BuildContext } from '../context';
+import { BuildContext } from '../context';
 
 export async function findAndUploadXcodeBuildLogsAsync(
   ctx: BuildContext<Ios.Job>,
@@ -14,7 +14,7 @@ export async function findAndUploadXcodeBuildLogsAsync(
   try {
     const xcodeBuildLogsPath = await findXcodeBuildLogsPathAsync(ctx.buildLogsDirectory);
     if (xcodeBuildLogsPath) {
-      await ctx.uploadArtifacts(ArtifactType.XCODE_BUILD_LOGS, [xcodeBuildLogsPath], logger);
+      await ctx.uploadArtifacts(ManagedArtifactType.XCODE_BUILD_LOGS, [xcodeBuildLogsPath], logger);
     }
   } catch (err: any) {
     logger.debug({ err }, 'Failed to upload Xcode build logs');

--- a/packages/build-tools/src/steps/functions/findAndUploadBuildArtifacts.ts
+++ b/packages/build-tools/src/steps/functions/findAndUploadBuildArtifacts.ts
@@ -1,7 +1,6 @@
-import { Ios, Platform } from '@expo/eas-build-job';
+import { ManagedArtifactType, Ios, Platform } from '@expo/eas-build-job';
 import { BuildFunction } from '@expo/steps';
 
-import { ArtifactType } from '../../context';
 import { findArtifacts } from '../../utils/artifacts';
 import { findXcodeBuildLogsPathAsync } from '../../ios/xcodeBuildLogs';
 import { CustomBuildContext } from '../../customBuildContext';
@@ -42,18 +41,18 @@ export function createFindAndUploadBuildArtifactsBuildFunction(
 
       logger.info('Uploading...');
       const [archiveUpload, artifactsUpload, xcodeBuildLogsUpload] = await Promise.allSettled([
-        ctx.runtimeApi.uploadArtifacts(
-          ArtifactType.APPLICATION_ARCHIVE,
-          applicationArchives,
-          logger
-        ),
+        ctx.runtimeApi.uploadArtifacts({
+          type: ManagedArtifactType.APPLICATION_ARCHIVE,
+          paths: applicationArchives,
+          logger,
+        }),
         (async () => {
           if (buildArtifacts.length > 0) {
-            await ctx.runtimeApi.uploadArtifacts(
-              ArtifactType.BUILD_ARTIFACTS,
-              buildArtifacts,
-              logger
-            );
+            await ctx.runtimeApi.uploadArtifacts({
+              type: ManagedArtifactType.BUILD_ARTIFACTS,
+              paths: buildArtifacts,
+              logger,
+            });
           }
         })(),
         (async () => {
@@ -64,11 +63,11 @@ export function createFindAndUploadBuildArtifactsBuildFunction(
             stepCtx.global.buildLogsDirectory
           );
           if (xcodeBuildLogsPath) {
-            await ctx.runtimeApi.uploadArtifacts(
-              ArtifactType.XCODE_BUILD_LOGS,
-              [xcodeBuildLogsPath],
-              logger
-            );
+            await ctx.runtimeApi.uploadArtifacts({
+              type: ManagedArtifactType.XCODE_BUILD_LOGS,
+              paths: [xcodeBuildLogsPath],
+              logger,
+            });
           }
         })(),
       ]);

--- a/packages/build-tools/src/utils/artifacts.ts
+++ b/packages/build-tools/src/utils/artifacts.ts
@@ -3,9 +3,9 @@ import path from 'path';
 import fs from 'fs-extra';
 import fg from 'fast-glob';
 import { bunyan } from '@expo/logger';
-import { Job } from '@expo/eas-build-job';
+import { ManagedArtifactType, Job } from '@expo/eas-build-job';
 
-import { ArtifactType, BuildContext } from '../context';
+import { BuildContext } from '../context';
 
 export async function findArtifacts(
   rootDir: string,
@@ -64,7 +64,7 @@ export async function maybeFindAndUploadBuildArtifacts(
     ).flat();
     logger.info(`Build artifacts: ${buildArtifacts.join(', ')}`);
     logger.info('Uploading build artifacts...');
-    await ctx.uploadArtifacts(ArtifactType.BUILD_ARTIFACTS, buildArtifacts, logger);
+    await ctx.uploadArtifacts(ManagedArtifactType.BUILD_ARTIFACTS, buildArtifacts, logger);
   } catch (err: any) {
     logger.error({ err }, 'Failed to upload build artifacts');
   }
@@ -85,5 +85,5 @@ export async function uploadApplicationArchive(
   const applicationArchives = await findArtifacts(rootDir, patternOrPath, logger);
   logger.info(`Application archives: ${applicationArchives.join(', ')}`);
   logger.info('Uploading application archive...');
-  await ctx.uploadArtifacts(ArtifactType.APPLICATION_ARCHIVE, applicationArchives, logger);
+  await ctx.uploadArtifacts(ManagedArtifactType.APPLICATION_ARCHIVE, applicationArchives, logger);
 }

--- a/packages/build-tools/src/utils/artifacts.ts
+++ b/packages/build-tools/src/utils/artifacts.ts
@@ -64,7 +64,11 @@ export async function maybeFindAndUploadBuildArtifacts(
     ).flat();
     logger.info(`Build artifacts: ${buildArtifacts.join(', ')}`);
     logger.info('Uploading build artifacts...');
-    await ctx.uploadArtifacts(ManagedArtifactType.BUILD_ARTIFACTS, buildArtifacts, logger);
+    await ctx.uploadArtifacts({
+      type: ManagedArtifactType.BUILD_ARTIFACTS,
+      paths: buildArtifacts,
+      logger,
+    });
   } catch (err: any) {
     logger.error({ err }, 'Failed to upload build artifacts');
   }
@@ -85,5 +89,9 @@ export async function uploadApplicationArchive(
   const applicationArchives = await findArtifacts(rootDir, patternOrPath, logger);
   logger.info(`Application archives: ${applicationArchives.join(', ')}`);
   logger.info('Uploading application archive...');
-  await ctx.uploadArtifacts(ManagedArtifactType.APPLICATION_ARCHIVE, applicationArchives, logger);
+  await ctx.uploadArtifacts({
+    type: ManagedArtifactType.APPLICATION_ARCHIVE,
+    paths: applicationArchives,
+    logger,
+  });
 }

--- a/packages/eas-build-job/src/artifacts.ts
+++ b/packages/eas-build-job/src/artifacts.ts
@@ -1,0 +1,8 @@
+export enum ManagedArtifactType {
+  APPLICATION_ARCHIVE = 'APPLICATION_ARCHIVE',
+  BUILD_ARTIFACTS = 'BUILD_ARTIFACTS',
+  /**
+   * @deprecated
+   */
+  XCODE_BUILD_LOGS = 'XCODE_BUILD_LOGS',
+}

--- a/packages/eas-build-job/src/index.ts
+++ b/packages/eas-build-job/src/index.ts
@@ -17,3 +17,4 @@ export { Job, sanitizeJob } from './job';
 export { Metadata, sanitizeMetadata } from './metadata';
 export * from './logs';
 export * as errors from './errors';
+export * from './artifacts';

--- a/packages/local-build-plugin/src/android.ts
+++ b/packages/local-build-plugin/src/android.ts
@@ -28,7 +28,7 @@ export async function buildAndroidAsync(
       if (artifact.type !== ManagedArtifactType.APPLICATION_ARCHIVE) {
         return null;
       } else {
-        return await prepareArtifacts(artifact.paths, logger);
+        return await prepareArtifacts(artifact.paths, artifact.logger);
       }
     },
     env,

--- a/packages/local-build-plugin/src/android.ts
+++ b/packages/local-build-plugin/src/android.ts
@@ -1,6 +1,6 @@
 import { bunyan } from '@expo/logger';
-import { Android, BuildPhase, Env } from '@expo/eas-build-job';
-import { Builders, BuildContext, ArtifactType, Artifacts } from '@expo/build-tools';
+import { Android, ManagedArtifactType, BuildPhase, Env } from '@expo/eas-build-job';
+import { Builders, BuildContext, Artifacts } from '@expo/build-tools';
 import omit from 'lodash/omit';
 
 import logger, { logBuffer } from './logger';
@@ -25,8 +25,8 @@ export async function buildAndroidAsync(
     logger,
     logBuffer,
     runGlobalExpoCliCommand: runGlobalExpoCliCommandAsync,
-    uploadArtifacts: async (type: ArtifactType, paths: string[], logger?: bunyan) => {
-      if (type !== ArtifactType.APPLICATION_ARCHIVE) {
+    uploadArtifacts: async (type: ManagedArtifactType, paths: string[], logger?: bunyan) => {
+      if (type !== ManagedArtifactType.APPLICATION_ARCHIVE) {
         return null;
       } else {
         return await prepareArtifacts(paths, logger);

--- a/packages/local-build-plugin/src/android.ts
+++ b/packages/local-build-plugin/src/android.ts
@@ -1,6 +1,5 @@
-import { bunyan } from '@expo/logger';
 import { Android, ManagedArtifactType, BuildPhase, Env } from '@expo/eas-build-job';
-import { Builders, BuildContext, Artifacts } from '@expo/build-tools';
+import { Builders, BuildContext, Artifacts, ArtifactToUpload } from '@expo/build-tools';
 import omit from 'lodash/omit';
 
 import logger, { logBuffer } from './logger';
@@ -25,11 +24,11 @@ export async function buildAndroidAsync(
     logger,
     logBuffer,
     runGlobalExpoCliCommand: runGlobalExpoCliCommandAsync,
-    uploadArtifacts: async (type: ManagedArtifactType, paths: string[], logger?: bunyan) => {
-      if (type !== ManagedArtifactType.APPLICATION_ARCHIVE) {
+    uploadArtifacts: async (artifact: ArtifactToUpload) => {
+      if (artifact.type !== ManagedArtifactType.APPLICATION_ARCHIVE) {
         return null;
       } else {
-        return await prepareArtifacts(paths, logger);
+        return await prepareArtifacts(artifact.paths, logger);
       }
     },
     env,

--- a/packages/local-build-plugin/src/ios.ts
+++ b/packages/local-build-plugin/src/ios.ts
@@ -1,6 +1,5 @@
 import { Ios, BuildPhase, Env, ManagedArtifactType } from '@expo/eas-build-job';
-import { Builders, BuildContext, Artifacts } from '@expo/build-tools';
-import { bunyan } from '@expo/logger';
+import { ArtifactToUpload, Builders, BuildContext, Artifacts } from '@expo/build-tools';
 import omit from 'lodash/omit';
 
 import { runGlobalExpoCliCommandAsync } from './expoCli';
@@ -25,7 +24,7 @@ export async function buildIosAsync(
     logger,
     logBuffer,
     runGlobalExpoCliCommand: runGlobalExpoCliCommandAsync,
-    uploadArtifacts: async (type: ManagedArtifactType, paths: string[], logger?: bunyan) => {
+    uploadArtifacts: async ({ type, paths, logger }: ArtifactToUpload) => {
       if (type !== ManagedArtifactType.APPLICATION_ARCHIVE) {
         return null;
       } else {

--- a/packages/local-build-plugin/src/ios.ts
+++ b/packages/local-build-plugin/src/ios.ts
@@ -1,5 +1,5 @@
-import { Ios, BuildPhase, Env } from '@expo/eas-build-job';
-import { Builders, BuildContext, ArtifactType, Artifacts } from '@expo/build-tools';
+import { Ios, BuildPhase, Env, ManagedArtifactType } from '@expo/eas-build-job';
+import { Builders, BuildContext, Artifacts } from '@expo/build-tools';
 import { bunyan } from '@expo/logger';
 import omit from 'lodash/omit';
 
@@ -25,8 +25,8 @@ export async function buildIosAsync(
     logger,
     logBuffer,
     runGlobalExpoCliCommand: runGlobalExpoCliCommandAsync,
-    uploadArtifacts: async (type: ArtifactType, paths: string[], logger?: bunyan) => {
-      if (type !== ArtifactType.APPLICATION_ARCHIVE) {
+    uploadArtifacts: async (type: ManagedArtifactType, paths: string[], logger?: bunyan) => {
+      if (type !== ManagedArtifactType.APPLICATION_ARCHIVE) {
         return null;
       } else {
         return await prepareArtifacts(paths, logger);


### PR DESCRIPTION
# Why

This should make adding generic artifacts easier.

# How

- renamed `ArtifactType` to `ManagedArtifactType` and moved to `eas-build-job`. `ManagedArtifactType`s are artifacts recognized and produced by managed workflow — application archive, "build artifacts" and Xcode logs. `GenericArtifactType`s will have much more possibilities.
- changed `uploadArtifacts` to accept a single object argument instead of a list. _Much_ better.

# Test Plan

I tested this with [the generic artifact types changes](https://github.com/expo/eas-build/pull/307). Mostly, those are types changes, so if types are all right, the pull request should be all right.