### PR TITLE
[steps][build-tools] add `eas-build` build function group

### DIFF
--- a/packages/build-tools/src/builders/custom.ts
+++ b/packages/build-tools/src/builders/custom.ts
@@ -9,6 +9,7 @@ import { prepareProjectSourcesAsync } from '../common/projectSources';
 import { getEasFunctions } from '../steps/easFunctions';
 import { CustomBuildContext } from '../customBuildContext';
 import { resolveEnvFromBuildProfileAsync } from '../common/easBuildInternal';
+import { getEasFunctionGroups } from '../steps/easFunctionGroups';
 
 export async function runCustomBuildAsync<T extends Job>(ctx: BuildContext<T>): Promise<Artifacts> {
   const customBuildCtx = new CustomBuildContext(ctx);
@@ -32,8 +33,10 @@ export async function runCustomBuildAsync<T extends Job>(ctx: BuildContext<T>): 
 
   const globalContext = new BuildStepGlobalContext(customBuildCtx, false);
   const easFunctions = getEasFunctions(customBuildCtx);
+  const easFunctionGroups = getEasFunctionGroups(customBuildCtx);
   const parser = new BuildConfigParser(globalContext, {
     externalFunctions: easFunctions,
+    externalFunctionGroups: easFunctionGroups,
     configPath,
   });
   const workflow = await ctx.runBuildPhase(BuildPhase.PARSE_CUSTOM_WORKFLOW_CONFIG, async () => {

--- a/packages/build-tools/src/steps/easFunctionGroups.ts
+++ b/packages/build-tools/src/steps/easFunctionGroups.ts
@@ -1,0 +1,9 @@
+import { BuildFunctionGroup } from '@expo/steps';
+
+import { CustomBuildContext } from '../customBuildContext';
+
+import { createEasBuildBuildFunctionGroup } from './functionGroups/build';
+
+export function getEasFunctionGroups(ctx: CustomBuildContext): BuildFunctionGroup[] {
+  return [createEasBuildBuildFunctionGroup(ctx)];
+}

--- a/packages/build-tools/src/steps/easFunctions.ts
+++ b/packages/build-tools/src/steps/easFunctions.ts
@@ -21,6 +21,7 @@ import { createStartAndroidEmulatorBuildFunction } from './functions/startAndroi
 import { createStartIosSimulatorBuildFunction } from './functions/startIosSimulator';
 import { createInstallMaestroBuildFunction } from './functions/installMaestro';
 import { createGetCredentialsForBuildTriggeredByGithubIntegration } from './functions/getCredentialsForBuildTriggeredByGitHubIntegration';
+import { createInstallPodsBuildFunction } from './functions/installPods';
 
 export function getEasFunctions(ctx: CustomBuildContext): BuildFunction[] {
   return [
@@ -43,5 +44,6 @@ export function getEasFunctions(ctx: CustomBuildContext): BuildFunction[] {
     createStartIosSimulatorBuildFunction(),
     createInstallMaestroBuildFunction(),
     createGetCredentialsForBuildTriggeredByGithubIntegration(ctx),
+    createInstallPodsBuildFunction(),
   ];
 }

--- a/packages/build-tools/src/steps/functionGroups/build.ts
+++ b/packages/build-tools/src/steps/functionGroups/build.ts
@@ -1,0 +1,149 @@
+import { BuildFunctionGroup, BuildStep, BuildStepGlobalContext } from '@expo/steps';
+import { Platform } from '@expo/eas-build-job';
+
+import { createCheckoutBuildFunction } from '../functions/checkout';
+import { createInstallNodeModulesBuildFunction } from '../functions/installNodeModules';
+import { createPrebuildBuildFunction } from '../functions/prebuild';
+import { createInstallPodsBuildFunction } from '../functions/installPods';
+import { configureEASUpdateIfInstalledFunction } from '../functions/configureEASUpdateIfInstalled';
+import { generateGymfileFromTemplateFunction } from '../functions/generateGymfileFromTemplate';
+import { runFastlaneFunction } from '../functions/runFastlane';
+import { createFindAndUploadBuildArtifactsBuildFunction } from '../functions/findAndUploadBuildArtifacts';
+import { CustomBuildContext } from '../../customBuildContext';
+import { createGetCredentialsForBuildTriggeredByGithubIntegration } from '../functions/getCredentialsForBuildTriggeredByGitHubIntegration';
+import { resolveAppleTeamIdFromCredentialsFunction } from '../functions/resolveAppleTeamIdFromCredentials';
+import { configureIosCredentialsFunction } from '../functions/configureIosCredentials';
+import { runGradleFunction } from '../functions/runGradle';
+import { configureIosVersionFunction } from '../functions/configureIosVersion';
+import { injectAndroidCredentialsFunction } from '../functions/injectAndroidCredentials';
+import { configureAndroidVersionFunction } from '../functions/configureAndroidVersion';
+
+interface HelperFunctionsInput {
+  globalCtx: BuildStepGlobalContext;
+  buildToolsContext: CustomBuildContext;
+}
+
+export function createEasBuildBuildFunctionGroup(
+  buildToolsContext: CustomBuildContext
+): BuildFunctionGroup {
+  return new BuildFunctionGroup({
+    namespace: 'eas',
+    id: 'build',
+    createBuildStepsFromFunctionGroupCall: (globalCtx) => {
+      if (buildToolsContext.job.platform === Platform.IOS) {
+        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+        if (buildToolsContext.job.simulator || !buildToolsContext.job.secrets?.buildCredentials) {
+          return createStepsForIosSimulatorBuild({
+            globalCtx,
+            buildToolsContext,
+          });
+        } else {
+          return createStepsForIosBuildWithCredentials({
+            globalCtx,
+            buildToolsContext,
+          });
+        }
+      } else {
+        if (!buildToolsContext.job.secrets?.buildCredentials) {
+          return createStepsForAndroidBuildWithoutCredentials({
+            globalCtx,
+            buildToolsContext,
+          });
+        } else {
+          return createStepsForAndroidBuildWithCredentials({
+            globalCtx,
+            buildToolsContext,
+          });
+        }
+      }
+    },
+  });
+}
+
+function createStepsForIosSimulatorBuild({
+  globalCtx,
+  buildToolsContext,
+}: HelperFunctionsInput): BuildStep[] {
+  return [
+    createCheckoutBuildFunction().createBuildStepFromFunctionCall(globalCtx),
+    createInstallNodeModulesBuildFunction().createBuildStepFromFunctionCall(globalCtx),
+    createPrebuildBuildFunction().createBuildStepFromFunctionCall(globalCtx),
+    createInstallPodsBuildFunction().createBuildStepFromFunctionCall(globalCtx),
+    configureEASUpdateIfInstalledFunction().createBuildStepFromFunctionCall(globalCtx),
+    generateGymfileFromTemplateFunction().createBuildStepFromFunctionCall(globalCtx),
+    runFastlaneFunction().createBuildStepFromFunctionCall(globalCtx),
+    createFindAndUploadBuildArtifactsBuildFunction(
+      buildToolsContext
+    ).createBuildStepFromFunctionCall(globalCtx),
+  ];
+}
+
+function createStepsForIosBuildWithCredentials({
+  globalCtx,
+  buildToolsContext,
+}: HelperFunctionsInput): BuildStep[] {
+  const resolveAppleTeamIdFromCredentials =
+    resolveAppleTeamIdFromCredentialsFunction().createBuildStepFromFunctionCall(globalCtx, {
+      id: 'resolve_apple_team_id_from_credentials',
+    });
+  const prebuildStep = createPrebuildBuildFunction().createBuildStepFromFunctionCall(globalCtx, {
+    callInputs: {
+      apple_team_id: '${ steps.resolve_apple_team_id_from_credentials.apple_team_id }',
+    },
+  });
+  return [
+    createCheckoutBuildFunction().createBuildStepFromFunctionCall(globalCtx),
+    createInstallNodeModulesBuildFunction().createBuildStepFromFunctionCall(globalCtx),
+    createGetCredentialsForBuildTriggeredByGithubIntegration(
+      buildToolsContext
+    ).createBuildStepFromFunctionCall(globalCtx),
+    resolveAppleTeamIdFromCredentials,
+    prebuildStep,
+    createInstallPodsBuildFunction().createBuildStepFromFunctionCall(globalCtx),
+    configureEASUpdateIfInstalledFunction().createBuildStepFromFunctionCall(globalCtx),
+    configureIosCredentialsFunction().createBuildStepFromFunctionCall(globalCtx),
+    configureIosVersionFunction().createBuildStepFromFunctionCall(globalCtx),
+    generateGymfileFromTemplateFunction().createBuildStepFromFunctionCall(globalCtx),
+    runFastlaneFunction().createBuildStepFromFunctionCall(globalCtx),
+    createFindAndUploadBuildArtifactsBuildFunction(
+      buildToolsContext
+    ).createBuildStepFromFunctionCall(globalCtx),
+  ];
+}
+
+function createStepsForAndroidBuildWithoutCredentials({
+  globalCtx,
+  buildToolsContext,
+}: HelperFunctionsInput): BuildStep[] {
+  return [
+    createCheckoutBuildFunction().createBuildStepFromFunctionCall(globalCtx),
+    createInstallNodeModulesBuildFunction().createBuildStepFromFunctionCall(globalCtx),
+    createPrebuildBuildFunction().createBuildStepFromFunctionCall(globalCtx),
+    configureEASUpdateIfInstalledFunction().createBuildStepFromFunctionCall(globalCtx),
+    runGradleFunction().createBuildStepFromFunctionCall(globalCtx),
+    createFindAndUploadBuildArtifactsBuildFunction(
+      buildToolsContext
+    ).createBuildStepFromFunctionCall(globalCtx),
+  ];
+}
+
+function createStepsForAndroidBuildWithCredentials({
+  globalCtx,
+  buildToolsContext,
+}: HelperFunctionsInput): BuildStep[] {
+  return [
+    createCheckoutBuildFunction().createBuildStepFromFunctionCall(globalCtx),
+    createInstallNodeModulesBuildFunction().createBuildStepFromFunctionCall(globalCtx),
+    createGetCredentialsForBuildTriggeredByGithubIntegration(
+      buildToolsContext
+    ).createBuildStepFromFunctionCall(globalCtx),
+    createPrebuildBuildFunction().createBuildStepFromFunctionCall(globalCtx),
+    configureEASUpdateIfInstalledFunction().createBuildStepFromFunctionCall(globalCtx),
+    injectAndroidCredentialsFunction().createBuildStepFromFunctionCall(globalCtx),
+    configureAndroidVersionFunction().createBuildStepFromFunctionCall(globalCtx),
+    runGradleFunction().createBuildStepFromFunctionCall(globalCtx),
+    createFindAndUploadBuildArtifactsBuildFunction(
+      buildToolsContext
+    ).createBuildStepFromFunctionCall(globalCtx),
+  ];
+}

--- a/packages/build-tools/src/steps/functions/configureIosVersion.ts
+++ b/packages/build-tools/src/steps/functions/configureIosVersion.ts
@@ -64,6 +64,13 @@ export function configureIosVersionFunction(): BuildFunction {
         );
       }
 
+      if (!buildNumber && !appVersion) {
+        stepCtx.logger.info(
+          'No build number or app version provided. Skipping the step to configure iOS version.'
+        );
+        return;
+      }
+
       stepCtx.logger.info('Setting iOS version...');
       if (buildNumber) {
         stepCtx.logger.info(`Build number: ${buildNumber}`);

--- a/packages/build-tools/src/steps/functions/installPods.ts
+++ b/packages/build-tools/src/steps/functions/installPods.ts
@@ -1,0 +1,18 @@
+import { BuildFunction } from '@expo/steps';
+import spawn from '@expo/turtle-spawn';
+
+export function createInstallPodsBuildFunction(): BuildFunction {
+  return new BuildFunction({
+    namespace: 'eas',
+    id: 'install_pods',
+    name: 'Install Pods',
+    fn: async (stepsCtx, { env }) => {
+      stepsCtx.logger.info('Installing pods');
+      await spawn('pod', ['install'], {
+        stdio: 'pipe',
+        env,
+        cwd: stepsCtx.workingDirectory,
+      });
+    },
+  });
+}

--- a/packages/build-tools/src/steps/utils/expoUpdates.ts
+++ b/packages/build-tools/src/steps/utils/expoUpdates.ts
@@ -35,9 +35,8 @@ export async function configureEASUpdateIfInstalledAsync({
   const expoUpdatesPackageVersion =
     await getExpoUpdatesPackageVersionIfInstalledAsync(workingDirectory);
   if (expoUpdatesPackageVersion === null) {
-    throw new Error(
-      `Cannot configure Expo Updates because the expo-updates package is not installed.`
-    );
+    logger.info('Expo Updates is not installed, skipping configuring Expo Updates.');
+    return;
   }
 
   const runtimeVersion =

--- a/packages/steps/src/BuildConfig.ts
+++ b/packages/steps/src/BuildConfig.ts
@@ -7,7 +7,6 @@ import YAML from 'yaml';
 
 import { BuildConfigError, BuildWorkflowError } from './errors.js';
 import { BuildRuntimePlatform } from './BuildRuntimePlatform.js';
-import { BuildFunction } from './BuildFunction.js';
 import {
   BuildStepInputValueTypeWithRequired,
   BuildStepInputValueTypeName,
@@ -37,7 +36,7 @@ export type BuildStepConfig =
   | BuildStepCommandRun
   | BuildStepBareCommandRun
   | BuildStepFunctionCall
-  | BuildStepBareFunctionCall;
+  | BuildStepBareFunctionOrFunctionGroupCall;
 
 export type BuildStepCommandRun = {
   run: BuildFunctionCallConfig & {
@@ -49,7 +48,7 @@ export type BuildStepBareCommandRun = { run: string };
 export type BuildStepFunctionCall = {
   [functionId: string]: BuildFunctionCallConfig;
 };
-export type BuildStepBareFunctionCall = string;
+export type BuildStepBareFunctionOrFunctionGroupCall = string;
 
 export type BuildFunctionCallConfig = {
   id?: string;
@@ -269,7 +268,8 @@ export const BuildConfigSchema = BuildFunctionsConfigFileSchema.append<BuildConf
 
 interface BuildConfigValidationParams {
   externalFunctionIds?: string[];
-  skipNamespacedFunctionsCheck?: boolean;
+  externalFunctionGroupsIds?: string[];
+  skipNamespacedFunctionsOrFunctionGroupsCheck?: boolean;
 }
 
 export async function readAndValidateBuildConfigAsync(
@@ -410,42 +410,56 @@ export function isBuildStepFunctionCall(step: BuildStepConfig): step is BuildSte
   return Boolean(step) && typeof step === 'object' && !('run' in step);
 }
 
-export function isBuildStepBareFunctionCall(
+export function isBuildStepBareFunctionOrFunctionGroupCall(
   step: BuildStepConfig
-): step is BuildStepBareFunctionCall {
+): step is BuildStepBareFunctionOrFunctionGroupCall {
   return typeof step === 'string';
 }
 
 export function validateAllFunctionsExist(
   config: BuildConfig,
-  { externalFunctionIds = [], skipNamespacedFunctionsCheck }: BuildConfigValidationParams
+  {
+    externalFunctionIds = [],
+    externalFunctionGroupsIds = [],
+    skipNamespacedFunctionsOrFunctionGroupsCheck,
+  }: BuildConfigValidationParams
 ): void {
-  const calledFunctionsSet = new Set<string>();
+  const calledFunctionsOrFunctionGroupsSet = new Set<string>();
   for (const step of config.build.steps) {
     if (typeof step === 'string') {
-      calledFunctionsSet.add(step);
+      calledFunctionsOrFunctionGroupsSet.add(step);
     } else if (step !== null && !('run' in step)) {
       const keys = Object.keys(step);
       assert(
         keys.length === 1,
         'There must be at most one function call in the step (enforced by joi).'
       );
-      calledFunctionsSet.add(keys[0]);
+      calledFunctionsOrFunctionGroupsSet.add(keys[0]);
     }
   }
-  const calledFunctions = Array.from(calledFunctionsSet);
+  const calledFunctionsOrFunctionGroup = Array.from(calledFunctionsOrFunctionGroupsSet);
   const externalFunctionIdsSet = new Set(externalFunctionIds);
-  const nonExistentFunctions = calledFunctions.filter((calledFunction) => {
-    if (BuildFunction.isFulldIdNamespaced(calledFunction) && skipNamespacedFunctionsCheck) {
-      return false;
+  const externalFunctionGroupsIdsSet = new Set(externalFunctionGroupsIds);
+  const nonExistentFunctionsOrfunctionGroups = calledFunctionsOrFunctionGroup.filter(
+    (calledFunctionOrFunctionGroup) => {
+      if (
+        isFulldIdNamespaced(calledFunctionOrFunctionGroup) &&
+        skipNamespacedFunctionsOrFunctionGroupsCheck
+      ) {
+        return false;
+      }
+      return (
+        !(calledFunctionOrFunctionGroup in (config.functions ?? {})) &&
+        !externalFunctionIdsSet.has(calledFunctionOrFunctionGroup) &&
+        !externalFunctionGroupsIdsSet.has(calledFunctionOrFunctionGroup)
+      );
     }
-    return (
-      !(calledFunction in (config.functions ?? {})) && !externalFunctionIdsSet.has(calledFunction)
-    );
-  });
-  if (nonExistentFunctions.length > 0) {
+  );
+  if (nonExistentFunctionsOrfunctionGroups.length > 0) {
     throw new BuildConfigError(
-      `Calling non-existent functions: ${nonExistentFunctions.map((f) => `"${f}"`).join(', ')}.`
+      `Calling non-existent functions: ${nonExistentFunctionsOrfunctionGroups
+        .map((f) => `"${f}"`)
+        .join(', ')}.`
     );
   }
 }
@@ -455,4 +469,8 @@ function maybeResolveCustomFunctionRelativePath(dir: string, customFunctionPath:
     return path.resolve(dir, customFunctionPath);
   }
   return customFunctionPath;
+}
+
+function isFulldIdNamespaced(fullId: string): boolean {
+  return fullId.includes('/');
 }

--- a/packages/steps/src/BuildFunction.ts
+++ b/packages/steps/src/BuildFunction.ts
@@ -23,10 +23,6 @@ export class BuildFunction {
   public readonly fn?: BuildStepFunction;
   public readonly shell?: string;
 
-  public static isFulldIdNamespaced(fullId: string): boolean {
-    return fullId.includes('/');
-  }
-
   constructor({
     namespace,
     id,

--- a/packages/steps/src/BuildFunctionGroup.ts
+++ b/packages/steps/src/BuildFunctionGroup.ts
@@ -1,0 +1,46 @@
+import { BuildStep } from './BuildStep.js';
+import { BuildStepGlobalContext } from './BuildStepContext.js';
+import { BuildConfigError } from './errors.js';
+
+export type BuildFunctionGroupById = Record<string, BuildFunctionGroup | undefined>;
+
+export class BuildFunctionGroup {
+  public readonly namespace: string;
+  public readonly id: string;
+  public readonly createBuildStepsFromFunctionGroupCall: (
+    globalCtx: BuildStepGlobalContext
+  ) => BuildStep[];
+
+  constructor({
+    namespace,
+    id,
+    createBuildStepsFromFunctionGroupCall,
+  }: {
+    namespace: string;
+    id: string;
+    createBuildStepsFromFunctionGroupCall: (globalCtx: BuildStepGlobalContext) => BuildStep[];
+  }) {
+    this.namespace = namespace;
+    this.id = id;
+    this.createBuildStepsFromFunctionGroupCall = createBuildStepsFromFunctionGroupCall;
+  }
+
+  public getFullId(): string {
+    return this.namespace === undefined ? this.id : `${this.namespace}/${this.id}`;
+  }
+}
+
+export function createBuildFunctionGroupByIdMapping(
+  buildFunctionGroups: BuildFunctionGroup[]
+): BuildFunctionGroupById {
+  const buildFunctionGroupById: BuildFunctionGroupById = {};
+  for (const buildFunctionGroup of buildFunctionGroups) {
+    if (buildFunctionGroupById[buildFunctionGroup.getFullId()] !== undefined) {
+      throw new BuildConfigError(
+        `Build function group with id ${buildFunctionGroup.getFullId()} is already defined.`
+      );
+    }
+    buildFunctionGroupById[buildFunctionGroup.getFullId()] = buildFunctionGroup;
+  }
+  return buildFunctionGroupById;
+}

--- a/packages/steps/src/__tests__/BuildConfig-test.ts
+++ b/packages/steps/src/__tests__/BuildConfig-test.ts
@@ -4,11 +4,11 @@ import url from 'url';
 
 import {
   BuildStepBareCommandRun,
-  BuildStepBareFunctionCall,
+  BuildStepBareFunctionOrFunctionGroupCall,
   BuildStepCommandRun,
   BuildStepFunctionCall,
   isBuildStepBareCommandRun,
-  isBuildStepBareFunctionCall,
+  isBuildStepBareFunctionOrFunctionGroupCall,
   isBuildStepCommandRun,
   isBuildStepFunctionCall,
   readRawBuildConfigAsync,
@@ -64,7 +64,7 @@ describe(readAndValidateBuildConfigAsync, () => {
         },
       },
     });
-    assert(isBuildStepBareFunctionCall(config.build.steps[1]));
+    assert(isBuildStepBareFunctionOrFunctionGroupCall(config.build.steps[1]));
     expect(config.build.steps[1]).toBe('say_hi_wojtek');
     expect(config.functions?.say_hi).toBeDefined();
     expect(config.functions?.say_hi_wojtek).toBeDefined();
@@ -964,7 +964,7 @@ describe(validateAllFunctionsExist, () => {
     expect(() => {
       validateAllFunctionsExist(buildConfig, {
         externalFunctionIds: [],
-        skipNamespacedFunctionsCheck: false,
+        skipNamespacedFunctionsOrFunctionGroupsCheck: false,
       });
     }).toThrowError(/Calling non-existent functions: "abc\/say_hi", "abc\/say_hello"/);
   });
@@ -978,7 +978,7 @@ describe(validateAllFunctionsExist, () => {
     expect(() => {
       validateAllFunctionsExist(buildConfig, {
         externalFunctionIds: [],
-        skipNamespacedFunctionsCheck: true,
+        skipNamespacedFunctionsOrFunctionGroupsCheck: true,
       });
     }).not.toThrow();
   });
@@ -1015,7 +1015,7 @@ const buildStepFunctionCall: BuildStepFunctionCall = {
   },
 };
 
-const buildStepBareFunctionCall: BuildStepBareFunctionCall = 'say_hi';
+const buildStepBareFunctionCall: BuildStepBareFunctionOrFunctionGroupCall = 'say_hi';
 
 describe(isBuildStepCommandRun, () => {
   it.each([buildStepBareCommandRun, buildStepFunctionCall, buildStepBareFunctionCall])(
@@ -1053,14 +1053,14 @@ describe(isBuildStepFunctionCall, () => {
   });
 });
 
-describe(isBuildStepBareFunctionCall, () => {
+describe(isBuildStepBareFunctionOrFunctionGroupCall, () => {
   it.each([buildStepCommandRun, buildStepBareCommandRun, buildStepFunctionCall])(
     'returns false',
     (i) => {
-      expect(isBuildStepBareFunctionCall(i)).toBe(false);
+      expect(isBuildStepBareFunctionOrFunctionGroupCall(i)).toBe(false);
     }
   );
   it('returns true', () => {
-    expect(isBuildStepBareFunctionCall(buildStepBareFunctionCall)).toBe(true);
+    expect(isBuildStepBareFunctionOrFunctionGroupCall(buildStepBareFunctionCall)).toBe(true);
   });
 });

--- a/packages/steps/src/index.ts
+++ b/packages/steps/src/index.ts
@@ -8,4 +8,6 @@ export { BuildStepOutput } from './BuildStepOutput.js';
 export { BuildStepGlobalContext, ExternalBuildContextProvider } from './BuildStepContext.js';
 export { BuildWorkflow } from './BuildWorkflow.js';
 export { BuildStepEnv } from './BuildStepEnv.js';
+export { BuildFunctionGroup } from './BuildFunctionGroup.js';
+export { BuildStep } from './BuildStep.js';
 export * as errors from './errors.js';


### PR DESCRIPTION
# Why

We want to add a concept called functions group to custom builds, so it is easier for users to just run our build process if they don't want to interfere with it but instead do some stuff after/before the build process.

# How

Add `eas/build` function group. This function group spawns build steps based on `eas` namespace functions required to complete the build in all needed configurations.

Usage:
```yml
build:
  name: test eas/build function group
  steps:
    - run: echo "Hello, world!"
    - eas/build
    - run: echo "Bye, world!"
```
Will do:
1. echo "Hello, world!"
2. checkout
3. install `node_modules`
...
n. upload artifacts
n+1. echo "Bye, world!"

# Test Plan

![image](https://github.com/expo/eas-build/assets/55145344/88c9a90f-46c2-4b99-a5b6-f280f433ead7)
![image](https://github.com/expo/eas-build/assets/55145344/a7e325d9-a5c0-450f-8599-5ea70d20f668)

TBA Automatic tests


