### PR TITLE
Change `uploadArtifacts` into `uploadArtifact`

### DIFF
--- a/packages/build-tools/src/builders/ios.ts
+++ b/packages/build-tools/src/builders/ios.ts
@@ -175,9 +175,11 @@ async function resignAsync(ctx: BuildContext<Ios.Job>): Promise<Artifacts> {
 
   await ctx.runBuildPhase(BuildPhase.UPLOAD_APPLICATION_ARCHIVE, async () => {
     ctx.logger.info(`Application archive: ${applicationArchivePath}`);
-    await ctx.uploadArtifacts({
-      type: ManagedArtifactType.APPLICATION_ARCHIVE,
-      paths: [applicationArchivePath],
+    await ctx.uploadArtifact({
+      artifact: {
+        type: ManagedArtifactType.APPLICATION_ARCHIVE,
+        paths: [applicationArchivePath],
+      },
       logger: ctx.logger,
     });
   });

--- a/packages/build-tools/src/context.ts
+++ b/packages/build-tools/src/context.ts
@@ -191,8 +191,8 @@ export class BuildContext<TJob extends Job> {
       const buildPhaseResult: BuildPhaseResult = this.buildPhaseSkipped
         ? BuildPhaseResult.SKIPPED
         : this.buildPhaseHasWarnings
-        ? BuildPhaseResult.WARNING
-        : BuildPhaseResult.SUCCESS;
+          ? BuildPhaseResult.WARNING
+          : BuildPhaseResult.SUCCESS;
       await this.endCurrentBuildPhaseAsync({ result: buildPhaseResult, doNotMarkEnd, durationMs });
       return result;
     } catch (err: any) {

--- a/packages/build-tools/src/customBuildContext.ts
+++ b/packages/build-tools/src/customBuildContext.ts
@@ -12,7 +12,7 @@ const platformToBuildRuntimePlatform: Record<Platform, BuildRuntimePlatform> = {
 };
 
 export interface BuilderRuntimeApi {
-  uploadArtifacts: (artifact: ArtifactToUpload) => Promise<void>;
+  uploadArtifact: (spec: { artifact: ArtifactToUpload; logger: bunyan }) => Promise<void>;
 }
 
 export class CustomBuildContext implements ExternalBuildContextProvider {
@@ -54,7 +54,7 @@ export class CustomBuildContext implements ExternalBuildContextProvider {
     this.defaultWorkingDirectory = buildCtx.getReactNativeProjectDirectory();
     this.buildLogsDirectory = path.join(buildCtx.workingdir, 'logs');
     this.runtimeApi = {
-      uploadArtifacts: (artifact) => buildCtx['uploadArtifacts'](artifact),
+      uploadArtifact: (...args) => buildCtx['uploadArtifact'](...args),
     };
   }
 

--- a/packages/build-tools/src/ios/credentials/__tests__/keychain.test.ios.ts
+++ b/packages/build-tools/src/ios/credentials/__tests__/keychain.test.ios.ts
@@ -40,7 +40,7 @@ describe('Keychain class', () => {
         logger: mockLogger,
         env: {},
         runGlobalExpoCliCommand: jest.fn(),
-        uploadArtifacts: jest.fn(),
+        uploadArtifact: jest.fn(),
       });
       keychain = new Keychain(ctx);
       await keychain.create();

--- a/packages/build-tools/src/ios/credentials/__tests__/manager.test.ios.ts
+++ b/packages/build-tools/src/ios/credentials/__tests__/manager.test.ios.ts
@@ -69,7 +69,7 @@ describe(IosCredentialsManager, () => {
         logger: mockLogger,
         env: {},
         runGlobalExpoCliCommand: jest.fn(),
-        uploadArtifacts: jest.fn(),
+        uploadArtifact: jest.fn(),
       });
       const manager = new IosCredentialsManager(ctx);
       const credentials = await manager.prepare();

--- a/packages/build-tools/src/ios/credentials/__tests__/provisioningProfile.test.ios.ts
+++ b/packages/build-tools/src/ios/credentials/__tests__/provisioningProfile.test.ios.ts
@@ -23,7 +23,7 @@ describe('ProvisioningProfile class', () => {
         logger: mockLogger,
         env: {},
         runGlobalExpoCliCommand: jest.fn(),
-        uploadArtifacts: jest.fn(),
+        uploadArtifact: jest.fn(),
       });
       keychain = new Keychain(ctx);
       await keychain.create();

--- a/packages/build-tools/src/ios/xcodeBuildLogs.ts
+++ b/packages/build-tools/src/ios/xcodeBuildLogs.ts
@@ -14,9 +14,11 @@ export async function findAndUploadXcodeBuildLogsAsync(
   try {
     const xcodeBuildLogsPath = await findXcodeBuildLogsPathAsync(ctx.buildLogsDirectory);
     if (xcodeBuildLogsPath) {
-      await ctx.uploadArtifacts({
-        type: ManagedArtifactType.XCODE_BUILD_LOGS,
-        paths: [xcodeBuildLogsPath],
+      await ctx.uploadArtifact({
+        artifact: {
+          type: ManagedArtifactType.XCODE_BUILD_LOGS,
+          paths: [xcodeBuildLogsPath],
+        },
         logger,
       });
     }

--- a/packages/build-tools/src/steps/functions/findAndUploadBuildArtifacts.ts
+++ b/packages/build-tools/src/steps/functions/findAndUploadBuildArtifacts.ts
@@ -41,16 +41,20 @@ export function createFindAndUploadBuildArtifactsBuildFunction(
 
       logger.info('Uploading...');
       const [archiveUpload, artifactsUpload, xcodeBuildLogsUpload] = await Promise.allSettled([
-        ctx.runtimeApi.uploadArtifacts({
-          type: ManagedArtifactType.APPLICATION_ARCHIVE,
-          paths: applicationArchives,
+        ctx.runtimeApi.uploadArtifact({
+          artifact: {
+            type: ManagedArtifactType.APPLICATION_ARCHIVE,
+            paths: applicationArchives,
+          },
           logger,
         }),
         (async () => {
           if (buildArtifacts.length > 0) {
-            await ctx.runtimeApi.uploadArtifacts({
-              type: ManagedArtifactType.BUILD_ARTIFACTS,
-              paths: buildArtifacts,
+            await ctx.runtimeApi.uploadArtifact({
+              artifact: {
+                type: ManagedArtifactType.BUILD_ARTIFACTS,
+                paths: buildArtifacts,
+              },
               logger,
             });
           }
@@ -63,9 +67,11 @@ export function createFindAndUploadBuildArtifactsBuildFunction(
             stepCtx.global.buildLogsDirectory
           );
           if (xcodeBuildLogsPath) {
-            await ctx.runtimeApi.uploadArtifacts({
-              type: ManagedArtifactType.XCODE_BUILD_LOGS,
-              paths: [xcodeBuildLogsPath],
+            await ctx.runtimeApi.uploadArtifact({
+              artifact: {
+                type: ManagedArtifactType.XCODE_BUILD_LOGS,
+                paths: [xcodeBuildLogsPath],
+              },
               logger,
             });
           }

--- a/packages/build-tools/src/steps/functions/uploadArtifact.ts
+++ b/packages/build-tools/src/steps/functions/uploadArtifact.ts
@@ -35,9 +35,11 @@ export function createUploadArtifactBuildFunction(ctx: CustomBuildContext): Buil
       );
       const artifactType = inputs.type.value as ManagedArtifactType;
 
-      await ctx.runtimeApi.uploadArtifacts({
-        type: artifactType,
-        paths: [filePath],
+      await ctx.runtimeApi.uploadArtifact({
+        artifact: {
+          type: artifactType,
+          paths: [filePath],
+        },
         logger: stepsCtx.logger,
       });
     },

--- a/packages/build-tools/src/utils/__tests__/hooks.test.ts
+++ b/packages/build-tools/src/utils/__tests__/hooks.test.ts
@@ -32,7 +32,7 @@ describe(runHookIfPresent, () => {
       logger: loggerMock as any,
       env: {},
       runGlobalExpoCliCommand: jest.fn(),
-      uploadArtifacts: jest.fn(),
+      uploadArtifact: jest.fn(),
     });
   });
 

--- a/packages/build-tools/src/utils/artifacts.ts
+++ b/packages/build-tools/src/utils/artifacts.ts
@@ -64,9 +64,11 @@ export async function maybeFindAndUploadBuildArtifacts(
     ).flat();
     logger.info(`Build artifacts: ${buildArtifacts.join(', ')}`);
     logger.info('Uploading build artifacts...');
-    await ctx.uploadArtifacts({
-      type: ManagedArtifactType.BUILD_ARTIFACTS,
-      paths: buildArtifacts,
+    await ctx.uploadArtifact({
+      artifact: {
+        type: ManagedArtifactType.BUILD_ARTIFACTS,
+        paths: buildArtifacts,
+      },
       logger,
     });
   } catch (err: any) {
@@ -89,9 +91,11 @@ export async function uploadApplicationArchive(
   const applicationArchives = await findArtifacts(rootDir, patternOrPath, logger);
   logger.info(`Application archives: ${applicationArchives.join(', ')}`);
   logger.info('Uploading application archive...');
-  await ctx.uploadArtifacts({
-    type: ManagedArtifactType.APPLICATION_ARCHIVE,
-    paths: applicationArchives,
+  await ctx.uploadArtifact({
+    artifact: {
+      type: ManagedArtifactType.APPLICATION_ARCHIVE,
+      paths: applicationArchives,
+    },
     logger,
   });
 }

--- a/packages/local-build-plugin/src/android.ts
+++ b/packages/local-build-plugin/src/android.ts
@@ -1,5 +1,5 @@
 import { Android, ManagedArtifactType, BuildPhase, Env } from '@expo/eas-build-job';
-import { Builders, BuildContext, Artifacts, ArtifactToUpload } from '@expo/build-tools';
+import { Builders, BuildContext, Artifacts } from '@expo/build-tools';
 import omit from 'lodash/omit';
 
 import logger, { logBuffer } from './logger';
@@ -24,11 +24,11 @@ export async function buildAndroidAsync(
     logger,
     logBuffer,
     runGlobalExpoCliCommand: runGlobalExpoCliCommandAsync,
-    uploadArtifacts: async (artifact: ArtifactToUpload) => {
+    uploadArtifact: async ({ artifact, logger }) => {
       if (artifact.type !== ManagedArtifactType.APPLICATION_ARCHIVE) {
         return null;
       } else {
-        return await prepareArtifacts(artifact.paths, artifact.logger);
+        return await prepareArtifacts(artifact.paths, logger);
       }
     },
     env,

--- a/packages/local-build-plugin/src/ios.ts
+++ b/packages/local-build-plugin/src/ios.ts
@@ -1,5 +1,5 @@
 import { Ios, BuildPhase, Env, ManagedArtifactType } from '@expo/eas-build-job';
-import { ArtifactToUpload, Builders, BuildContext, Artifacts } from '@expo/build-tools';
+import { Builders, BuildContext, Artifacts } from '@expo/build-tools';
 import omit from 'lodash/omit';
 
 import { runGlobalExpoCliCommandAsync } from './expoCli';
@@ -24,11 +24,11 @@ export async function buildIosAsync(
     logger,
     logBuffer,
     runGlobalExpoCliCommand: runGlobalExpoCliCommandAsync,
-    uploadArtifacts: async ({ type, paths, logger }: ArtifactToUpload) => {
-      if (type !== ManagedArtifactType.APPLICATION_ARCHIVE) {
+    uploadArtifact: async ({ artifact, logger }) => {
+      if (artifact.type !== ManagedArtifactType.APPLICATION_ARCHIVE) {
         return null;
       } else {
-        return await prepareArtifacts(paths, logger);
+        return await prepareArtifacts(artifact.paths, logger);
       }
     },
     env,


### PR DESCRIPTION
# Why

We won't "upload artifacts" anymore the way we did. Also, artifacts have types which should live nested inside `artifact` property and that property should live _alongside_ logger.

# How

Renamed functions, changed calls.

# Test Plan

Believing in TS.