### PR TITLE
[build-tools] don't use `turtle-v2` in keychain name

### DIFF
--- a/packages/build-tools/src/ios/credentials/keychain.ts
+++ b/packages/build-tools/src/ios/credentials/keychain.ts
@@ -15,7 +15,7 @@ export default class Keychain<TJob extends Ios.Job> {
   private destroyed = false;
 
   constructor(private readonly ctx: BuildContext<TJob>) {
-    this.keychainPath = path.join(os.tmpdir(), `turtle-v2-${uuid()}.keychain`);
+    this.keychainPath = path.join(os.tmpdir(), `eas-build-${uuid()}.keychain`);
     this.keychainPassword = uuid();
   }
 
@@ -90,7 +90,7 @@ export default class Keychain<TJob extends Ios.Job> {
       i.slice(1, i.length - 1)
     );
     const turtleKeychainList = keychainList.filter((keychain) =>
-      /turtle-v2-[\w-]+\.keychain$/.exec(keychain)
+      /eas-build-[\w-]+\.keychain$/.exec(keychain)
     );
     for (const turtleKeychainPath of turtleKeychainList) {
       await this.destroy(turtleKeychainPath);

--- a/packages/build-tools/src/steps/utils/ios/credentials/keychain.ts
+++ b/packages/build-tools/src/steps/utils/ios/credentials/keychain.ts
@@ -14,7 +14,7 @@ export default class Keychain {
   private destroyed = false;
 
   constructor() {
-    this.keychainPath = path.join(os.tmpdir(), `turtle-v2-${uuid()}.keychain`);
+    this.keychainPath = path.join(os.tmpdir(), `eas-build-${uuid()}.keychain`);
     this.keychainPassword = uuid();
   }
 
@@ -93,7 +93,7 @@ export default class Keychain {
       i.slice(1, i.length - 1)
     );
     const turtleKeychainList = keychainList.filter((keychain) =>
-      /turtle-v2-[\w-]+\.keychain$/.exec(keychain)
+      /eas-build-[\w-]+\.keychain$/.exec(keychain)
     );
     for (const turtleKeychainPath of turtleKeychainList) {
       await this.destroy(logger, turtleKeychainPath);


### PR DESCRIPTION
# Why

https://exponent-internal.slack.com/archives/C02123T524U/p1709063772203869?thread_ts=1709001502.363679&cid=C02123T524U

# How

don't use `turtle-v2` in keychain name

# Test Plan

Tests
