### PR TITLE
Add support for absolute paths in `upload_artifact` input

### DIFF
--- a/packages/build-tools/src/utils/__tests__/artifacts.test.ts
+++ b/packages/build-tools/src/utils/__tests__/artifacts.test.ts
@@ -27,6 +27,24 @@ describe(findArtifacts, () => {
     expect(paths[0]).toBe('/dir1/dir2/dir3/dir4/file');
   });
 
+  test('with absolute path', async () => {
+    await fs.mkdirp('/Users/expo/build');
+    await fs.mkdirp('/Users/expo/.maestro/tests');
+    await fs.writeFile('/Users/expo/.maestro/tests/log', Buffer.from('some content'));
+    const loggerMock = {
+      info: jest.fn(),
+      error: jest.fn(),
+    };
+    const paths = await findArtifacts({
+      rootDir: '/Users/expo/build',
+      patternOrPath: '/Users/expo/.maestro/tests',
+      logger: loggerMock as any,
+    });
+    expect(loggerMock.error).toHaveBeenCalledTimes(0);
+    expect(paths.length).toBe(1);
+    expect(paths[0]).toBe('/Users/expo/.maestro/tests');
+  });
+
   test('with glob pattern', async () => {
     await fs.mkdirp('/dir1/dir2/dir3/dir4');
     await fs.writeFile('/dir1/dir2/dir3/dir4/file.aab', Buffer.from('some content'));

--- a/packages/build-tools/src/utils/artifacts.ts
+++ b/packages/build-tools/src/utils/artifacts.ts
@@ -30,7 +30,18 @@ export async function findArtifacts({
       throw new FindArtifactsError(`No such file or directory ${patternOrPath}`);
     }
   }
-  return files.map((relativePath) => path.join(rootDir, relativePath));
+
+  return files.map((filePath) => {
+    // User may provide an absolute path as input in which case
+    // fg will return an absolute path.
+    if (path.isAbsolute(filePath)) {
+      return filePath;
+    }
+
+    // User may also provide a relative path in which case
+    // fg will return a path relative to rootDir.
+    return path.join(rootDir, filePath);
+  });
 }
 
 async function logMissingFileError(artifactPath: string, buildLogger: bunyan): Promise<void> {


### PR DESCRIPTION
# Why

I was providing `${ eas.env.HOME }/.maestro` to `upload_artifact` and [it failed](https://expo.dev/accounts/exponent/projects/eas-custom-builds-example/builds/97c96289-4b89-499f-90b3-ae7b92a9a10c).

# How

Noticed we always `path.join` in `findArtifacts`. Made sure we don't if the path is already an absolute path.

# Test Plan

Added test.