### PR TITLE
[build-tools] Update expo-updates runtime version resolution

### DIFF
--- a/packages/build-tools/src/steps/utils/expoUpdates.ts
+++ b/packages/build-tools/src/steps/utils/expoUpdates.ts
@@ -1,7 +1,8 @@
 import { Job, Platform } from '@expo/eas-build-job';
 import { bunyan } from '@expo/logger';
 import { ExpoConfig } from '@expo/config';
-import { getRuntimeVersionNullableAsync } from '@expo/config-plugins/build/utils/Updates';
+
+import { resolveRuntimeVersionAsync } from '../../utils/resolveRuntimeVersionAsync';
 
 import {
   iosGetNativelyDefinedChannelAsync,
@@ -31,9 +32,14 @@ export async function configureEASUpdateAsync({
   appConfig: ExpoConfig;
 }): Promise<void> {
   const runtimeVersion =
-    inputs.channel ??
+    inputs.runtimeVersion ??
     job.version?.runtimeVersion ??
-    (await getRuntimeVersionNullableAsync(workingDirectory, appConfig, job.platform));
+    (await resolveRuntimeVersionAsync({
+      projectDir: workingDirectory,
+      exp: appConfig,
+      platform: job.platform,
+      logger,
+    }));
 
   const jobOrInputChannel = inputs.channel ?? job.updates?.channel;
 

--- a/packages/build-tools/src/utils/expoUpdates.ts
+++ b/packages/build-tools/src/utils/expoUpdates.ts
@@ -1,7 +1,6 @@
 import assert from 'assert';
 
 import { Platform, Job } from '@expo/eas-build-job';
-import { getRuntimeVersionNullableAsync } from '@expo/config-plugins/build/utils/Updates';
 import semver from 'semver';
 
 import {
@@ -23,6 +22,7 @@ import {
 import { BuildContext } from '../context';
 
 import getExpoUpdatesPackageVersionIfInstalledAsync from './getExpoUpdatesPackageVersionIfInstalledAsync';
+import { resolveRuntimeVersionAsync } from './resolveRuntimeVersionAsync';
 
 export async function setRuntimeVersionNativelyAsync(
   ctx: BuildContext<Job>,
@@ -148,11 +148,12 @@ export async function configureExpoUpdatesIfInstalledAsync(ctx: BuildContext<Job
 
   const appConfigRuntimeVersion =
     ctx.job.version?.runtimeVersion ??
-    (await getRuntimeVersionNullableAsync(
-      ctx.getReactNativeProjectDirectory(),
-      ctx.appConfig,
-      ctx.job.platform
-    ));
+    (await resolveRuntimeVersionAsync({
+      projectDir: ctx.getReactNativeProjectDirectory(),
+      exp: ctx.appConfig,
+      platform: ctx.job.platform,
+      logger: ctx.logger,
+    }));
   if (ctx.metadata?.runtimeVersion && ctx.metadata?.runtimeVersion !== appConfigRuntimeVersion) {
     ctx.markBuildPhaseHasWarnings();
     ctx.logger.warn(

--- a/packages/build-tools/src/utils/expoUpdatesCli.ts
+++ b/packages/build-tools/src/utils/expoUpdatesCli.ts
@@ -1,0 +1,34 @@
+import spawnAsync from '@expo/spawn-async';
+import resolveFrom, { silent as silentResolveFrom } from 'resolve-from';
+
+export class ExpoUpdatesCLIModuleNotFoundError extends Error {}
+export class ExpoUpdatesCLIInvalidCommandError extends Error {}
+
+export async function expoUpdatesCommandAsync(projectDir: string, args: string[]): Promise<string> {
+  let expoUpdatesCli;
+  try {
+    expoUpdatesCli =
+      silentResolveFrom(projectDir, 'expo-updates/bin/cli') ??
+      resolveFrom(projectDir, 'expo-updates/bin/cli.js');
+  } catch (e: any) {
+    if (e.code === 'MODULE_NOT_FOUND') {
+      throw new ExpoUpdatesCLIModuleNotFoundError(
+        `The \`expo-updates\` package was not found. Follow the installation directions at https://docs.expo.dev/bare/installing-expo-modules/`
+      );
+    }
+    throw e;
+  }
+
+  try {
+    return (await spawnAsync(expoUpdatesCli, args)).stdout;
+  } catch (e: any) {
+    if (e.stderr) {
+      if ((e.stderr as string).includes('Invalid command')) {
+        throw new ExpoUpdatesCLIInvalidCommandError(
+          `The command specified by ${args} was not valid in the \`expo-updates\` CLI.`
+        );
+      }
+    }
+    throw e;
+  }
+}

--- a/packages/build-tools/src/utils/resolveRuntimeVersionAsync.ts
+++ b/packages/build-tools/src/utils/resolveRuntimeVersionAsync.ts
@@ -1,0 +1,46 @@
+import { ExpoConfig } from '@expo/config';
+import { Updates } from '@expo/config-plugins';
+import { bunyan } from '@expo/logger';
+
+import {
+  ExpoUpdatesCLIInvalidCommandError,
+  ExpoUpdatesCLIModuleNotFoundError,
+  expoUpdatesCommandAsync,
+} from './expoUpdatesCli';
+
+export async function resolveRuntimeVersionAsync({
+  exp,
+  platform,
+  projectDir,
+  logger,
+}: {
+  exp: ExpoConfig;
+  platform: 'ios' | 'android';
+  projectDir: string;
+  logger: bunyan;
+}): Promise<string | null> {
+  try {
+    const resolvedRuntimeVersionJSONResult = await expoUpdatesCommandAsync(projectDir, [
+      'runtimeversion:resolve',
+      '--platform',
+      platform,
+    ]);
+    const runtimeVersionResult = JSON.parse(resolvedRuntimeVersionJSONResult);
+    if (runtimeVersionResult.fingerprintSources) {
+      logger.debug(`Resolved fingeprint runtime version for platform "${platform}". Sources:`);
+      logger.debug(runtimeVersionResult.fingerprintSources);
+    }
+    return runtimeVersionResult.runtimeVersion ?? null;
+  } catch (e: any) {
+    // if expo-updates is not installed, there's no need for a runtime version in the build
+    if (e instanceof ExpoUpdatesCLIModuleNotFoundError) {
+      return null;
+    } else if (e instanceof ExpoUpdatesCLIInvalidCommandError) {
+      // fall back to the previous behavior (using the @expo/config-plugins eas-cli dependency rather
+      // than the versioned @expo/config-plugins dependency in the project)
+      return await Updates.getRuntimeVersionNullableAsync(projectDir, exp, platform);
+    }
+
+    throw e;
+  }
+}


### PR DESCRIPTION
# Why

Same as https://github.com/expo/eas-cli/pull/2251 but for build-tools. This issue (using a single version of config plugins to execute updates related logic rather than the version of config plugins the app uses) seems to be pretty widespread.

This PR applies the same strategy: call into the app versioned expo-updates CLI to resolve runtime version (if possible, falling back to single version config plugins for now).

# How

Copy paste code.

# Test Plan

1. Follow instructions to do build locally using local copy of eas-cli and eas-build.
2. run `~/expo/run-with-local-eas-build.sh build --local`, see runtime version is consistently resolved.
