### PR TITLE
Add `eas/maestro_test` function group

### DIFF
--- a/packages/build-tools/src/steps/easFunctionGroups.ts
+++ b/packages/build-tools/src/steps/easFunctionGroups.ts
@@ -3,7 +3,8 @@ import { BuildFunctionGroup } from '@expo/steps';
 import { CustomBuildContext } from '../customBuildContext';
 
 import { createEasBuildBuildFunctionGroup } from './functionGroups/build';
+import { createEasMaestroTestFunctionGroup } from './functionGroups/maestroTest';
 
 export function getEasFunctionGroups(ctx: CustomBuildContext): BuildFunctionGroup[] {
-  return [createEasBuildBuildFunctionGroup(ctx)];
+  return [createEasBuildBuildFunctionGroup(ctx), createEasMaestroTestFunctionGroup(ctx)];
 }

--- a/packages/build-tools/src/steps/functionGroups/maestroTest.ts
+++ b/packages/build-tools/src/steps/functionGroups/maestroTest.ts
@@ -1,0 +1,69 @@
+import {
+  BuildFunctionGroup,
+  BuildStep,
+  BuildStepInput,
+  BuildStepInputValueTypeName,
+} from '@expo/steps';
+import { Platform } from '@expo/eas-build-job';
+
+import { CustomBuildContext } from '../../customBuildContext';
+import { createInstallMaestroBuildFunction } from '../functions/installMaestro';
+import { createStartIosSimulatorBuildFunction } from '../functions/startIosSimulator';
+import { createStartAndroidEmulatorBuildFunction } from '../functions/startAndroidEmulator';
+
+export function createEasMaestroTestFunctionGroup(
+  buildToolsContext: CustomBuildContext
+): BuildFunctionGroup {
+  return new BuildFunctionGroup({
+    namespace: 'eas',
+    id: 'maestro_test',
+    inputProviders: [
+      BuildStepInput.createProvider({
+        allowedValueTypeName: BuildStepInputValueTypeName.STRING,
+        id: 'flow_file_path',
+        required: false,
+      }),
+    ],
+    createBuildStepsFromFunctionGroupCall: (globalCtx, { inputs }) => {
+      const steps: BuildStep[] = [
+        createInstallMaestroBuildFunction().createBuildStepFromFunctionCall(globalCtx),
+      ];
+
+      if (buildToolsContext.job.platform === Platform.IOS) {
+        steps.push(
+          createStartIosSimulatorBuildFunction().createBuildStepFromFunctionCall(globalCtx)
+        );
+      } else if (buildToolsContext.job.platform === Platform.ANDROID) {
+        steps.push(
+          createStartAndroidEmulatorBuildFunction().createBuildStepFromFunctionCall(globalCtx)
+        );
+      }
+
+      const flowFilePath = inputs.flow_file_path.value;
+      if (flowFilePath) {
+        steps.push(
+          new BuildStep(globalCtx, {
+            id: BuildStep.getNewId(),
+            name: 'maestro_test',
+            displayName: 'Run "maestro test"',
+            command: `maestro test ${inputs.flow_path.value}`,
+          })
+        );
+      } else {
+        steps.push(
+          new BuildStep(globalCtx, {
+            id: BuildStep.getNewId(),
+            name: 'maestro_test',
+            displayName: 'Run "maestro test"',
+            ifCondition: '${ never() }',
+            fn: (ctx) => {
+              ctx.logger.warn('flow_file_path not provided. Skipping running test.');
+            },
+          })
+        );
+      }
+
+      return steps;
+    },
+  });
+}

--- a/packages/build-tools/src/steps/functionGroups/maestroTest.ts
+++ b/packages/build-tools/src/steps/functionGroups/maestroTest.ts
@@ -21,8 +21,8 @@ export function createEasMaestroTestFunctionGroup(
     inputProviders: [
       BuildStepInput.createProvider({
         allowedValueTypeName: BuildStepInputValueTypeName.STRING,
-        id: 'flow_file_path',
-        required: false,
+        id: 'flow_path',
+        required: true,
       }),
     ],
     createBuildStepsFromFunctionGroupCall: (globalCtx, { inputs }) => {
@@ -40,34 +40,17 @@ export function createEasMaestroTestFunctionGroup(
         );
       }
 
-      const flowFilePath = inputs.flow_file_path.value;
-      if (flowFilePath) {
-        const flowFilePaths = flowFilePath
-          .toString()
-          .split('\n')
-          // It's easy to get an empty line with YAML
-          .filter((entry) => entry);
-        for (const flowFilePath of flowFilePaths) {
-          steps.push(
-            new BuildStep(globalCtx, {
-              id: BuildStep.getNewId(),
-              name: 'maestro_test',
-              ifCondition: '${ always() }',
-              displayName: `maestro test ${flowFilePath}`,
-              command: `maestro test ${flowFilePath}`,
-            })
-          );
-        }
-      } else {
+      const flowPaths = `${inputs.flow_path.value}`
+        .split('\n') // It's easy to get an empty line with YAML
+        .filter((entry) => entry);
+      for (const flowPath of flowPaths) {
         steps.push(
           new BuildStep(globalCtx, {
             id: BuildStep.getNewId(),
             name: 'maestro_test',
-            displayName: 'Run "maestro test"',
-            ifCondition: '${ never() }',
-            fn: (ctx) => {
-              ctx.logger.warn('flow_file_path not provided. Skipping running test.');
-            },
+            ifCondition: '${ always() }',
+            displayName: `maestro test ${flowPath}`,
+            command: `maestro test ${flowPath}`,
           })
         );
       }

--- a/packages/build-tools/src/steps/functions/uploadArtifact.ts
+++ b/packages/build-tools/src/steps/functions/uploadArtifact.ts
@@ -105,6 +105,7 @@ export function createUploadArtifactBuildFunction(ctx: CustomBuildContext): Buil
         });
       } catch (error) {
         if (inputs.ignore_error.value) {
+          logger.error(`Failed to upload ${artifact.type}. Ignoring error.`, error);
           // Ignoring error.
           return;
         }

--- a/packages/build-tools/src/steps/functions/uploadArtifact.ts
+++ b/packages/build-tools/src/steps/functions/uploadArtifact.ts
@@ -50,6 +50,11 @@ export function createUploadArtifactBuildFunction(ctx: CustomBuildContext): Buil
         required: true,
         allowedValueTypeName: BuildStepInputValueTypeName.STRING,
       }),
+      BuildStepInput.createProvider({
+        id: 'ignore_error',
+        required: false,
+        allowedValueTypeName: BuildStepInputValueTypeName.BOOLEAN,
+      }),
     ],
     fn: async ({ logger, global }, { inputs }) => {
       assert(inputs.path.value, 'Path input cannot be empty.');
@@ -93,10 +98,19 @@ export function createUploadArtifactBuildFunction(ctx: CustomBuildContext): Buil
         key: inputs.key.value as string,
       };
 
-      await ctx.runtimeApi.uploadArtifact({
-        artifact,
-        logger,
-      });
+      try {
+        await ctx.runtimeApi.uploadArtifact({
+          artifact,
+          logger,
+        });
+      } catch (error) {
+        if (inputs.ignore_error.value) {
+          // Ignoring error.
+          return;
+        }
+
+        throw error;
+      }
     },
   });
 }

--- a/packages/steps/src/BuildFunctionGroup.ts
+++ b/packages/steps/src/BuildFunctionGroup.ts
@@ -1,5 +1,11 @@
+import { BuildFunctionCallInputs } from './BuildFunction.js';
 import { BuildStep } from './BuildStep.js';
 import { BuildStepGlobalContext } from './BuildStepContext.js';
+import {
+  BuildStepInputById,
+  BuildStepInputProvider,
+  makeBuildStepInputByIdMap,
+} from './BuildStepInput.js';
 import { BuildConfigError } from './errors.js';
 
 export type BuildFunctionGroupById = Record<string, BuildFunctionGroup | undefined>;
@@ -7,22 +13,50 @@ export type BuildFunctionGroupById = Record<string, BuildFunctionGroup | undefin
 export class BuildFunctionGroup {
   public readonly namespace: string;
   public readonly id: string;
+  public readonly inputProviders?: BuildStepInputProvider[];
   public readonly createBuildStepsFromFunctionGroupCall: (
-    globalCtx: BuildStepGlobalContext
+    globalCtx: BuildStepGlobalContext,
+    {
+      callInputs,
+    }?: {
+      callInputs?: BuildFunctionCallInputs;
+    }
   ) => BuildStep[];
 
   constructor({
     namespace,
     id,
+    inputProviders,
     createBuildStepsFromFunctionGroupCall,
   }: {
     namespace: string;
     id: string;
-    createBuildStepsFromFunctionGroupCall: (globalCtx: BuildStepGlobalContext) => BuildStep[];
+    inputProviders?: BuildStepInputProvider[];
+    createBuildStepsFromFunctionGroupCall: (
+      globalCtx: BuildStepGlobalContext,
+      {
+        inputs,
+      }: {
+        inputs: BuildStepInputById;
+      }
+    ) => BuildStep[];
   }) {
     this.namespace = namespace;
     this.id = id;
-    this.createBuildStepsFromFunctionGroupCall = createBuildStepsFromFunctionGroupCall;
+    this.inputProviders = inputProviders;
+
+    this.createBuildStepsFromFunctionGroupCall = (ctx, { callInputs = {} } = {}) => {
+      const inputs = this.inputProviders?.map((inputProvider) => {
+        const input = inputProvider(ctx, id);
+        if (input.id in callInputs) {
+          input.set(callInputs[input.id]);
+        }
+        return input;
+      });
+      return createBuildStepsFromFunctionGroupCall(ctx, {
+        inputs: makeBuildStepInputByIdMap(inputs),
+      });
+    };
   }
 
   public getFullId(): string {

--- a/packages/steps/src/BuildFunctionGroup.ts
+++ b/packages/steps/src/BuildFunctionGroup.ts
@@ -16,9 +16,7 @@ export class BuildFunctionGroup {
   public readonly inputProviders?: BuildStepInputProvider[];
   public readonly createBuildStepsFromFunctionGroupCall: (
     globalCtx: BuildStepGlobalContext,
-    {
-      callInputs,
-    }?: {
+    options?: {
       callInputs?: BuildFunctionCallInputs;
     }
   ) => BuildStep[];

--- a/packages/steps/src/BuildStep.ts
+++ b/packages/steps/src/BuildStep.ts
@@ -297,6 +297,8 @@ export class BuildStep extends BuildStepOutputAccessor {
         return hasAnyPreviousStepsFailed;
       case 'always':
         return true;
+      case 'never':
+        return false;
     }
   }
 

--- a/packages/steps/src/utils/template.ts
+++ b/packages/steps/src/utils/template.ts
@@ -9,7 +9,8 @@ export const BUILD_STEP_INPUT_EXPRESSION_REGEXP = /\${\s*(inputs\.[\S]+)\s*}/;
 export const BUILD_STEP_OUTPUT_EXPRESSION_REGEXP = /\${\s*(steps\.[\S]+)\s*}/;
 export const BUILD_GLOBAL_CONTEXT_EXPRESSION_REGEXP = /\${\s*(eas\.[\S]+)\s*}/;
 export const BUILD_STEP_OR_BUILD_GLOBAL_CONTEXT_REFERENCE_REGEX = /\${\s*((steps|eas)\.[\S]+)\s*}/;
-export const BUILD_STEP_IF_CONDITION_EXPRESSION_REGEXP = /\${\s*(always|success|failure)\(\)\s*}/;
+export const BUILD_STEP_IF_CONDITION_EXPRESSION_REGEXP =
+  /\${\s*(always|success|failure|never)\(\)\s*}/;
 
 export function interpolateWithInputs(
   templateString: string,
@@ -31,7 +32,7 @@ export function interpolateWithOutputs(
  */
 export function getSelectedStatusCheckFromIfStatementTemplate(
   ifCondition: string
-): 'success' | 'failure' | 'always' {
+): 'success' | 'failure' | 'always' | 'never' {
   const matched = ifCondition.match(new RegExp(BUILD_STEP_IF_CONDITION_EXPRESSION_REGEXP, 'g'));
   if (!matched) {
     // this should never happen because of regex pattern validation
@@ -40,7 +41,7 @@ export function getSelectedStatusCheckFromIfStatementTemplate(
   const [, selectedStatusCheck] = nullthrows(
     matched[0].match(BUILD_STEP_IF_CONDITION_EXPRESSION_REGEXP)
   );
-  return selectedStatusCheck as 'success' | 'failure' | 'always';
+  return selectedStatusCheck as 'success' | 'failure' | 'always' | 'never';
 }
 
 export function getObjectValueForInterpolation(


### PR DESCRIPTION
# Why

We want to help developers get started with EAS Build + Maestro.

# How

Added another function group that takes care of setting up environment for Maestro, running the actual tests and uploading test results later.

Ideas for improvement:
- support multiple flows (implemented)
- skip setup of (Maestro, Simulator, Emulator) if a matching # is ready (not implemented)

# Test Plan

I ran it on my computer and:
- iOS Simulator could not boot
- Android script could not run:

<img width="1154" alt="Zrzut ekranu 2024-02-19 o 23 21 46" src="https://github.com/expo/eas-build/assets/1151041/f9195a29-fd64-44ce-bb36-52a093990cd6">

Maybe tomorrow it will work.