### PR TITLE
Add `eas/start_android_emulator` build function

### DIFF
--- a/packages/build-tools/src/steps/easFunctions.ts
+++ b/packages/build-tools/src/steps/easFunctions.ts
@@ -17,6 +17,7 @@ import { configureIosCredentialsFunction } from './functions/configureIosCredent
 import { configureIosVersionFunction } from './functions/configureIosVersion';
 import { generateGymfileFromTemplateFunction } from './functions/generateGymfileFromTemplate';
 import { runFastlaneFunction } from './functions/runFastlane';
+import { createStartAndroidEmulatorBuildFunction } from './functions/startAndroidEmulator';
 
 export function getEasFunctions(ctx: CustomBuildContext): BuildFunction[] {
   return [
@@ -35,5 +36,6 @@ export function getEasFunctions(ctx: CustomBuildContext): BuildFunction[] {
     configureIosVersionFunction(),
     generateGymfileFromTemplateFunction(),
     runFastlaneFunction(),
+    createStartAndroidEmulatorBuildFunction(),
   ];
 }

--- a/packages/build-tools/src/steps/functions/startAndroidEmulator.ts
+++ b/packages/build-tools/src/steps/functions/startAndroidEmulator.ts
@@ -16,6 +16,12 @@ export function createStartAndroidEmulatorBuildFunction(): BuildFunction {
     name: 'Start Android Emulator',
     inputProviders: [
       BuildStepInput.createProvider({
+        id: 'device_name',
+        required: false,
+        defaultValue: 'EasAndroidDevice01',
+        allowedValueTypeName: BuildStepInputValueTypeName.STRING,
+      }),
+      BuildStepInput.createProvider({
         id: 'system_image_package',
         required: false,
         defaultValue: defaultSystemImagePackage,
@@ -23,7 +29,7 @@ export function createStartAndroidEmulatorBuildFunction(): BuildFunction {
       }),
     ],
     fn: async ({ logger }, { inputs }) => {
-      const deviceName = 'EasAndroidDevice01';
+      const deviceName = `${inputs.device_name.value}`;
       const systemImagePackage = `${inputs.system_image_package.value}`;
       logger.info('Making sure system image is installed');
       await spawn('sdkmanager', [systemImagePackage], {

--- a/packages/build-tools/src/steps/functions/startAndroidEmulator.ts
+++ b/packages/build-tools/src/steps/functions/startAndroidEmulator.ts
@@ -1,0 +1,115 @@
+import assert from 'assert';
+
+import { BuildFunction, BuildStepInput, BuildStepInputValueTypeName } from '@expo/steps';
+import spawn from '@expo/turtle-spawn';
+import { v4 as uuidv4 } from 'uuid';
+import { PipeMode } from '@expo/logger';
+
+const defaultSystemImagePackage = `system-images;android-30;default;${
+  process.arch === 'arm64' ? 'arm64-v8a' : 'x86_64'
+}`;
+
+export function createStartAndroidEmulatorBuildFunction(): BuildFunction {
+  return new BuildFunction({
+    namespace: 'eas',
+    id: 'start_android_emulator',
+    name: 'Start Android Emulator',
+    inputProviders: [
+      BuildStepInput.createProvider({
+        id: 'system_image_package',
+        required: false,
+        defaultValue: defaultSystemImagePackage,
+        allowedValueTypeName: BuildStepInputValueTypeName.STRING,
+      }),
+    ],
+    fn: async ({ logger }, { inputs }) => {
+      const deviceName = 'EasAndroidDevice01';
+      const systemImagePackage = `${inputs.system_image_package.value}`;
+      logger.info('Making sure system image is installed');
+      await spawn('sdkmanager', [systemImagePackage], {
+        logger,
+      });
+
+      logger.info('Creating emulator device');
+      await spawn(
+        'avdmanager',
+        ['create', 'avd', '--name', deviceName, '--package', systemImagePackage, '--force'],
+        {
+          ignoreStdio: true,
+        }
+      );
+
+      const emuPropId = uuidv4();
+
+      logger.info('Starting emulator device');
+      const emulatorPromise = spawn(
+        `${process.env.ANDROID_HOME}/emulator/emulator`,
+        [
+          '-no-window',
+          '-no-boot-anim',
+          '-writable-system',
+          '-noaudio',
+          '-avd',
+          deviceName,
+          '-prop',
+          `qemu.uuid=${emuPropId}`,
+        ],
+        {
+          detached: true,
+          stdio: 'ignore',
+        }
+      );
+      // If emulator fails to start, throw its error.
+      if (!emulatorPromise.child.pid) {
+        await emulatorPromise;
+      }
+      emulatorPromise.child.unref();
+
+      logger.info('Waiting for emulator to become ready');
+      await spawn('adb', ['wait-for-device']);
+
+      const serialId = await getEmulatorSerialId({ emuPropId });
+      assert(serialId, 'Failed to configure emulator: emulator with required ID not found.');
+
+      let hasBootCompleted = false;
+      while (!hasBootCompleted) {
+        const { stdout } = await spawn(
+          'adb',
+          ['-s', serialId, 'shell', 'getprop', 'sys.boot_completed'],
+          {
+            mode: PipeMode.COMBINED,
+          }
+        );
+        if (stdout.startsWith('1')) {
+          hasBootCompleted = true;
+        }
+      }
+
+      logger.info(`${deviceName} is ready.`);
+    },
+  });
+}
+
+async function getEmulatorSerialId({ emuPropId }: { emuPropId: string }): Promise<string | null> {
+  const adbDevices = await spawn('adb', ['devices'], { mode: PipeMode.COMBINED });
+  for (const adbDeviceLine of adbDevices.stdout.split('\n')) {
+    if (!adbDeviceLine.startsWith('emulator')) {
+      continue;
+    }
+
+    const matches = adbDeviceLine.match(/^(\S+)/);
+    if (!matches) {
+      continue;
+    }
+
+    const [, serialId] = matches;
+    const getProp = await spawn('adb', ['-s', serialId, 'shell', 'getprop', 'qemu.uuid'], {
+      mode: PipeMode.COMBINED,
+    });
+    if (getProp.stdout.startsWith(emuPropId)) {
+      return serialId;
+    }
+  }
+
+  return null;
+}

--- a/packages/build-tools/src/utils/retry.ts
+++ b/packages/build-tools/src/utils/retry.ts
@@ -1,0 +1,38 @@
+import { bunyan } from '@expo/logger';
+
+export async function sleepAsync(ms: number): Promise<void> {
+  await new Promise((res) => setTimeout(res, ms));
+}
+
+export interface RetryOptions {
+  retries: number;
+  retryIntervalMs: number;
+}
+
+export async function retryAsync<T = void>(
+  fn: (attemptCount: number) => Promise<T>,
+  {
+    retryOptions: { retries, retryIntervalMs },
+    logger,
+  }: {
+    retryOptions: RetryOptions;
+    logger?: bunyan;
+  }
+): Promise<T> {
+  let attemptCount = -1;
+  for (;;) {
+    try {
+      attemptCount += 1;
+      return await fn(attemptCount);
+    } catch (err: any) {
+      logger?.debug(
+        { err, stdout: err.stdout, stderr: err.stderr },
+        `Retry attempt ${attemptCount}`
+      );
+      await sleepAsync(retryIntervalMs);
+      if (attemptCount === retries) {
+        throw err;
+      }
+    }
+  }
+}


### PR DESCRIPTION
# Why

We want to provide users with an easy way to start an Android emulator for E2E tests.

# How

It's rather simple, just a couple bash commands. I'm happy by using `detached` I was able to work around the ([previously necessary](https://exponent-internal.slack.com/archives/C05JR16NWAX/p1691606736451939)) `echo 'nohup ...' | at now`.

# Test Plan

I've played with it a bunch and even was able to start two emulators at once! The emulators are alive as long as `eas-build-worker` is alive, which I think is ok.