### PR TITLE
[steps] [ENG-11196] Add object interpolation support

### DIFF
--- a/packages/steps/src/BuildStepContext.ts
+++ b/packages/steps/src/BuildStepContext.ts
@@ -4,7 +4,6 @@ import path from 'path';
 import { BuildStaticContext } from '@expo/eas-build-job';
 import { bunyan } from '@expo/logger';
 import { v4 as uuidv4 } from 'uuid';
-import cloneDeep from 'lodash.clonedeep';
 
 import {
   BuildStep,
@@ -111,14 +110,6 @@ export class BuildStepGlobalContext {
   public interpolate<InterpolableType extends string | object>(
     value: InterpolableType
   ): InterpolableType {
-    if (typeof value === 'string') {
-      return this.interpolateString(value) as InterpolableType;
-    } else {
-      return this.interpolateObject(value) as InterpolableType;
-    }
-  }
-
-  public interpolateString(value: string): string {
     return interpolateWithGlobalContext(value, (path) => {
       return (
         getObjectValueForInterpolation(path, {
@@ -129,17 +120,6 @@ export class BuildStepGlobalContext {
         })?.toString() ?? ''
       );
     });
-  }
-
-  public interpolateObject(value: object): object {
-    const valueDeepCopy = cloneDeep(value);
-    Object.keys(value).forEach((property) => {
-      const propertyValue = value[property as keyof typeof value];
-      if (['string', 'object'].includes(typeof propertyValue)) {
-        valueDeepCopy[property as keyof typeof valueDeepCopy] = this.interpolate(propertyValue);
-      }
-    });
-    return valueDeepCopy;
   }
 
   public stepCtx(options: { logger: bunyan; relativeWorkingDirectory?: string }): BuildStepContext {

--- a/packages/steps/src/BuildStepContext.ts
+++ b/packages/steps/src/BuildStepContext.ts
@@ -4,6 +4,7 @@ import path from 'path';
 import { BuildStaticContext } from '@expo/eas-build-job';
 import { bunyan } from '@expo/logger';
 import { v4 as uuidv4 } from 'uuid';
+import cloneDeep from 'lodash.clonedeep';
 
 import {
   BuildStep,
@@ -131,7 +132,7 @@ export class BuildStepGlobalContext {
   }
 
   public interpolateObject(value: object): object {
-    const valueDeepCopy = JSON.parse(JSON.stringify(value));
+    const valueDeepCopy = cloneDeep(value);
     Object.keys(value).forEach((property) => {
       const propertyValue = value[property as keyof typeof value];
       if (['string', 'object'].includes(typeof propertyValue)) {

--- a/packages/steps/src/BuildStepContext.ts
+++ b/packages/steps/src/BuildStepContext.ts
@@ -136,7 +136,7 @@ export class BuildStepGlobalContext {
     Object.keys(value).forEach((property) => {
       const propertyValue = value[property as keyof typeof value];
       if (['string', 'object'].includes(typeof propertyValue)) {
-        valueDeepCopy[property] = this.interpolate(propertyValue);
+        valueDeepCopy[property as keyof typeof valueDeepCopy] = this.interpolate(propertyValue);
       }
     });
     return valueDeepCopy;

--- a/packages/steps/src/BuildStepInput.ts
+++ b/packages/steps/src/BuildStepInput.ts
@@ -1,3 +1,5 @@
+import assert from 'assert';
+
 import { bunyan } from '@expo/logger';
 
 import { BuildStepGlobalContext, SerializedBuildStepGlobalContext } from './BuildStepContext.js';
@@ -119,7 +121,8 @@ export class BuildStepInput<
       }
       return rawValue as BuildStepInputValueTypeWithRequired<T, R>;
     } else {
-      const valueInterpolatedWithGlobalContext = this.ctx.interpolate(rawValue as string | object);
+      assert(rawValue !== undefined);
+      const valueInterpolatedWithGlobalContext = this.ctx.interpolate(rawValue);
       const valueInterpolatedWithOutputsAndGlobalContext = interpolateWithOutputs(
         valueInterpolatedWithGlobalContext,
         (path) => this.ctx.getStepOutputValue(path) ?? ''

--- a/packages/steps/src/BuildStepInput.ts
+++ b/packages/steps/src/BuildStepInput.ts
@@ -121,6 +121,8 @@ export class BuildStepInput<
       }
       return rawValue as BuildStepInputValueTypeWithRequired<T, R>;
     } else {
+      // `valueDoesNotRequireInterpolation` checks that `rawValue` is not undefined
+      // so this will never be true.
       assert(rawValue !== undefined);
       const valueInterpolatedWithGlobalContext = this.ctx.interpolate(rawValue);
       const valueInterpolatedWithOutputsAndGlobalContext = interpolateWithOutputs(

--- a/packages/steps/src/BuildStepInput.ts
+++ b/packages/steps/src/BuildStepInput.ts
@@ -110,21 +110,16 @@ export class BuildStepInput<
     }
 
     const valueDoesNotRequireInterpolation =
-      rawValue === undefined ||
-      typeof rawValue === 'boolean' ||
-      typeof rawValue === 'number' ||
-      typeof rawValue === 'object';
+      rawValue === undefined || typeof rawValue === 'boolean' || typeof rawValue === 'number';
     if (valueDoesNotRequireInterpolation) {
-      const currentTypeName =
-        typeof rawValue === 'object' ? BuildStepInputValueTypeName.JSON : typeof rawValue;
-      if (currentTypeName !== this.allowedValueTypeName && rawValue !== undefined) {
+      if (typeof rawValue !== this.allowedValueTypeName && rawValue !== undefined) {
         throw new BuildStepRuntimeError(
           `Input parameter "${this.id}" for step "${this.stepDisplayName}" must be of type "${this.allowedValueTypeName}".`
         );
       }
       return rawValue as BuildStepInputValueTypeWithRequired<T, R>;
     } else {
-      const valueInterpolatedWithGlobalContext = this.ctx.interpolate(rawValue);
+      const valueInterpolatedWithGlobalContext = this.ctx.interpolate(rawValue as string | object);
       const valueInterpolatedWithOutputsAndGlobalContext = interpolateWithOutputs(
         valueInterpolatedWithGlobalContext,
         (path) => this.ctx.getStepOutputValue(path) ?? ''
@@ -193,7 +188,12 @@ export class BuildStepInput<
     return input;
   }
 
-  private parseInputValueToAllowedType(value: string): BuildStepInputValueTypeWithRequired<T, R> {
+  private parseInputValueToAllowedType(
+    value: string | object
+  ): BuildStepInputValueTypeWithRequired<T, R> {
+    if (typeof value === 'object') {
+      return value as BuildStepInputValueTypeWithRequired<T, R>;
+    }
     if (this.allowedValueTypeName === BuildStepInputValueTypeName.STRING) {
       return value as BuildStepInputValueTypeWithRequired<T, R>;
     } else if (this.allowedValueTypeName === BuildStepInputValueTypeName.NUMBER) {

--- a/packages/steps/src/__tests__/BuildStepInput-test.ts
+++ b/packages/steps/src/__tests__/BuildStepInput-test.ts
@@ -307,6 +307,7 @@ describe(BuildStepInput, () => {
       baz: {
         bazfoo: 'bazfoo',
         bazbar: '${ eas.context_val_2.in_val_1 }',
+        bazbaz: ['bazbaz', '${ eas.context_val_1 }', '${ eas.context_val_2.in_val_1 }'],
       },
     });
     expect(i.value).toEqual({
@@ -315,6 +316,7 @@ describe(BuildStepInput, () => {
       baz: {
         bazfoo: 'bazfoo',
         bazbar: 'in_val_1',
+        bazbaz: ['bazbaz', 'val_1', 'in_val_1'],
       },
     });
   });

--- a/packages/steps/src/__tests__/BuildStepInput-test.ts
+++ b/packages/steps/src/__tests__/BuildStepInput-test.ts
@@ -286,6 +286,39 @@ describe(BuildStepInput, () => {
     );
   });
 
+  test('context values in an object', () => {
+    const ctx = createGlobalContextMock({
+      staticContextContent: {
+        context_val_1: 'val_1',
+        context_val_2: {
+          in_val_1: 'in_val_1',
+        },
+      } as unknown as BuildStaticContext,
+    });
+    const i = new BuildStepInput(ctx, {
+      id: 'foo',
+      stepDisplayName: BuildStep.getDisplayName({ id: 'test1' }),
+      required: true,
+      allowedValueTypeName: BuildStepInputValueTypeName.JSON,
+    });
+    i.set({
+      foo: 'foo',
+      bar: '${ eas.context_val_1 }',
+      baz: {
+        bazfoo: 'bazfoo',
+        bazbar: '${ eas.context_val_2.in_val_1 }',
+      },
+    });
+    expect(i.value).toEqual({
+      foo: 'foo',
+      bar: 'val_1',
+      baz: {
+        bazfoo: 'bazfoo',
+        bazbar: 'in_val_1',
+      },
+    });
+  });
+
   test('default value number', () => {
     const ctx = createGlobalContextMock();
     const i = new BuildStepInput(ctx, {

--- a/packages/steps/src/utils/template.ts
+++ b/packages/steps/src/utils/template.ts
@@ -46,7 +46,8 @@ export function interpolateObjectWithOutputs(
   Object.keys(interpolableObject).forEach((property) => {
     const propertyValue = interpolableObject[property as keyof typeof interpolableObject];
     if (['string', 'object'].includes(typeof propertyValue)) {
-      interpolableObjectCopy[property] = interpolateWithOutputs(propertyValue, fn);
+      interpolableObjectCopy[property as keyof typeof interpolableObjectCopy] =
+        interpolateWithOutputs(propertyValue, fn);
     }
   });
   return interpolableObjectCopy;

--- a/packages/steps/src/utils/template.ts
+++ b/packages/steps/src/utils/template.ts
@@ -1,4 +1,5 @@
 import get from 'lodash.get';
+import cloneDeep from 'lodash.clonedeep';
 
 import { BuildStepInputValueTypeName } from '../BuildStepInput.js';
 import { BuildConfigError, BuildStepRuntimeError } from '../errors.js';
@@ -41,7 +42,7 @@ export function interpolateObjectWithOutputs(
   interpolableObject: object,
   fn: (path: string) => string
 ): object {
-  const interpolableObjectCopy = JSON.parse(JSON.stringify(interpolableObject));
+  const interpolableObjectCopy = cloneDeep(interpolableObject);
   Object.keys(interpolableObject).forEach((property) => {
     const propertyValue = interpolableObject[property as keyof typeof interpolableObject];
     if (['string', 'object'].includes(typeof propertyValue)) {

--- a/packages/steps/src/utils/template.ts
+++ b/packages/steps/src/utils/template.ts
@@ -98,11 +98,37 @@ export function getObjectValueForInterpolation(
   return value;
 }
 
-export function interpolateWithGlobalContext(
+export function interpolateWithGlobalContext<InterpolableType extends string | object>(
+  interpolableValue: InterpolableType,
+  fn: (path: string) => string
+): InterpolableType {
+  if (typeof interpolableValue === 'string') {
+    return interpolateStringWithGlobalContext(interpolableValue, fn) as InterpolableType;
+  } else {
+    return interpolateObjectWithGlobalContext(interpolableValue, fn) as InterpolableType;
+  }
+}
+
+export function interpolateStringWithGlobalContext(
   templateString: string,
   fn: (path: string) => string
 ): string {
   return interpolate(templateString, BUILD_GLOBAL_CONTEXT_EXPRESSION_REGEXP, fn);
+}
+
+export function interpolateObjectWithGlobalContext(
+  templateObject: object,
+  fn: (path: string) => string
+): object {
+  const templateObjectCopy = cloneDeep(templateObject);
+  Object.keys(templateObject).forEach((property) => {
+    const propertyValue = templateObject[property as keyof typeof templateObject];
+    if (['string', 'object'].includes(typeof propertyValue)) {
+      templateObjectCopy[property as keyof typeof templateObjectCopy] =
+        interpolateWithGlobalContext(propertyValue, fn);
+    }
+  });
+  return templateObjectCopy;
 }
 
 function interpolate(


### PR DESCRIPTION
# Why

https://linear.app/expo/issue/ENG-11196/create-custom-build-example-slacking-team-members
Previously you could interpolate string input with string/number/boolean/object values, but you couldn't interpolate object inputs, even if they had string values with interpolation templates. This change adds support for that.
We can use it for example for allowing users to send Slack messages in custom builds using the Slack Block Kit layout with dynamically injected build details.

# How

Made object interpolable, similar to strings. If the interpolated value is a string it is interpolated as before. If it is an object, it's properties are iterated over and interpolated recursively.

# Test Plan

Previous tests continue to pass, added another one for the case when an object input is interpolated