### PR TITLE
[build-tools] Handle expo-updates canary versions

### DIFF
--- a/packages/build-tools/src/utils/__tests__/expoUpdates.test.ts
+++ b/packages/build-tools/src/utils/__tests__/expoUpdates.test.ts
@@ -223,4 +223,27 @@ describe(expoUpdates.configureExpoUpdatesIfInstalledAsync, () => {
     expect(androidGetNativelyDefinedClassicReleaseChannelAsync).not.toBeCalled();
     expect(iosGetNativelyDefinedClassicReleaseChannelAsync).not.toBeCalled();
   });
+
+  it('does not use the default release channel if the releaseChannel is not defined in ctx.job.releaseChannel nor natively, and expo-updates version is canary', async () => {
+    jest
+      .mocked(getExpoUpdatesPackageVersionIfInstalledAsync)
+      .mockResolvedValue('0.0.1-canary-20240109-93608d8');
+
+    const infoLogger = jest.fn();
+    const managedCtx: BuildContext<Job> = {
+      appConfig: {},
+      job: { platform: Platform.IOS },
+      logger: { info: infoLogger, warn: () => {} },
+      getReactNativeProjectDirectory: () => '/app',
+    } as any;
+    await expoUpdates.configureExpoUpdatesIfInstalledAsync(managedCtx);
+
+    expect(infoLogger).not.toBeCalledWith(
+      `Using default release channel for 'expo-updates' (default)`
+    );
+    expect(iosSetClassicReleaseChannelNativelyAsync).not.toBeCalled();
+    expect(androidSetClassicReleaseChannelNativelyAsync).not.toBeCalled();
+    expect(androidGetNativelyDefinedClassicReleaseChannelAsync).not.toBeCalled();
+    expect(iosGetNativelyDefinedClassicReleaseChannelAsync).not.toBeCalled();
+  });
 });

--- a/packages/build-tools/src/utils/expoUpdates.ts
+++ b/packages/build-tools/src/utils/expoUpdates.ts
@@ -239,6 +239,10 @@ export function isEASUpdateConfigured(ctx: BuildContext<Job>): boolean {
 export function shouldConfigureClassicUpdatesReleaseChannelAsFallback(
   expoUpdatesPackageVersion: string
 ): boolean {
+  if (expoUpdatesPackageVersion.includes('canary')) {
+    return false;
+  }
+
   // Anything before SDK 50 should configure classic updates as a fallback. The first version
   // of the expo-updates package published for SDK 50 was 0.19.0
   return semver.lt(expoUpdatesPackageVersion, '0.19.0');


### PR DESCRIPTION
# Why

eas-build equivalent of https://github.com/expo/eas-cli/pull/2243.

# Test Plan

Run test.
