### PR TITLE
Add type to `staticContext`

### DIFF
--- a/packages/build-tools/src/customBuildContext.ts
+++ b/packages/build-tools/src/customBuildContext.ts
@@ -1,6 +1,14 @@
 import path from 'path';
 
-import { BuildPhase, BuildTrigger, Env, Job, Metadata, Platform } from '@expo/eas-build-job';
+import {
+  BuildPhase,
+  BuildStaticContext,
+  BuildTrigger,
+  Env,
+  Job,
+  Metadata,
+  Platform,
+} from '@expo/eas-build-job';
 import { bunyan } from '@expo/logger';
 import { ExternalBuildContextProvider, BuildRuntimePlatform } from '@expo/steps';
 
@@ -66,10 +74,10 @@ export class CustomBuildContext implements ExternalBuildContextProvider {
     return this._env;
   }
 
-  public staticContext(): any {
+  public staticContext(): BuildStaticContext {
     return {
       job: this.job,
-      metadata: this.metadata,
+      metadata: this.metadata ?? null,
       env: this.env,
     };
   }

--- a/packages/build-tools/src/steps/functions/configureEASUpdateIfInstalled.ts
+++ b/packages/build-tools/src/steps/functions/configureEASUpdateIfInstalled.ts
@@ -1,7 +1,7 @@
 import assert from 'assert';
 
 import { BuildFunction, BuildStepInput, BuildStepInputValueTypeName } from '@expo/steps';
-import { Job, Metadata } from '@expo/eas-build-job';
+import { Metadata } from '@expo/eas-build-job';
 import semver from 'semver';
 
 import { configureEASUpdateAsync } from '../utils/expoUpdates';
@@ -33,7 +33,7 @@ export function configureEASUpdateIfInstalledFunction(): BuildFunction {
     ],
     fn: async (stepCtx, { env, inputs }) => {
       assert(stepCtx.global.staticContext.job, 'Job is not defined');
-      const job = stepCtx.global.staticContext.job as Job;
+      const job = stepCtx.global.staticContext.job;
       const metadata = stepCtx.global.staticContext.metadata as Metadata | undefined;
 
       const appConfig = readAppConfig({

--- a/packages/build-tools/src/steps/functions/prebuild.ts
+++ b/packages/build-tools/src/steps/functions/prebuild.ts
@@ -37,7 +37,7 @@ export function createPrebuildBuildFunction(): BuildFunction {
       const packageManager = resolvePackageManager(stepCtx.global.projectTargetDirectory);
 
       assert(stepCtx.global.staticContext.job, 'Job is not defined');
-      const job = stepCtx.global.staticContext.job as Job;
+      const job = stepCtx.global.staticContext.job;
       const prebuildCommandArgs = getPrebuildCommandArgs(job, {
         clean: inputs.clean.value as boolean,
       });

--- a/packages/build-tools/src/steps/functions/runGradle.ts
+++ b/packages/build-tools/src/steps/functions/runGradle.ts
@@ -1,6 +1,7 @@
 import path from 'path';
 import assert from 'assert';
 
+import { Platform } from '@expo/eas-build-job';
 import { BuildFunction, BuildStepInput, BuildStepInputValueTypeName } from '@expo/steps';
 
 import { resolveGradleCommand, runGradleCommand } from '../utils/android/gradle';
@@ -19,6 +20,10 @@ export function runGradleFunction(): BuildFunction {
     ],
     fn: async (stepCtx, { env, inputs }) => {
       assert(stepCtx.global.staticContext.job, 'Job is required');
+      assert(
+        stepCtx.global.staticContext.job.platform === Platform.ANDROID,
+        'This function is only available when building for Android'
+      );
       const command = resolveGradleCommand(
         stepCtx.global.staticContext.job,
         inputs.command.value as string | undefined

--- a/packages/eas-build-job/src/context.ts
+++ b/packages/eas-build-job/src/context.ts
@@ -1,0 +1,9 @@
+import { Env } from './common';
+import { Job } from './job';
+import { Metadata } from './metadata';
+
+export type BuildStaticContext<TJob extends Job = Job> = {
+  job: TJob;
+  metadata: Metadata | null;
+  env: Env;
+};

--- a/packages/eas-build-job/src/context.ts
+++ b/packages/eas-build-job/src/context.ts
@@ -2,8 +2,8 @@ import { Env } from './common';
 import { Job } from './job';
 import { Metadata } from './metadata';
 
-export type BuildStaticContext<TJob extends Job = Job> = {
-  job: TJob;
+export type BuildStaticContext = {
+  job: Job;
   metadata: Metadata | null;
   env: Env;
 };

--- a/packages/eas-build-job/src/index.ts
+++ b/packages/eas-build-job/src/index.ts
@@ -18,3 +18,4 @@ export { Metadata, sanitizeMetadata } from './metadata';
 export * from './logs';
 export * as errors from './errors';
 export * from './artifacts';
+export * from './context';

--- a/packages/steps/src/BuildStep.ts
+++ b/packages/steps/src/BuildStep.ts
@@ -43,8 +43,8 @@ export enum BuildStepLogMarker {
   END_STEP = 'end-step',
 }
 
-export type BuildStepFunction = (
-  ctx: BuildStepContext,
+export type BuildStepFunction<TStaticContext> = (
+  ctx: BuildStepContext<TStaticContext>,
   {
     inputs,
     outputs,
@@ -116,7 +116,7 @@ export class BuildStepOutputAccessor {
   }
 }
 
-export class BuildStep extends BuildStepOutputAccessor {
+export class BuildStep<TStaticContext> extends BuildStepOutputAccessor {
   public readonly id: string;
   public readonly name?: string;
   public readonly displayName: string;
@@ -124,9 +124,9 @@ export class BuildStep extends BuildStepOutputAccessor {
   public readonly inputs?: BuildStepInput[];
   public readonly outputs?: BuildStepOutput[];
   public readonly command?: string;
-  public readonly fn?: BuildStepFunction;
+  public readonly fn?: BuildStepFunction<TStaticContext>;
   public readonly shell: string;
-  public readonly ctx: BuildStepContext;
+  public readonly ctx: BuildStepContext<TStaticContext>;
   public readonly env: BuildStepEnv;
   public readonly ifCondition?: string;
   public status: BuildStepStatus;
@@ -168,7 +168,7 @@ export class BuildStep extends BuildStepOutputAccessor {
   }
 
   constructor(
-    ctx: BuildStepGlobalContext,
+    ctx: BuildStepGlobalContext<TStaticContext>,
     {
       id,
       name,
@@ -189,7 +189,7 @@ export class BuildStep extends BuildStepOutputAccessor {
       inputs?: BuildStepInput[];
       outputs?: BuildStepOutput[];
       command?: string;
-      fn?: BuildStepFunction;
+      fn?: BuildStepFunction<TStaticContext>;
       workingDirectory?: string;
       shell?: string;
       supportedRuntimePlatforms?: BuildRuntimePlatform[];

--- a/packages/steps/src/BuildStep.ts
+++ b/packages/steps/src/BuildStep.ts
@@ -43,8 +43,8 @@ export enum BuildStepLogMarker {
   END_STEP = 'end-step',
 }
 
-export type BuildStepFunction<TStaticContext> = (
-  ctx: BuildStepContext<TStaticContext>,
+export type BuildStepFunction = (
+  ctx: BuildStepContext,
   {
     inputs,
     outputs,
@@ -116,7 +116,7 @@ export class BuildStepOutputAccessor {
   }
 }
 
-export class BuildStep<TStaticContext> extends BuildStepOutputAccessor {
+export class BuildStep extends BuildStepOutputAccessor {
   public readonly id: string;
   public readonly name?: string;
   public readonly displayName: string;
@@ -124,9 +124,9 @@ export class BuildStep<TStaticContext> extends BuildStepOutputAccessor {
   public readonly inputs?: BuildStepInput[];
   public readonly outputs?: BuildStepOutput[];
   public readonly command?: string;
-  public readonly fn?: BuildStepFunction<TStaticContext>;
+  public readonly fn?: BuildStepFunction;
   public readonly shell: string;
-  public readonly ctx: BuildStepContext<TStaticContext>;
+  public readonly ctx: BuildStepContext;
   public readonly env: BuildStepEnv;
   public readonly ifCondition?: string;
   public status: BuildStepStatus;
@@ -168,7 +168,7 @@ export class BuildStep<TStaticContext> extends BuildStepOutputAccessor {
   }
 
   constructor(
-    ctx: BuildStepGlobalContext<TStaticContext>,
+    ctx: BuildStepGlobalContext,
     {
       id,
       name,
@@ -189,7 +189,7 @@ export class BuildStep<TStaticContext> extends BuildStepOutputAccessor {
       inputs?: BuildStepInput[];
       outputs?: BuildStepOutput[];
       command?: string;
-      fn?: BuildStepFunction<TStaticContext>;
+      fn?: BuildStepFunction;
       workingDirectory?: string;
       shell?: string;
       supportedRuntimePlatforms?: BuildRuntimePlatform[];

--- a/packages/steps/src/__tests__/BuildStepContext-test.ts
+++ b/packages/steps/src/__tests__/BuildStepContext-test.ts
@@ -1,5 +1,6 @@
 import os from 'os';
 
+import { BuildStaticContext } from '@expo/eas-build-job';
 import { instance, mock, when } from 'ts-mockito';
 
 import { BuildStep } from '../BuildStep.js';
@@ -21,7 +22,8 @@ describe(BuildStepGlobalContext, () => {
           '/non/existent/path',
           '/another/non/existent/path',
           '/working/dir/path',
-          '/non/existent/path'
+          '/non/existent/path',
+          {} as unknown as BuildStaticContext
         ),
         false
       );
@@ -39,7 +41,8 @@ describe(BuildStepGlobalContext, () => {
           '/non/existent/path',
           projectTargetDirectory,
           workingDirectory,
-          '/non/existent/path'
+          '/non/existent/path',
+          {} as unknown as BuildStaticContext
         ),
         false
       );
@@ -56,7 +59,8 @@ describe(BuildStepGlobalContext, () => {
           '/non/existent/path',
           projectTargetDirectory,
           workingDirectory,
-          '/non/existent/path'
+          '/non/existent/path',
+          {} as unknown as BuildStaticContext
         ),
         false
       );
@@ -78,7 +82,7 @@ describe(BuildStepGlobalContext, () => {
         projectSourceDirectory: '/a/b/c',
         projectTargetDirectory: '/d/e/f',
         relativeWorkingDirectory: 'i',
-        staticContextContent: { a: 1 },
+        staticContextContent: { a: 1 } as unknown as BuildStaticContext,
       });
       expect(ctx.serialize()).toEqual(
         expect.objectContaining({
@@ -110,7 +114,7 @@ describe(BuildStepGlobalContext, () => {
             defaultWorkingDirectory: '/g/h/i',
             buildLogsDirectory: '/j/k/l',
             runtimePlatform: BuildRuntimePlatform.DARWIN,
-            staticContext: { a: 1 },
+            staticContext: { a: 1 } as unknown as BuildStaticContext,
             env: {},
           },
           skipCleanup: true,

--- a/packages/steps/src/__tests__/BuildStepInput-test.ts
+++ b/packages/steps/src/__tests__/BuildStepInput-test.ts
@@ -1,3 +1,5 @@
+import { BuildStaticContext } from '@expo/eas-build-job';
+
 import { BuildStepRuntimeError } from '../errors.js';
 import { BuildStep } from '../BuildStep.js';
 import {
@@ -131,7 +133,7 @@ describe(BuildStepInput, () => {
             },
           ],
         },
-      },
+      } as unknown as BuildStaticContext,
     });
     const i = new BuildStepInput<BuildStepInputValueTypeName>(ctx, {
       id: 'foo',
@@ -158,7 +160,7 @@ describe(BuildStepInput, () => {
             },
           ],
         },
-      },
+      } as unknown as BuildStaticContext,
     });
     const i = new BuildStepInput<BuildStepInputValueTypeName>(ctx, {
       id: 'foo',
@@ -185,7 +187,7 @@ describe(BuildStepInput, () => {
             },
           ],
         },
-      },
+      } as unknown as BuildStaticContext,
     });
     const i = new BuildStepInput<BuildStepInputValueTypeName>(ctx, {
       id: 'foo',
@@ -212,7 +214,7 @@ describe(BuildStepInput, () => {
             },
           ],
         },
-      },
+      } as unknown as BuildStaticContext,
     });
     const i = new BuildStepInput<BuildStepInputValueTypeName>(ctx, {
       id: 'foo',
@@ -241,7 +243,7 @@ describe(BuildStepInput, () => {
             },
           ],
         },
-      },
+      } as unknown as BuildStaticContext,
     });
     const i = new BuildStepInput<BuildStepInputValueTypeName>(ctx, {
       id: 'foo',
@@ -270,7 +272,7 @@ describe(BuildStepInput, () => {
             },
           ],
         },
-      },
+      } as unknown as BuildStaticContext,
     });
     const i = new BuildStepInput<BuildStepInputValueTypeName>(ctx, {
       id: 'foo',

--- a/packages/steps/src/__tests__/utils/context.ts
+++ b/packages/steps/src/__tests__/utils/context.ts
@@ -1,6 +1,7 @@
 import os from 'os';
 import path from 'path';
 
+import { BuildStaticContext } from '@expo/eas-build-job';
 import { bunyan } from '@expo/logger';
 import { v4 as uuidv4 } from 'uuid';
 
@@ -14,9 +15,7 @@ import { BuildStepEnv } from '../../BuildStepEnv.js';
 
 import { createMockLogger } from './logger.js';
 
-export class MockContextProvider<TStaticContext>
-  implements ExternalBuildContextProvider<TStaticContext>
-{
+export class MockContextProvider implements ExternalBuildContextProvider {
   private _env: BuildStepEnv = {};
 
   constructor(
@@ -26,12 +25,12 @@ export class MockContextProvider<TStaticContext>
     public readonly projectTargetDirectory: string,
     public readonly defaultWorkingDirectory: string,
     public readonly buildLogsDirectory: string,
-    public readonly staticContextContent: TStaticContext
+    public readonly staticContextContent: BuildStaticContext
   ) {}
   public get env(): BuildStepEnv {
     return this._env;
   }
-  public staticContext(): TStaticContext {
+  public staticContext(): BuildStaticContext {
     return { ...this.staticContextContent };
   }
   public updateEnv(env: BuildStepEnv): void {
@@ -39,7 +38,7 @@ export class MockContextProvider<TStaticContext>
   }
 }
 
-interface BuildContextParams<TStaticContext> {
+interface BuildContextParams {
   buildId?: string;
   logger?: bunyan;
   skipCleanup?: boolean;
@@ -47,10 +46,10 @@ interface BuildContextParams<TStaticContext> {
   projectSourceDirectory?: string;
   projectTargetDirectory?: string;
   relativeWorkingDirectory?: string;
-  staticContextContent?: TStaticContext;
+  staticContextContent?: BuildStaticContext;
 }
 
-export function createStepContextMock<TStaticContext>({
+export function createStepContextMock({
   buildId,
   logger,
   skipCleanup,
@@ -59,7 +58,7 @@ export function createStepContextMock<TStaticContext>({
   projectTargetDirectory,
   relativeWorkingDirectory,
   staticContextContent,
-}: BuildContextParams<TStaticContext> = {}): BuildStepContext<TStaticContext> {
+}: BuildContextParams = {}): BuildStepContext {
   const globalCtx = createGlobalContextMock({
     buildId,
     logger,
@@ -76,7 +75,7 @@ export function createStepContextMock<TStaticContext>({
   });
 }
 
-export function createGlobalContextMock<TStaticContext>({
+export function createGlobalContextMock({
   logger,
   skipCleanup,
   runtimePlatform,
@@ -84,11 +83,11 @@ export function createGlobalContextMock<TStaticContext>({
   projectTargetDirectory,
   relativeWorkingDirectory,
   staticContextContent,
-}: BuildContextParams<TStaticContext> = {}): BuildStepGlobalContext<TStaticContext> {
+}: BuildContextParams = {}): BuildStepGlobalContext {
   const resolvedProjectTargetDirectory =
     projectTargetDirectory ?? path.join(os.tmpdir(), 'eas-build', uuidv4());
-  return new BuildStepGlobalContext<TStaticContext>(
-    new MockContextProvider<TStaticContext>(
+  return new BuildStepGlobalContext(
+    new MockContextProvider(
       logger ?? createMockLogger(),
       runtimePlatform ?? BuildRuntimePlatform.LINUX,
       projectSourceDirectory ?? '/non/existent/dir',
@@ -97,7 +96,7 @@ export function createGlobalContextMock<TStaticContext>({
         ? path.resolve(resolvedProjectTargetDirectory, relativeWorkingDirectory)
         : resolvedProjectTargetDirectory,
       '/non/existent/dir',
-      staticContextContent ?? ({} as TStaticContext)
+      staticContextContent ?? ({} as BuildStaticContext)
     ),
     skipCleanup ?? false
   );

--- a/packages/steps/src/cli/cli.ts
+++ b/packages/steps/src/cli/cli.ts
@@ -1,5 +1,6 @@
 import path from 'path';
 
+import { BuildStaticContext, Env, Job, Metadata } from '@expo/eas-build-job';
 import { bunyan, createLogger } from '@expo/logger';
 
 import { BuildConfigParser } from '../BuildConfigParser.js';
@@ -27,8 +28,12 @@ export class CliContextProvider implements ExternalBuildContextProvider {
   public get env(): BuildStepEnv {
     return this._env;
   }
-  public staticContext(): any {
-    return {};
+  public staticContext(): BuildStaticContext {
+    return {
+      job: {} as Job,
+      metadata: {} as Metadata,
+      env: this.env as Env,
+    };
   }
   public updateEnv(env: BuildStepEnv): void {
     this._env = env;

--- a/packages/steps/src/scripts/runCustomFunction.ts
+++ b/packages/steps/src/scripts/runCustomFunction.ts
@@ -82,7 +82,7 @@ async function runCustomJsFunctionAsync(): Promise<void> {
   const env = serializedFunctionArguments.env;
   const envBefore = cloneDeep(serializedFunctionArguments.env);
 
-  let customModule: any;
+  let customModule: { default: BuildStepFunction };
   try {
     customModule = await require(customJavascriptFunctionModulePath);
   } catch (e) {
@@ -90,7 +90,7 @@ async function runCustomJsFunctionAsync(): Promise<void> {
     throw e;
   }
 
-  const customJavascriptFunction: BuildStepFunction = customModule.default;
+  const customJavascriptFunction = customModule.default;
 
   await customJavascriptFunction(ctx, { inputs, outputs, env });
 

--- a/packages/steps/src/utils/expodash/duplicates.ts
+++ b/packages/steps/src/utils/expodash/duplicates.ts
@@ -1,4 +1,4 @@
-export function duplicates<T = any>(items: T[]): T[] {
+export function duplicates<T>(items: T[]): T[] {
   const visitedItemsSet = new Set<T>();
   const duplicatedItemsSet = new Set<T>();
   for (const item of items) {

--- a/packages/steps/src/utils/expodash/uniq.ts
+++ b/packages/steps/src/utils/expodash/uniq.ts
@@ -1,4 +1,4 @@
-export function uniq<T = any>(items: T[]): T[] {
+export function uniq<T>(items: T[]): T[] {
   const set = new Set(items);
   return [...set];
 }

--- a/packages/steps/src/utils/template.ts
+++ b/packages/steps/src/utils/template.ts
@@ -45,7 +45,7 @@ export function getSelectedStatusCheckFromIfStatementTemplate(
 
 export function getObjectValueForInterpolation(
   path: string,
-  obj: Record<string, any>
+  obj: Record<string, unknown>
 ): string | number | boolean | null {
   const value = get(obj, path);
 
@@ -96,7 +96,7 @@ function interpolate(
 }
 
 function isAllowedValueTypeForObjectInterpolation(
-  value: any
+  value: unknown
 ): value is string | number | boolean | object | null {
   return (
     typeof value === 'string' ||


### PR DESCRIPTION
# Why

We want to let users depend on `staticContext` properties.

# How

Added `BuildStaticContext` type and used it anywhere we reference `staticContext`.

I considered making everything generic with `TStaticContext` to better handle tests, but in the end decided to cast in tests `as unknown as BuildStaticContext`.

# Test Plan

This mostly changes types. Automated tests.