### PR TITLE
Install apps in `maestro_test`

### DIFF
--- a/packages/build-tools/src/steps/functionGroups/maestroTest.ts
+++ b/packages/build-tools/src/steps/functionGroups/maestroTest.ts
@@ -34,9 +34,35 @@ export function createEasMaestroTestFunctionGroup(
         steps.push(
           createStartIosSimulatorBuildFunction().createBuildStepFromFunctionCall(globalCtx)
         );
+        steps.push(
+          new BuildStep(globalCtx, {
+            id: BuildStep.getNewId(),
+            name: 'install_app',
+            displayName: `Install app to Simulator`,
+            command: `
+              for APP_PATH in ios/build/Build/Products/*simulator/*.app; do
+                xcrun simctl install booted $APP_PATH
+              done
+            `,
+          })
+        );
       } else if (buildToolsContext.job.platform === Platform.ANDROID) {
         steps.push(
           createStartAndroidEmulatorBuildFunction().createBuildStepFromFunctionCall(globalCtx)
+        );
+        steps.push(
+          new BuildStep(globalCtx, {
+            id: BuildStep.getNewId(),
+            name: 'install_app',
+            displayName: `Install app to Emulator`,
+            // shopt -s globstar is necessary to add /**/ support
+            command: `
+              shopt -s globstar
+              for APP_PATH in android/app/build/outputs/**/*.apk; do
+                adb install $APP_PATH
+              done
+            `,
+          })
         );
       }
 


### PR DESCRIPTION
# Why

After the app is built, before we test it we need to install it!

# How

Added what already worked in my other tests:

https://github.com/expo/eas-custom-builds-example/blob/e2fbfe2afb37d8d8af9ed465f4a4741ccf5a4d81/.eas/build/development-build-ios.yml#L27-L32

https://github.com/expo/eas-custom-builds-example/blob/e2fbfe2afb37d8d8af9ed465f4a4741ccf5a4d81/.eas/build/development-build-android.yml#L24-L30

# Test Plan

Deploy and test.