### PR TITLE
[eas-build-job] allow secrets to be empty strings

### DIFF
--- a/packages/eas-build-job/src/common.ts
+++ b/packages/eas-build-job/src/common.ts
@@ -97,7 +97,7 @@ export enum EnvironmentSecretType {
 export const EnvironmentSecretsSchema = Joi.array().items(
   Joi.object({
     name: Joi.string().required(),
-    value: Joi.string().required(),
+    value: Joi.string().allow('').required(),
     type: Joi.string()
       .valid(...Object.values(EnvironmentSecretType))
       .required(),


### PR DESCRIPTION
# Why

https://exponent-internal.slack.com/archives/CLQ58M23X/p1708680627608489

# How

I believe `''` are valid env vars and we should allow it 🤔 