### PR TITLE
[ENG-11472][build-tools] better expo update error message

### DIFF
--- a/packages/build-tools/src/steps/utils/expoUpdates.ts
+++ b/packages/build-tools/src/steps/utils/expoUpdates.ts
@@ -39,7 +39,7 @@ export async function configureEASUpdateAsync({
 
   if (isEASUpdateConfigured(appConfig, logger)) {
     const channel = jobOrInputChannel ?? (await getChannelAsync(job, workingDirectory));
-    const isDevelopmentClient = job.isDevelopmentClient ?? false;
+    const isDevelopmentClient = job.developmentClient ?? false;
     if (channel) {
       await configureEASUpdate(job, logger, channel, workingDirectory);
     } else if (isDevelopmentClient) {

--- a/packages/build-tools/src/steps/utils/expoUpdates.ts
+++ b/packages/build-tools/src/steps/utils/expoUpdates.ts
@@ -47,8 +47,16 @@ export async function configureEASUpdateAsync({
           `This build is configured with EAS Update however has a Classic Updates releaseChannel set instead of having an EAS Update channel.`
         );
       } else {
+        const easUpdateUrl = appConfig.updates?.url ?? null;
+        const jobProfile = job.buildProfile ?? null;
         logger.warn(
-          `This build is configured to query EAS Update for updates, however no channel is set.`
+          `This build has an invalid EAS Update configuration: update.url is set to "${easUpdateUrl}" in app config, but a channel is not specified${
+            jobProfile ? '' : ` for the current build profile "${jobProfile}" in eas.json`
+          }.`
+        );
+        logger.warn(`- No channel will be set and EAS Update will be disabled for the build.`);
+        logger.warn(
+          `- Run \`eas update:configure\` to set your channel in eas.json. For more details, see https://docs.expo.dev/eas-update/getting-started/#configure-your-project`
         );
       }
     }

--- a/packages/build-tools/src/steps/utils/expoUpdates.ts
+++ b/packages/build-tools/src/steps/utils/expoUpdates.ts
@@ -39,8 +39,11 @@ export async function configureEASUpdateAsync({
 
   if (isEASUpdateConfigured(appConfig, logger)) {
     const channel = jobOrInputChannel ?? (await getChannelAsync(job, workingDirectory));
+    const isDevelopmentClient = job.isDevelopmentClient ?? false;
     if (channel) {
       await configureEASUpdate(job, logger, channel, workingDirectory);
+    } else if (isDevelopmentClient) {
+      // NO-OP: Development clients don't need to have a channel set
     } else {
       if (job.releaseChannel !== undefined) {
         logger.warn(

--- a/packages/build-tools/src/utils/expoUpdates.ts
+++ b/packages/build-tools/src/utils/expoUpdates.ts
@@ -182,9 +182,6 @@ export async function configureExpoUpdatesIfInstalledAsync(ctx: BuildContext<Job
             `This build is configured with EAS Update however has a Classic Updates releaseChannel set instead of having an EAS Update channel.`
           );
         } else {
-          ctx.logger.warn(
-            `This build is configured to query EAS Update for updates, however no channel is set in eas.json.`
-          );
           const easUpdateUrl = ctx.appConfig.updates?.url ?? null;
           const jobProfile = ctx.job.buildProfile ?? null;
           ctx.logger.warn(

--- a/packages/build-tools/src/utils/expoUpdates.ts
+++ b/packages/build-tools/src/utils/expoUpdates.ts
@@ -181,6 +181,19 @@ export async function configureExpoUpdatesIfInstalledAsync(ctx: BuildContext<Job
           ctx.logger.warn(
             `This build is configured to query EAS Update for updates, however no channel is set in eas.json.`
           );
+          const easUpdateUrl = ctx.appConfig.updates?.url ?? null;
+          const jobProfile = ctx.job.buildProfile ?? null;
+          ctx.logger.warn(
+            `This build has an invalid EAS Update configuration: update.url is set to "${easUpdateUrl}" in app config, but a channel is not specified${
+              jobProfile ? '' : ` for the current build profile "${jobProfile}" in eas.json`
+            }.`
+          );
+          ctx.logger.warn(
+            `- No channel will be set and EAS Update will be disabled for the build.`
+          );
+          ctx.logger.warn(
+            `- Run \`eas update:configure\` to set your channel in eas.json. For more details, see https://docs.expo.dev/eas-update/getting-started/#configure-your-project`
+          );
         }
         ctx.markBuildPhaseHasWarnings();
       }

--- a/packages/build-tools/src/utils/expoUpdates.ts
+++ b/packages/build-tools/src/utils/expoUpdates.ts
@@ -168,7 +168,7 @@ export async function configureExpoUpdatesIfInstalledAsync(ctx: BuildContext<Job
       await configureEASExpoUpdatesAsync(ctx);
     } else {
       const channel = await getChannelAsync(ctx);
-      const isDevelopmentClient = ctx.job.isDevelopmentClient ?? false;
+      const isDevelopmentClient = ctx.job.developmentClient ?? false;
 
       if (channel !== null) {
         const configFile =

--- a/packages/build-tools/src/utils/expoUpdates.ts
+++ b/packages/build-tools/src/utils/expoUpdates.ts
@@ -168,10 +168,14 @@ export async function configureExpoUpdatesIfInstalledAsync(ctx: BuildContext<Job
       await configureEASExpoUpdatesAsync(ctx);
     } else {
       const channel = await getChannelAsync(ctx);
+      const isDevelopmentClient = ctx.job.isDevelopmentClient ?? false;
+
       if (channel !== null) {
         const configFile =
           ctx.job.platform === Platform.ANDROID ? 'AndroidManifest.xml' : 'Expo.plist';
         ctx.logger.info(`The channel name for EAS Update in ${configFile} is set to "${channel}"`);
+      } else if (isDevelopmentClient) {
+        // NO-OP: Development clients don't need to have a channel set
       } else {
         if (ctx.job.releaseChannel !== undefined) {
           ctx.logger.warn(


### PR DESCRIPTION
# Why

Add a better warning message during a build if the `channel` is not set correctly, as suggested by brent [here](https://linear.app/expo/issue/ENG-11472/add-annotation-for-misconfigured-eas-update-with-link-to-docs#comment-8d7d6fe5)

# How
In the case that the channel is not set:

- If you have a development client build, don't print any warning, because channels are not relevant. 

- Else print:
> This build has an invalid EAS Update configuration: update.url is set to "${easUpdateUrl}" in app config, but a channel is not specified for the current build profile "${jobProfile}" in eas.json.
>- No channel will be set and EAS Update will be disabled for the build.
>- Run \`eas update:configure\` to set your channel in eas.json. For more details, see https://docs.expo.dev/eas-update/getting-started/#configure-your-project

# Test Plan

- [ ] current tests pass
