### PR TITLE
[build-tools] [ENG-11196] Support object input for Block Kit messages

### DIFF
--- a/packages/build-tools/src/steps/functions/__tests__/sendSlackMessage.test.ts
+++ b/packages/build-tools/src/steps/functions/__tests__/sendSlackMessage.test.ts
@@ -182,10 +182,7 @@ describe(createSendSlackMessageFunction, () => {
     await expect(buildStep.executeAsync()).rejects.toThrow(expectedError);
     expect(fetchMock).not.toHaveBeenCalled();
     expect(loggerInfoMock).toHaveBeenCalledTimes(1);
-    expect(loggerWarnMock).toHaveBeenCalledTimes(1);
-    expect(loggerWarnMock).toHaveBeenCalledWith(
-      'You need to provide either "message" input or "payload" input to specify the Slack message contents'
-    );
+    expect(loggerWarnMock).not.toHaveBeenCalled();
   });
 
   it('does not call the webhook when both message and payload are specified', async () => {
@@ -210,10 +207,7 @@ describe(createSendSlackMessageFunction, () => {
     await expect(buildStep.executeAsync()).rejects.toThrow(expectedError);
     expect(fetchMock).not.toHaveBeenCalled();
     expect(loggerInfoMock).toHaveBeenCalledTimes(1);
-    expect(loggerWarnMock).toHaveBeenCalledTimes(1);
-    expect(loggerWarnMock).toHaveBeenCalledWith(
-      'You cannot specify both "message" input and "payload" input - choose one for the Slack message contents'
-    );
+    expect(loggerWarnMock).not.toHaveBeenCalled();
   });
 
   it('catches error if thrown, logs warning and details in debug, throws new error', async () => {
@@ -245,10 +239,7 @@ describe(createSendSlackMessageFunction, () => {
     });
     expect(loggerInfoMock).toHaveBeenCalledTimes(2);
     expect(loggerInfoMock).toHaveBeenCalledWith('Sending Slack message');
-    expect(loggerWarnMock).toHaveBeenCalledTimes(1);
-    expect(loggerWarnMock).toHaveBeenCalledWith(
-      'Sending Slack message to webhook url "https://slack.hook.url" failed'
-    );
+    expect(loggerWarnMock).not.toHaveBeenCalled();
     expect(loggerDebugMock).toHaveBeenCalledWith(thrownError);
     expect(loggerErrorMock).toHaveBeenCalledWith({
       err: expectedError,
@@ -288,10 +279,7 @@ describe(createSendSlackMessageFunction, () => {
       });
       expect(loggerInfoMock).toHaveBeenCalledTimes(2);
       expect(loggerInfoMock).toHaveBeenCalledWith('Sending Slack message');
-      expect(loggerWarnMock).toHaveBeenCalledTimes(1);
-      expect(loggerWarnMock).toHaveBeenCalledWith(
-        `Sending Slack message to webhook url "https://slack.hook.url" failed with status ${statusCode}`
-      );
+      expect(loggerWarnMock).not.toHaveBeenCalled();
       expect(loggerDebugMock).toHaveBeenCalledWith(`${statusCode} - ${statusText}`);
       expect(loggerErrorMock).toHaveBeenCalledWith({
         err: expectedError,

--- a/packages/build-tools/src/steps/functions/sendSlackMessage.ts
+++ b/packages/build-tools/src/steps/functions/sendSlackMessage.ts
@@ -29,17 +29,11 @@ export function createSendSlackMessageFunction(): BuildFunction {
       const slackMessage = inputs.message.value as string;
       const slackPayload = inputs.payload.value as object;
       if (!slackMessage && !slackPayload) {
-        logger.warn(
-          'You need to provide either "message" input or "payload" input to specify the Slack message contents'
-        );
         throw new Error(
           'You need to provide either "message" input or "payload" input to specify the Slack message contents'
         );
       }
       if (slackMessage && slackPayload) {
-        logger.warn(
-          'You cannot specify both "message" input and "payload" input - choose one for the Slack message contents'
-        );
         throw new Error(
           'You cannot specify both "message" input and "payload" input - choose one for the Slack message contents'
         );
@@ -80,14 +74,10 @@ async function sendSlackMessageAsync({
       headers: { 'Content-Type': 'application/json' },
     });
   } catch (error) {
-    logger.warn(`Sending Slack message to webhook url "${slackHookUrl}" failed`);
     logger.debug(error);
     throw new Error(`Sending Slack message to webhook url "${slackHookUrl}" failed`);
   }
   if (!fetchResult.ok) {
-    logger.warn(
-      `Sending Slack message to webhook url "${slackHookUrl}" failed with status ${fetchResult.status}`
-    );
     logger.debug(`${fetchResult.status} - ${fetchResult.statusText}`);
     throw new Error(
       `Sending Slack message to webhook url "${slackHookUrl}" failed with status ${fetchResult.status}`

--- a/packages/build-tools/src/steps/functions/sendSlackMessage.ts
+++ b/packages/build-tools/src/steps/functions/sendSlackMessage.ts
@@ -11,7 +11,12 @@ export function createSendSlackMessageFunction(): BuildFunction {
       BuildStepInput.createProvider({
         id: 'message',
         allowedValueTypeName: BuildStepInputValueTypeName.STRING,
-        required: true,
+        required: false,
+      }),
+      BuildStepInput.createProvider({
+        id: 'payload',
+        allowedValueTypeName: BuildStepInputValueTypeName.JSON,
+        required: false,
       }),
       BuildStepInput.createProvider({
         id: 'slack_hook_url',
@@ -22,6 +27,23 @@ export function createSendSlackMessageFunction(): BuildFunction {
     fn: async (stepCtx, { inputs, env }) => {
       const { logger } = stepCtx;
       const slackMessage = inputs.message.value as string;
+      const slackPayload = inputs.payload.value as object;
+      if (!slackMessage && !slackPayload) {
+        logger.warn(
+          'You need to provide either "message" input or "payload" input to specify the Slack message contents'
+        );
+        throw new Error(
+          'You need to provide either "message" input or "payload" input to specify the Slack message contents'
+        );
+      }
+      if (slackMessage && slackPayload) {
+        logger.warn(
+          'You cannot specify both "message" input and "payload" input - choose one for the Slack message contents'
+        );
+        throw new Error(
+          'You cannot specify both "message" input and "payload" input - choose one for the Slack message contents'
+        );
+      }
       const slackHookUrl = (inputs.slack_hook_url.value as string) ?? env.SLACK_HOOK_URL;
       if (!slackHookUrl) {
         logger.warn(
@@ -31,7 +53,7 @@ export function createSendSlackMessageFunction(): BuildFunction {
           'Sending Slack message failed - provide input "slack_hook_url" or set "SLACK_HOOK_URL" secret'
         );
       }
-      await sendSlackMessageAsync({ logger, slackHookUrl, slackMessage });
+      await sendSlackMessageAsync({ logger, slackHookUrl, slackMessage, slackPayload });
     },
   });
 }
@@ -40,14 +62,16 @@ async function sendSlackMessageAsync({
   logger,
   slackHookUrl,
   slackMessage,
+  slackPayload,
 }: {
   logger: bunyan;
   slackHookUrl: string;
-  slackMessage: string;
+  slackMessage: string | undefined;
+  slackPayload: object | undefined;
 }): Promise<void> {
   logger.info('Sending Slack message');
 
-  const body = { text: slackMessage };
+  const body = slackPayload ? slackPayload : { text: slackMessage };
   let fetchResult: Response;
   try {
     fetchResult = await fetch(slackHookUrl, {


### PR DESCRIPTION
# Why

https://linear.app/expo/issue/ENG-11196/create-custom-build-example-slacking-team-members
Added support for object payload of slack messages for usage with the slack block kit
Depends on: https://github.com/expo/eas-build/pull/350

# How

Added a second input for the message contents - `payload`. It is mutually exclusive with `message` input, so providing both will result in an error, but one of them is required so providing none will also result in an error.
`payload` is a JSON type input and contains the Slack message in their Block Kit layout form.
With the recent changes in the `steps` package it is also possible to interpolate values in these message blocks for richer messages with build details

# Test Plan

Automatic tests pass
Tested manually
Config
<img width="1163" alt="Screenshot 2024-02-27 at 19 27 50" src="https://github.com/expo/eas-build/assets/2974455/0a5b851b-30ee-4627-aa3c-66a827ecfde2">
<img width="1163" alt="Screenshot 2024-02-27 at 19 27 56" src="https://github.com/expo/eas-build/assets/2974455/63abca68-10a0-45cb-a0d9-d93d575702de">
<img width="1163" alt="Screenshot 2024-02-27 at 19 28 02" src="https://github.com/expo/eas-build/assets/2974455/3e588cce-834d-48f2-883e-afb7c5843061">
Message
<img width="980" alt="Screenshot 2024-02-27 at 19 21 53" src="https://github.com/expo/eas-build/assets/2974455/f48ffa4c-a18d-4b71-8d52-aa48ca006f19">
