### PR TITLE
[ENG-9499][build-tools] add support for custom GH builds with credentials

### DIFF
--- a/packages/build-tools/src/customBuildContext.ts
+++ b/packages/build-tools/src/customBuildContext.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 
-import { BuildPhase, Env, Job, Metadata, Platform } from '@expo/eas-build-job';
+import { BuildPhase, BuildTrigger, Env, Job, Metadata, Platform } from '@expo/eas-build-job';
 import { bunyan } from '@expo/logger';
 import { ExternalBuildContextProvider, BuildRuntimePlatform } from '@expo/steps';
 
@@ -38,8 +38,8 @@ export class CustomBuildContext implements ExternalBuildContextProvider {
 
   public readonly logger: bunyan;
   public readonly runtimeApi: BuilderRuntimeApi;
-  public readonly job: Job;
-  public readonly metadata?: Metadata;
+  public job: Job;
+  public metadata?: Metadata;
 
   private _env: Env;
 
@@ -75,5 +75,15 @@ export class CustomBuildContext implements ExternalBuildContextProvider {
 
   public updateEnv(env: Env): void {
     this._env = env;
+  }
+
+  public updateJobInformation(job: Job, metadata: Metadata): void {
+    if (this.job.triggeredBy !== BuildTrigger.GIT_BASED_INTEGRATION) {
+      throw new Error(
+        'Updating job information is only allowed when build was triggered by a git-based integration.'
+      );
+    }
+    this.job = { ...job, triggeredBy: this.job.triggeredBy };
+    this.metadata = metadata;
   }
 }

--- a/packages/build-tools/src/steps/easFunctions.ts
+++ b/packages/build-tools/src/steps/easFunctions.ts
@@ -20,6 +20,7 @@ import { runFastlaneFunction } from './functions/runFastlane';
 import { createStartAndroidEmulatorBuildFunction } from './functions/startAndroidEmulator';
 import { createStartIosSimulatorBuildFunction } from './functions/startIosSimulator';
 import { createInstallMaestroBuildFunction } from './functions/installMaestro';
+import { createGetCredentialsForBuildTriggeredByGithubIntegration } from './functions/getCredentialsForBuildTriggeredByGitHubIntegration';
 
 export function getEasFunctions(ctx: CustomBuildContext): BuildFunction[] {
   return [
@@ -41,5 +42,6 @@ export function getEasFunctions(ctx: CustomBuildContext): BuildFunction[] {
     createStartAndroidEmulatorBuildFunction(),
     createStartIosSimulatorBuildFunction(),
     createInstallMaestroBuildFunction(),
+    createGetCredentialsForBuildTriggeredByGithubIntegration(ctx),
   ];
 }

--- a/packages/build-tools/src/steps/functions/getCredentialsForBuildTriggeredByGitHubIntegration.ts
+++ b/packages/build-tools/src/steps/functions/getCredentialsForBuildTriggeredByGitHubIntegration.ts
@@ -1,0 +1,30 @@
+import { BuildTrigger } from '@expo/eas-build-job';
+import { BuildFunction } from '@expo/steps';
+
+import { runEasBuildInternalAsync } from '../../common/easBuildInternal';
+import { CustomBuildContext } from '../../customBuildContext';
+
+export function createGetCredentialsForBuildTriggeredByGithubIntegration(
+  ctx: CustomBuildContext
+): BuildFunction {
+  return new BuildFunction({
+    namespace: 'eas',
+    id: 'get_credentials_for_build_triggered_by_github_integration',
+    name: 'Get credentials for build triggered by GitHub integration',
+    fn: async (stepCtx, { env }) => {
+      if (ctx.job.triggeredBy === BuildTrigger.GIT_BASED_INTEGRATION) {
+        stepCtx.logger.info('Getting credentials for build triggered by EAS GitHub integration...');
+        const { newJob, newMetadata } = await runEasBuildInternalAsync({
+          job: ctx.job,
+          env,
+          logger: stepCtx.logger,
+          cwd: stepCtx.workingDirectory,
+        });
+        ctx.updateJobInformation(newJob, newMetadata);
+        stepCtx.logger.info('Credentials obtained.');
+      } else {
+        stepCtx.logger.info('Not a build triggered by EAS GitHub integration. Skipping...');
+      }
+    },
+  });
+}


### PR DESCRIPTION
# Why

https://linear.app/expo/issue/ENG-9499/add-support-for-gh-builds

# How

Apply the logic that is used to make GH builds work for standard build flow (resolving envs from `eas.json` and resolving credentials using `eas build:internal`) : 
https://github.com/expo/eas-build/blob/25c65873f3a737ad7afda5db3081f2455a34edb2/packages/build-tools/src/common/setup.ts#L37-L44
https://github.com/expo/eas-build/blob/25c65873f3a737ad7afda5db3081f2455a34edb2/packages/build-tools/src/common/setup.ts#L62-L72
to the custom builds flow.

Read `env` from `eas.json` automatically after preparing project sources:
https://github.com/expo/eas-build/blob/25c65873f3a737ad7afda5db3081f2455a34edb2/packages/build-tools/src/builders/custom.ts#L15-L23

The `eas build:internal` command (to get the credentials) expects the dependencies to be installed. Therefore it can't be run silently after preparing project files similar to how we resolve `env` from `eas.json`. I added a new custom function to allow users to get the credentials for their GH builds. This function should be called after installing node modules.
```yml
build:
  name: store build
  steps:
    - eas/checkout
    - run:
        name: Install dependencies
        command: npm install
    - eas/get_credentials_for_build_triggered_by_github_integration
    ...
```

# Test Plan

I'm not able to trigger the GH builds in my local environment, as it requires running background jobs which I can't get to run locally.

I believe it might be best to merge it, do the new release, and test it on staging, as it seems to be low-risk PR to me (very low chance of breaking prod, worst case scenario is the new function just won't work)
