### PR TITLE
Put temporary directories in `os.tmpdir`

### DIFF
--- a/packages/build-tools/src/steps/functions/installMaestro.ts
+++ b/packages/build-tools/src/steps/functions/installMaestro.ts
@@ -1,7 +1,8 @@
 import assert from 'assert';
+import fs from 'fs';
+import os from 'os';
 import path from 'path';
 
-import fs from 'fs-extra';
 import {
   BuildFunction,
   BuildRuntimePlatform,
@@ -129,12 +130,12 @@ async function installMaestro({
   env: BuildStepEnv;
 }): Promise<void> {
   logger.info('Fetching install script');
-  const tempDirectory = await fs.mkdtemp('install_maestro');
+  const tempDirectory = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'install_maestro'));
   try {
     const installMaestroScriptResponse = await fetch('https://get.maestro.mobile.dev');
     const installMaestroScript = await installMaestroScriptResponse.text();
     const installMaestroScriptFilePath = path.join(tempDirectory, 'install_maestro.sh');
-    await fs.writeFile(installMaestroScriptFilePath, installMaestroScript, {
+    await fs.promises.writeFile(installMaestroScriptFilePath, installMaestroScript, {
       mode: 0o777,
     });
     logger.info('Installing Maestro');
@@ -161,7 +162,7 @@ async function installMaestro({
     env.PATH = `${env.PATH}:${maestroBinDir}`;
     process.env.PATH = `${process.env.PATH}:${maestroBinDir}`;
   } finally {
-    await fs.remove(tempDirectory);
+    await fs.promises.rm(tempDirectory, { force: true, recursive: true });
   }
 }
 
@@ -222,7 +223,7 @@ async function installJavaFromGcs({
   const downloadUrl =
     'https://storage.googleapis.com/turtle-v2/zulu11.68.17-ca-jdk11.0.21-macosx_aarch64.dmg';
   const filename = path.basename(downloadUrl);
-  const tempDirectory = await fs.mkdtemp('install_java');
+  const tempDirectory = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'install_java'));
   const installerPath = path.join(tempDirectory, filename);
   const installerMountDirectory = path.join(tempDirectory, 'mountpoint');
   try {
@@ -230,7 +231,7 @@ async function installJavaFromGcs({
     // This is simpler than piping body into a write stream with node-fetch.
     await spawn('curl', ['--output', installerPath, downloadUrl], { env });
 
-    await fs.mkdir(installerMountDirectory);
+    await fs.promises.mkdir(installerMountDirectory);
     logger.info('Mounting Java installer');
     await spawn(
       'hdiutil',
@@ -256,6 +257,6 @@ async function installJavaFromGcs({
       await spawn('hdiutil', ['detach', installerMountDirectory], { env });
     } catch {}
 
-    await fs.remove(tempDirectory);
+    await fs.promises.rm(tempDirectory, { force: true, recursive: true });
   }
 }


### PR DESCRIPTION
# Why

Turns out `fs.mkdtemp('install_maestro')` can [suddenly throw `EACCESS`](https://expo.dev/accounts/exponent/projects/eas-custom-builds-example/builds/59f6ccf3-a209-4c7d-b0dd-ab494fb62c04).

# How

Replaced `fs.mkdtemp('string')` with `fs.mkdtemp(path.join(os.tmpdir(), 'string'))`. This is what Node.js documentation suggests to do and also what we do in `www`.


# Test Plan

I verified this works right now on both [Android](https://expo.dev/accounts/exponent/projects/eas-custom-builds-example/builds/7ca68836-63ef-45bc-8ebf-207c827257e2) and [iOS](https://expo.dev/accounts/exponent/projects/eas-custom-builds-example/builds/97f592fa-24b9-4b73-bae4-f88379cf4b65) builds by copying `installMaestro` function into `my-custom-ts-function` and triggering builds manually. Both passed the "Install Maestro" step.