### PR TITLE
Set stdin of shell scripts to "ignore"

### DIFF
--- a/packages/steps/src/BuildStep.ts
+++ b/packages/steps/src/BuildStep.ts
@@ -339,6 +339,8 @@ export class BuildStep extends BuildStepOutputAccessor {
         cwd: this.ctx.workingDirectory,
         logger: this.ctx.logger,
         env: this.getScriptEnv({ outputsDir, envsDir }),
+        // stdin is /dev/null, std{out,err} are piped into logger.
+        stdio: ['ignore', 'pipe', 'pipe'],
       });
       this.ctx.logger.debug(`Script completed successfully`);
 

--- a/packages/steps/src/scripts/runCustomFunction.ts
+++ b/packages/steps/src/scripts/runCustomFunction.ts
@@ -101,6 +101,7 @@ async function runCustomJsFunctionAsync(): Promise<void> {
       promises.push(
         spawnAsync('set-output', [output.id, output.value], {
           env,
+          stdio: 'pipe',
         })
       );
     }
@@ -111,6 +112,7 @@ async function runCustomJsFunctionAsync(): Promise<void> {
       promises.push(
         spawnAsync('set-env', [envName, envValue], {
           env,
+          stdio: 'pipe',
         })
       );
     }

--- a/packages/steps/src/utils/customFunction.ts
+++ b/packages/steps/src/utils/customFunction.ts
@@ -56,6 +56,7 @@ export function createCustomFunctionCall(rawCustomFunctionModulePath: string): B
           logger: ctx.logger,
           cwd: ctx.workingDirectory,
           env,
+          stdio: 'pipe',
         }
       );
     } catch {


### PR DESCRIPTION
# Why

Executing `maestro test` in a custom TS function with `stdin: ignore` seems to be more reliable than with `stdin: pipe`.

# How

Made `spawnAsync` require some `stdio` settings when passing in `logger`. Set `stdin: ignore` when executing shell scripts.

I'm not 1000% sure this may or may not break people's scripts. I don't expect it to though — nobody should depend on `stdin` piped from worker.

# Test Plan

I have deployed a worker with this version of `@expo/steps` to staging and it allowed me to run `maestro test` in a script without the `< /dev/null 2>&1 > maestro.log &` hacks. [Staging](https://staging.expo.dev/accounts/exponent/projects/eas-custom-builds-example/builds/dbee99a1-cef2-46db-be85-5636a66ae19e) vs [production](https://expo.dev/accounts/exponent/projects/eas-custom-builds-example/builds/767c41f9-d265-4f6b-b389-fb8684720e6a) (the same code).