### PR TITLE
Fix installing apps in `maestro_test`

### DIFF
--- a/packages/build-tools/src/steps/functionGroups/maestroTest.ts
+++ b/packages/build-tools/src/steps/functionGroups/maestroTest.ts
@@ -55,7 +55,7 @@ export function createEasMaestroTestFunctionGroup(
               
               if ! $FILES_FOUND; then
                 echo "No files found matching \\"$SEARCH_PATH\\". Are you sure you've built a Simulator app?"
-                #exit 1
+                exit 1
               fi
             `,
           })

--- a/packages/build-tools/src/steps/functionGroups/maestroTest.ts
+++ b/packages/build-tools/src/steps/functionGroups/maestroTest.ts
@@ -40,6 +40,10 @@ export function createEasMaestroTestFunctionGroup(
             name: 'install_app',
             displayName: `Install app to Simulator`,
             command: `
+              # shopt -s nullglob is necessary not to try to install
+              # SEARCH_PATH literally if there are no matching files.
+              shopt -s nullglob
+
               SEARCH_PATH="ios/build/Build/Products/*simulator/*.app"
               FILES_FOUND=false
 
@@ -49,9 +53,9 @@ export function createEasMaestroTestFunctionGroup(
                 xcrun simctl install booted "$APP_PATH"
               done
               
-              if ! FILES_FOUND; then
+              if ! $FILES_FOUND; then
                 echo "No files found matching \\"$SEARCH_PATH\\". Are you sure you've built a Simulator app?"
-                exit 1
+                #exit 1
               fi
             `,
           })
@@ -68,6 +72,9 @@ export function createEasMaestroTestFunctionGroup(
             command: `
               # shopt -s globstar is necessary to add /**/ support
               shopt -s globstar
+              # shopt -s nullglob is necessary not to try to install
+              # SEARCH_PATH literally if there are no matching files.
+              shopt -s nullglob
 
               SEARCH_PATH="android/app/build/outputs/**/*.apk"
               FILES_FOUND=false
@@ -78,7 +85,7 @@ export function createEasMaestroTestFunctionGroup(
                 adb install "$APP_PATH"
               done
               
-              if ! FILES_FOUND; then
+              if ! $FILES_FOUND; then
                 echo "No files found matching \\"$SEARCH_PATH\\". Are you sure you've built an Emulator app?"
                 exit 1
               fi

--- a/packages/build-tools/src/steps/functionGroups/maestroTest.ts
+++ b/packages/build-tools/src/steps/functionGroups/maestroTest.ts
@@ -49,7 +49,7 @@ export function createEasMaestroTestFunctionGroup(
                 xcrun simctl install booted "$APP_PATH"
               done
               
-              if ! FILES_FOUND; do
+              if ! FILES_FOUND; then
                 echo "No files found matching \\"$SEARCH_PATH\\". Are you sure you've built a Simulator app?"
                 exit 1
               fi
@@ -78,7 +78,7 @@ export function createEasMaestroTestFunctionGroup(
                 adb install "$APP_PATH"
               done
               
-              if ! FILES_FOUND; do
+              if ! FILES_FOUND; then
                 echo "No files found matching \\"$SEARCH_PATH\\". Are you sure you've built an Emulator app?"
                 exit 1
               fi
@@ -109,7 +109,7 @@ export function createEasMaestroTestFunctionGroup(
             ifCondition: '${ always() }',
             name: 'Upload Maestro test results',
             callInputs: {
-              path: '${ eas.env.HOME }/.maestro/',
+              path: '${ eas.env.HOME }/.maestro/tests',
               ignore_error: true,
               type: 'build-artifact',
             },


### PR DESCRIPTION
# Why

https://expo.dev/accounts/exponent/projects/eas-custom-builds-example/builds/4e0ed832-ec6d-4e76-8c98-3a38cf60f380

# How

- fixed wrong bash command (do -> then, **$**FILES_FOUND
- fixed Maestro artifact path (`.maestro` -> `.maestro/tests`)

<img width="393" alt="Zrzut ekranu 2024-02-22 o 00 06 57" src="https://github.com/expo/eas-build/assets/1151041/762a3164-31e6-43ff-a3b3-4330c541e01a">

# Test Plan

I have verified manually by running those scripts with `bash` that they should work.