### PR TITLE
[eas-build-job] [ENG-11196] Add optional buildExpoUrl field to Job

### DIFF
--- a/packages/eas-build-job/src/__tests__/android.test.ts
+++ b/packages/eas-build-job/src/__tests__/android.test.ts
@@ -44,7 +44,7 @@ describe('Android.JobSchema', () => {
           SOME_ENV: '123',
         },
       },
-      buildExpoUrl: 'https://expo.dev/fake/build/url',
+      expoBuildUrl: 'https://expo.dev/fake/build/url',
     };
 
     const { value, error } = Android.JobSchema.validate(genericJob, joiOptions);

--- a/packages/eas-build-job/src/__tests__/android.test.ts
+++ b/packages/eas-build-job/src/__tests__/android.test.ts
@@ -44,6 +44,7 @@ describe('Android.JobSchema', () => {
           SOME_ENV: '123',
         },
       },
+      buildExpoUrl: 'https://expo.dev/fake/build/url',
     };
 
     const { value, error } = Android.JobSchema.validate(genericJob, joiOptions);

--- a/packages/eas-build-job/src/__tests__/ios.test.ts
+++ b/packages/eas-build-job/src/__tests__/ios.test.ts
@@ -46,7 +46,7 @@ describe('Ios.JobSchema', () => {
           ENV_VAR: '123',
         },
       },
-      buildExpoUrl: 'https://expo.dev/fake/build/url',
+      expoBuildUrl: 'https://expo.dev/fake/build/url',
     };
 
     const { value, error } = Ios.JobSchema.validate(genericJob, joiOptions);

--- a/packages/eas-build-job/src/__tests__/ios.test.ts
+++ b/packages/eas-build-job/src/__tests__/ios.test.ts
@@ -46,6 +46,7 @@ describe('Ios.JobSchema', () => {
           ENV_VAR: '123',
         },
       },
+      buildExpoUrl: 'https://expo.dev/fake/build/url',
     };
 
     const { value, error } = Ios.JobSchema.validate(genericJob, joiOptions);

--- a/packages/eas-build-job/src/android.ts
+++ b/packages/eas-build-job/src/android.ts
@@ -106,6 +106,7 @@ export interface Job {
   experimental?: {
     prebuildCommand?: string;
   };
+  buildExpoUrl?: string;
 }
 
 const SecretsSchema = Joi.object({
@@ -164,4 +165,5 @@ export const JobSchema = Joi.object({
   experimental: Joi.object({
     prebuildCommand: Joi.string(),
   }),
+  buildExpoUrl: Joi.string().uri().optional(),
 }).oxor('releaseChannel', 'updates.channel');

--- a/packages/eas-build-job/src/android.ts
+++ b/packages/eas-build-job/src/android.ts
@@ -106,7 +106,7 @@ export interface Job {
   experimental?: {
     prebuildCommand?: string;
   };
-  buildExpoUrl?: string;
+  expoBuildUrl?: string;
 }
 
 const SecretsSchema = Joi.object({
@@ -165,5 +165,5 @@ export const JobSchema = Joi.object({
   experimental: Joi.object({
     prebuildCommand: Joi.string(),
   }),
-  buildExpoUrl: Joi.string().uri().optional(),
+  expoBuildUrl: Joi.string().uri().optional(),
 }).oxor('releaseChannel', 'updates.channel');

--- a/packages/eas-build-job/src/ios.ts
+++ b/packages/eas-build-job/src/ios.ts
@@ -120,6 +120,7 @@ export interface Job {
   experimental?: {
     prebuildCommand?: string;
   };
+  buildExpoUrl?: string;
 }
 
 const SecretsSchema = Joi.object({
@@ -200,4 +201,5 @@ export const JobSchema = Joi.object({
   experimental: Joi.object({
     prebuildCommand: Joi.string(),
   }),
+  buildExpoUrl: Joi.string().uri().optional(),
 }).oxor('releaseChannel', 'updates.channel');

--- a/packages/eas-build-job/src/ios.ts
+++ b/packages/eas-build-job/src/ios.ts
@@ -120,7 +120,7 @@ export interface Job {
   experimental?: {
     prebuildCommand?: string;
   };
-  buildExpoUrl?: string;
+  expoBuildUrl?: string;
 }
 
 const SecretsSchema = Joi.object({
@@ -201,5 +201,5 @@ export const JobSchema = Joi.object({
   experimental: Joi.object({
     prebuildCommand: Joi.string(),
   }),
-  buildExpoUrl: Joi.string().uri().optional(),
+  expoBuildUrl: Joi.string().uri().optional(),
 }).oxor('releaseChannel', 'updates.channel');


### PR DESCRIPTION
# Why

https://linear.app/expo/issue/ENG-11196/create-custom-build-example-slacking-team-members
We want to allow the user to customise their Slack messages in custom builds with build details. One of those should be the link to the build, which we don't want to be build step specific, since the same url will be valid and constant for all build steps. In such a case, the build link has been added as a new field to the Job object, and will be set either by cli or www before the build starts

# How

Added new field to the Job object and to schema validator

# Test Plan

Updated automated tests