### PR TITLE
Add support for generic artifacts

### DIFF
--- a/packages/build-tools/src/context.ts
+++ b/packages/build-tools/src/context.ts
@@ -12,6 +12,8 @@ import {
   errors,
   Metadata,
   EnvironmentSecretType,
+  GenericArtifactType,
+  isGenericArtifact,
 } from '@expo/eas-build-job';
 import { ExpoConfig } from '@expo/config';
 import { bunyan } from '@expo/logger';
@@ -35,10 +37,16 @@ export interface LogBuffer {
   getPhaseLogs(buildPhase: string): string[];
 }
 
-export type ArtifactToUpload = {
-  type: ManagedArtifactType;
-  paths: string[];
-};
+export type ArtifactToUpload =
+  | {
+      type: ManagedArtifactType;
+      paths: string[];
+    }
+  | {
+      type: GenericArtifactType;
+      key: string;
+      paths: string[];
+    };
 
 export interface BuildContextOptions {
   workingdir: string;
@@ -219,7 +227,7 @@ export class BuildContext<TJob extends Job> {
     logger: bunyan;
   }): Promise<void> {
     const bucketKey = await this._uploadArtifact({ artifact, logger });
-    if (bucketKey) {
+    if (bucketKey && !isGenericArtifact(artifact)) {
       this.artifacts[artifact.type] = bucketKey;
     }
   }

--- a/packages/eas-build-job/src/artifacts.ts
+++ b/packages/eas-build-job/src/artifacts.ts
@@ -6,3 +6,24 @@ export enum ManagedArtifactType {
    */
   XCODE_BUILD_LOGS = 'XCODE_BUILD_LOGS',
 }
+
+export enum GenericArtifactType {
+  ANDROID_APK = 'android-apk',
+  ANDROID_AAB = 'android-aab',
+
+  IOS_SIMULATOR_APP = 'ios-simulator-app',
+  IOS_IPA = 'ios-ipa',
+
+  UNKNOWN = 'unknown',
+}
+
+export const isGenericArtifact = <
+  TSpec extends { type: GenericArtifactType | ManagedArtifactType },
+>(
+  artifactSpec: TSpec
+): artifactSpec is TSpec & { type: GenericArtifactType } => {
+  if (Object.values(GenericArtifactType).includes(artifactSpec.type as GenericArtifactType)) {
+    return true;
+  }
+  return false;
+};


### PR DESCRIPTION
# Why

We want to allow users to upload multiple artifacts, possibly of similar meaning (e.g. multiple iOS apps).

# How

Added `GenericArtifactType` alongside `ManagedArtifactType`.

# Test Plan

- [x] Tested generic artifacts with complementary `turtle-v2` changes.