### PR TITLE
Bring back `build-artifact` and `application-archive` artifact type inputs

### DIFF
--- a/packages/build-tools/src/__tests__/utils/context.ts
+++ b/packages/build-tools/src/__tests__/utils/context.ts
@@ -1,0 +1,101 @@
+import path from 'path';
+import os from 'os';
+
+import { bunyan } from '@expo/logger';
+import { v4 as uuidv4 } from 'uuid';
+import {
+  BuildRuntimePlatform,
+  BuildStepContext,
+  BuildStepEnv,
+  BuildStepGlobalContext,
+  ExternalBuildContextProvider,
+} from '@expo/steps';
+
+import { createMockLogger } from './logger';
+
+export class MockContextProvider implements ExternalBuildContextProvider {
+  private _env: BuildStepEnv = {};
+
+  constructor(
+    public readonly logger: bunyan,
+    public readonly runtimePlatform: BuildRuntimePlatform,
+    public readonly projectSourceDirectory: string,
+    public readonly projectTargetDirectory: string,
+    public readonly defaultWorkingDirectory: string,
+    public readonly buildLogsDirectory: string,
+    public readonly staticContextContent: Record<string, any> = {}
+  ) {}
+  public get env(): BuildStepEnv {
+    return this._env;
+  }
+  public staticContext(): any {
+    return { ...this.staticContextContent };
+  }
+  public updateEnv(env: BuildStepEnv): void {
+    this._env = env;
+  }
+}
+
+interface BuildContextParams {
+  buildId?: string;
+  logger?: bunyan;
+  skipCleanup?: boolean;
+  runtimePlatform?: BuildRuntimePlatform;
+  projectSourceDirectory?: string;
+  projectTargetDirectory?: string;
+  relativeWorkingDirectory?: string;
+  staticContextContent?: Record<string, any>;
+}
+
+export function createStepContextMock({
+  buildId,
+  logger,
+  skipCleanup,
+  runtimePlatform,
+  projectSourceDirectory,
+  projectTargetDirectory,
+  relativeWorkingDirectory,
+  staticContextContent,
+}: BuildContextParams = {}): BuildStepContext {
+  const globalCtx = createGlobalContextMock({
+    buildId,
+    logger,
+    skipCleanup,
+    runtimePlatform,
+    projectSourceDirectory,
+    projectTargetDirectory,
+    relativeWorkingDirectory,
+    staticContextContent,
+  });
+  return new BuildStepContext(globalCtx, {
+    logger: logger ?? createMockLogger(),
+    relativeWorkingDirectory,
+  });
+}
+
+export function createGlobalContextMock({
+  logger,
+  skipCleanup,
+  runtimePlatform,
+  projectSourceDirectory,
+  projectTargetDirectory,
+  relativeWorkingDirectory,
+  staticContextContent,
+}: BuildContextParams = {}): BuildStepGlobalContext {
+  const resolvedProjectTargetDirectory =
+    projectTargetDirectory ?? path.join(os.tmpdir(), 'eas-build', uuidv4());
+  return new BuildStepGlobalContext(
+    new MockContextProvider(
+      logger ?? createMockLogger(),
+      runtimePlatform ?? BuildRuntimePlatform.LINUX,
+      projectSourceDirectory ?? '/non/existent/dir',
+      resolvedProjectTargetDirectory,
+      relativeWorkingDirectory
+        ? path.resolve(resolvedProjectTargetDirectory, relativeWorkingDirectory)
+        : resolvedProjectTargetDirectory,
+      '/non/existent/dir',
+      staticContextContent ?? {}
+    ),
+    skipCleanup ?? false
+  );
+}

--- a/packages/build-tools/src/__tests__/utils/job.ts
+++ b/packages/build-tools/src/__tests__/utils/job.ts
@@ -1,0 +1,47 @@
+import {
+  ArchiveSourceType,
+  BuildMode,
+  BuildTrigger,
+  Ios,
+  Platform,
+  Workflow,
+} from '@expo/eas-build-job';
+
+const iosCredentials: Ios.BuildCredentials = {
+  testapp: {
+    provisioningProfileBase64: '',
+    distributionCertificate: {
+      dataBase64: '',
+      password: '',
+    },
+  },
+};
+
+export function createTestIosJob({
+  buildCredentials = iosCredentials,
+}: {
+  buildCredentials?: Ios.BuildCredentials;
+} = {}): Ios.Job {
+  return {
+    mode: BuildMode.BUILD,
+    platform: Platform.IOS,
+    triggeredBy: BuildTrigger.EAS_CLI,
+    type: Workflow.GENERIC,
+    projectArchive: {
+      type: ArchiveSourceType.URL,
+      url: 'https://turtle-v2-test-fixtures.s3.us-east-2.amazonaws.com/project.tar.gz',
+    },
+    scheme: 'turtlebareproj',
+    buildConfiguration: 'Release',
+    applicationArchivePath: './ios/build/*.ipa',
+    projectRootDirectory: '.',
+    cache: {
+      clear: false,
+      disabled: false,
+      paths: [],
+    },
+    secrets: {
+      buildCredentials,
+    },
+  };
+}

--- a/packages/build-tools/src/__tests__/utils/logger.ts
+++ b/packages/build-tools/src/__tests__/utils/logger.ts
@@ -1,0 +1,12 @@
+import { bunyan } from '@expo/logger';
+
+export function createMockLogger(): bunyan {
+  const logger = {
+    info: jest.fn(),
+    debug: jest.fn(),
+    error: jest.fn(),
+    warn: jest.fn(),
+    child: jest.fn().mockImplementation(() => createMockLogger()),
+  } as unknown as bunyan;
+  return logger;
+}

--- a/packages/build-tools/src/steps/functions/__tests__/uploadArtifact.test.ts
+++ b/packages/build-tools/src/steps/functions/__tests__/uploadArtifact.test.ts
@@ -1,0 +1,52 @@
+import { createGlobalContextMock } from '../../../__tests__/utils/context';
+import { createTestIosJob } from '../../../__tests__/utils/job';
+import { createMockLogger } from '../../../__tests__/utils/logger';
+import { BuildContext } from '../../../context';
+import { CustomBuildContext } from '../../../customBuildContext';
+import { createUploadArtifactBuildFunction } from '../uploadArtifact';
+
+describe(createUploadArtifactBuildFunction, () => {
+  const ctx = new BuildContext(createTestIosJob({}), {
+    env: {},
+    logBuffer: { getLogs: () => [], getPhaseLogs: () => [] },
+    logger: createMockLogger(),
+    uploadArtifact: jest.fn(),
+    workingdir: '',
+    runGlobalExpoCliCommand: jest.fn(),
+  });
+  const customContext = new CustomBuildContext(ctx);
+  const uploadArtifact = createUploadArtifactBuildFunction(customContext);
+
+  it.each(['build-artifact', 'BUILD_ARTIFACTS'])('accepts %s', async (type) => {
+    const buildStep = uploadArtifact.createBuildStepFromFunctionCall(createGlobalContextMock({}), {
+      callInputs: {
+        type,
+        path: '/',
+      },
+    });
+    const typeInput = buildStep.inputs?.find((input) => input.id === 'type')!;
+    expect(typeInput.isValueOneOfAllowedValues()).toBe(true);
+  });
+
+  it('does not throw for undefined type input', async () => {
+    const buildStep = uploadArtifact.createBuildStepFromFunctionCall(createGlobalContextMock({}), {
+      callInputs: {
+        path: '/',
+      },
+    });
+    for (const input of buildStep.inputs ?? []) {
+      expect(input.isValueOneOfAllowedValues()).toBe(true);
+    }
+  });
+
+  it.each(['invalid-value'])('does not accept %s', async (type) => {
+    const buildStep = uploadArtifact.createBuildStepFromFunctionCall(createGlobalContextMock({}), {
+      callInputs: {
+        type,
+        path: '/',
+      },
+    });
+    const typeInput = buildStep.inputs?.find((input) => input.id === 'type')!;
+    expect(typeInput.isValueOneOfAllowedValues()).toBe(false);
+  });
+});

--- a/packages/eas-build-job/src/artifacts.ts
+++ b/packages/eas-build-job/src/artifacts.ts
@@ -14,7 +14,7 @@ export enum GenericArtifactType {
   IOS_SIMULATOR_APP = 'ios-simulator-app',
   IOS_IPA = 'ios-ipa',
 
-  UNKNOWN = 'unknown',
+  OTHER = 'other',
 }
 
 export const isGenericArtifact = <


### PR DESCRIPTION
# Why

I mistakenly broke the API by removing those values from `allowedValues` when adding `ManagedArtifactType`.

# How

Brought back those values to `allowedValues`, added mapping.

# Test Plan

Added test that ensures both values are accepted. While adding test realized input validation does not work like we expect it to. https://linear.app/expo/issue/ENG-11215/fix-validating-inputs
