### PR TITLE
Log installed apps in `maestro_test`

### DIFF
--- a/packages/build-tools/src/steps/functions/installMaestro.ts
+++ b/packages/build-tools/src/steps/functions/installMaestro.ts
@@ -188,6 +188,7 @@ async function installIdbFromBrew({
   const localEnv = {
     ...env,
     HOMEBREW_NO_AUTO_UPDATE: '1',
+    HOMEBREW_NO_INSTALL_CLEANUP: '1',
   };
 
   await spawn(brewPath, ['tap', 'facebook/fb'], {
@@ -236,7 +237,7 @@ async function installJavaFromGcs({
     await spawn(
       'hdiutil',
       ['attach', installerPath, '-noverify', '-mountpoint', installerMountDirectory],
-      { logger, env }
+      { env }
     );
 
     logger.info('Installing Java');
@@ -249,7 +250,7 @@ async function installJavaFromGcs({
         '-target',
         '/',
       ],
-      { logger, env }
+      { env }
     );
   } finally {
     try {

--- a/packages/steps/src/index.ts
+++ b/packages/steps/src/index.ts
@@ -11,3 +11,4 @@ export { BuildStepEnv } from './BuildStepEnv.js';
 export { BuildFunctionGroup } from './BuildFunctionGroup.js';
 export { BuildStep } from './BuildStep.js';
 export * as errors from './errors.js';
+export * from './utils/shell/spawn.js';


### PR DESCRIPTION
# Why

I didn't like:
- "Install app to Simulator" printed out no logs
- Install Maestro printed out too many logs.

# How

For installing apps changed `command` into an `fn` which lets us use `fast-glob`, `logger` and in general feels simpler to maintain.

For hiding Maestro logs removed `logger` from `spawnAsync`.

Also added `HOMEBREW_NO_INSTALL_CLEANUP` so it doesn't clean up packages. Reduces install time by 3 seconds.

# Test Plan

Will deploy and test.