### PR TITLE
[ENG-11467][create-eas-build-function] improve readme in custom build function templates

### DIFF
--- a/packages/create-eas-build-function/templates/javascript/README.md
+++ b/packages/create-eas-build-function/templates/javascript/README.md
@@ -2,12 +2,12 @@
 
 ## What is this? 👀
 
-This is a custom build function that can be used as a step in the EAS Build custom build process. If you don't know what custom builds are or how to use them, refer to the [custom builds documentation](https://docs.expo.dev/custom-builds/get-started/).
+This is a custom build function that can be used as a step in the EAS Build build process. If you don't know what custom builds are or how to use them, refer to the [custom builds documentation](https://docs.expo.dev/custom-builds/get-started/).
 
-This is a way of executing your custom and very own JavaScript code as a part of your build process running on EAS servers.
+This is a way of executing your custom JavaScript code as a part of your build process running on EAS servers.
 
 ## How can I use it? 🚀
 
 Please refer to [this](https://docs.expo.dev/custom-builds/functions/) tutorial to learn how to use this function in your EAS Build custom build process.
 
-You can also check the [custom build's **config.yml** schema reference](https://docs.expo.dev/custom-builds/schema/) to learn more!
+Check out the [custom build's **config.yml** schema reference](https://docs.expo.dev/custom-builds/schema/) to learn more!

--- a/packages/create-eas-build-function/templates/javascript/README.md
+++ b/packages/create-eas-build-function/templates/javascript/README.md
@@ -8,6 +8,6 @@ This is a way of executing your custom JavaScript code as a part of your build p
 
 ## How can I use it? 🚀
 
-Please refer to [this](https://docs.expo.dev/custom-builds/functions/) tutorial to learn how to use this function in your EAS Build custom build process.
+Please refer to [this tutorial](https://docs.expo.dev/custom-builds/functions/) to learn how to use this function in your EAS Build custom build process.
 
 Check out the [custom build's **config.yml** schema reference](https://docs.expo.dev/custom-builds/schema/) to learn more!

--- a/packages/create-eas-build-function/templates/javascript/README.md
+++ b/packages/create-eas-build-function/templates/javascript/README.md
@@ -1,34 +1,13 @@
-# My EAS Build function
+# This is your JavaScript function for EAS Build custom builds 🎉
 
-This is an EAS Build function written in JavaScript. It can be used as a step in a [custom build](https://docs.expo.dev/preview/custom-build-config/).
+## What is this? 👀
 
-## How to use it
+This is a custom build function that can be used as a step in the EAS Build custom build process. If you don't know what custom builds are or how to use them, refer to the [custom builds documentation](https://docs.expo.dev/custom-builds/get-started/).
 
-1. Install dependencies: `npm install`.
-2. Implement your function in `src/index.js`.
-3. Install [`ncc`](https://github.com/vercel/ncc) if not yet installed: `npm install -g @vercel/ncc`.
-4. Compile the function with `ncc` by running `npm run build`. Ensure that the `build` directory is not ignored by `.gitignore` / `.easignore`, it must be included in the [archive uploaded when running `eas build`](https://expo.fyi/eas-build-archive).
-5. Use the function in a custom build YAML config. For example:
+This is a way of executing your custom and very own JavaScript code as a part of your build process running on EAS servers.
 
-    ```yml
-    build:
-        name: Custom build
-        steps:
-            - run:
-                name: Hi!
-                command: echo "Hello! Let's run a custom function!"
-            - my_function:
-                id: my-function-call
-            - run:
-                name: Bye!
-                command: echo "Bye! The custom function has finished its job."
+## How can I use it? 🚀
 
-    functions:
-        my_function:
-            name: my-function
-            path: ./my-function # The path is resolved relative to this config file.
-    ```
+Please refer to [this](https://docs.expo.dev/custom-builds/functions/) tutorial to learn how to use this function in your EAS Build custom build process.
 
-## Learn more
-
-Refer to the [custom builds documentation](https://docs.expo.dev/preview/custom-build-config/).
+You can also check the [custom build's **config.yml** schema reference](https://docs.expo.dev/custom-builds/schema/) to learn more!

--- a/packages/create-eas-build-function/templates/javascript/package.json
+++ b/packages/create-eas-build-function/templates/javascript/package.json
@@ -4,9 +4,9 @@
   "main": "./build/index.js",
   "type": "commonjs",
   "devDependencies": {
-    "@babel/cli": "^7.22.9",
-    "@babel/core": "^7.22.9",
-    "@babel/preset-env": "^7.22.9"
+    "@babel/cli": "^7.23.9",
+    "@babel/core": "^7.23.9",
+    "@babel/preset-env": "^7.23.9"
   },
   "scripts": {
     "babel": "babel src --out-dir babel",

--- a/packages/create-eas-build-function/templates/typescript/README.md
+++ b/packages/create-eas-build-function/templates/typescript/README.md
@@ -2,12 +2,12 @@
 
 ## What is this? 👀
 
-This is a custom build function that can be used as a step in the EAS Build custom build process. If you don't know what custom builds are or how to use them, refer to the [custom builds documentation](https://docs.expo.dev/custom-builds/get-started/).
+This is a custom build function that can be used as a step in the EAS Build build process. If you don't know what custom builds are or how to use them, refer to the [custom builds documentation](https://docs.expo.dev/custom-builds/get-started/).
 
-This is a way of executing your custom and very own TypeScript code as a part of your build process running on EAS servers.
+This is a way of executing your custom TypeScript code as a part of your build process running on EAS servers.
 
 ## How can I use it? 🚀
 
-Please refer to [this](https://docs.expo.dev/custom-builds/functions/) tutorial to learn how to use this function in your EAS Build custom build process.
+Please refer to [this tutorial](https://docs.expo.dev/custom-builds/functions/) to learn how to use this function in your EAS Build custom build process.
 
-You can also check the [custom build's **config.yml** schema reference](https://docs.expo.dev/custom-builds/schema/) to learn more!
+Check out the [custom build's **config.yml** schema reference](https://docs.expo.dev/custom-builds/schema/) to learn more!

--- a/packages/create-eas-build-function/templates/typescript/README.md
+++ b/packages/create-eas-build-function/templates/typescript/README.md
@@ -1,33 +1,13 @@
-# My EAS Build function
+# This is your TypeScript function for EAS Build custom builds 🎉
 
-This is an EAS Build function written in TypeScript. It can be used as a step in a [custom build](https://docs.expo.dev/preview/custom-build-config/).
+## What is this? 👀
 
-## How to use it
+This is a custom build function that can be used as a step in the EAS Build custom build process. If you don't know what custom builds are or how to use them, refer to the [custom builds documentation](https://docs.expo.dev/custom-builds/get-started/).
 
-1. Install dependencies: `npm install`.
-2. Implement your function in `src/index.ts`.
-3. Install [`ncc`](https://github.com/vercel/ncc) if not yet installed: `npm install -g @vercel/ncc`.
-4. Compile the function with `ncc` by running `npm run build`. Ensure that the `build` directory is not ignored by `.gitignore` / `.easignore`, it must be included in the [archive uploaded when running `eas build`](https://expo.fyi/eas-build-archive).
-5. Use the function in a custom build YAML config. For example:
+This is a way of executing your custom and very own TypeScript code as a part of your build process running on EAS servers.
 
-    ```yml
-    build:
-        name: Custom build
-        steps:
-            - run:
-                name: Hi!
-                command: echo "Hello! Let's run a custom function!"
-            - my_function:
-                id: my-function-call
-            - run:
-                name: Bye!
-                command: echo "Bye! The custom function has finished its job."
+## How can I use it? 🚀
 
-    functions:
-        my_function:
-            name: my-function
-            path: ./my-function # The path is resolved relative to this config file.
-    ```
-## Learn more
+Please refer to [this](https://docs.expo.dev/custom-builds/functions/) tutorial to learn how to use this function in your EAS Build custom build process.
 
-Refer to the [custom builds documentation](https://docs.expo.dev/preview/custom-build-config/).
+You can also check the [custom build's **config.yml** schema reference](https://docs.expo.dev/custom-builds/schema/) to learn more!

--- a/packages/create-eas-build-function/templates/typescript/package.json
+++ b/packages/create-eas-build-function/templates/typescript/package.json
@@ -12,6 +12,6 @@
   "devDependencies": {
     "@types/node": "20.11.0",
     "typescript": "^5.3.3",
-    "@expo/steps": "^1.0.55"
+    "@expo/steps": "^1.0.75"
   }
 }


### PR DESCRIPTION
# Why

Our current readme is outdated and doesn't reference https://docs.expo.dev/custom-builds/functions/ tutorial (which is the best way to start IMO)

# How

Update readme. Make it more "cheerful" and reference our tutorial.

# Test Plan

@sjchmiela code review and him verifying that this is actually user friendly 😅 
