### PR TITLE
Revert "Revert "[build-tools] Update expo-updates runtime version resolution (#354)" (#355)"

### DIFF
--- a/packages/build-tools/src/steps/functions/configureEASUpdateIfInstalled.ts
+++ b/packages/build-tools/src/steps/functions/configureEASUpdateIfInstalled.ts
@@ -74,6 +74,7 @@ export function configureEASUpdateIfInstalledFunction(): BuildFunction {
       }
 
       await configureEASUpdateAsync({
+        expoUpdatesPackageVersion,
         job,
         workingDirectory: stepCtx.workingDirectory,
         logger: stepCtx.logger,

--- a/packages/build-tools/src/steps/utils/__tests__/expoUpdates.test.ts
+++ b/packages/build-tools/src/steps/utils/__tests__/expoUpdates.test.ts
@@ -22,6 +22,7 @@ describe(configureEASUpdateAsync, () => {
 
   it('aborts if updates.url (app config) is set but updates.channel (eas.json) is not', async () => {
     await configureEASUpdateAsync({
+      expoUpdatesPackageVersion: '1.0',
       job: { platform: Platform.IOS } as unknown as Job,
       workingDirectory: '/app',
       logger: createLogger({
@@ -43,6 +44,7 @@ describe(configureEASUpdateAsync, () => {
 
   it('configures for EAS if updates.channel (eas.json) and updates.url (app config) are set', async () => {
     await configureEASUpdateAsync({
+      expoUpdatesPackageVersion: '1.0',
       job: {
         updates: {
           channel: 'main',
@@ -69,6 +71,7 @@ describe(configureEASUpdateAsync, () => {
 
   it('configures for EAS if the updates.channel and releaseChannel are both set', async () => {
     await configureEASUpdateAsync({
+      expoUpdatesPackageVersion: '1.0',
       job: {
         updates: { channel: 'main' },
         releaseChannel: 'default',

--- a/packages/build-tools/src/steps/utils/expoUpdates.ts
+++ b/packages/build-tools/src/steps/utils/expoUpdates.ts
@@ -21,6 +21,7 @@ export async function configureEASUpdateAsync({
   logger,
   inputs,
   appConfig,
+  expoUpdatesPackageVersion,
 }: {
   job: Job;
   workingDirectory: string;
@@ -30,11 +31,13 @@ export async function configureEASUpdateAsync({
     channel?: string;
   };
   appConfig: ExpoConfig;
+  expoUpdatesPackageVersion: string;
 }): Promise<void> {
   const runtimeVersion =
     inputs.runtimeVersion ??
     job.version?.runtimeVersion ??
     (await resolveRuntimeVersionAsync({
+      expoUpdatesPackageVersion,
       projectDir: workingDirectory,
       exp: appConfig,
       platform: job.platform,

--- a/packages/build-tools/src/steps/utils/expoUpdates.ts
+++ b/packages/build-tools/src/steps/utils/expoUpdates.ts
@@ -1,7 +1,8 @@
 import { Job, Platform } from '@expo/eas-build-job';
 import { bunyan } from '@expo/logger';
 import { ExpoConfig } from '@expo/config';
-import { getRuntimeVersionNullableAsync } from '@expo/config-plugins/build/utils/Updates';
+
+import { resolveRuntimeVersionAsync } from '../../utils/resolveRuntimeVersionAsync';
 
 import {
   iosGetNativelyDefinedChannelAsync,
@@ -31,9 +32,14 @@ export async function configureEASUpdateAsync({
   appConfig: ExpoConfig;
 }): Promise<void> {
   const runtimeVersion =
-    inputs.channel ??
+    inputs.runtimeVersion ??
     job.version?.runtimeVersion ??
-    (await getRuntimeVersionNullableAsync(workingDirectory, appConfig, job.platform));
+    (await resolveRuntimeVersionAsync({
+      projectDir: workingDirectory,
+      exp: appConfig,
+      platform: job.platform,
+      logger,
+    }));
 
   const jobOrInputChannel = inputs.channel ?? job.updates?.channel;
 

--- a/packages/build-tools/src/utils/expoUpdates.ts
+++ b/packages/build-tools/src/utils/expoUpdates.ts
@@ -139,10 +139,10 @@ export async function configureEASExpoUpdatesAsync(ctx: BuildContext<Job>): Prom
 }
 
 export async function configureExpoUpdatesIfInstalledAsync(ctx: BuildContext<Job>): Promise<void> {
-  const expoUpdatesVersion = await getExpoUpdatesPackageVersionIfInstalledAsync(
+  const expoUpdatesPackageVersion = await getExpoUpdatesPackageVersionIfInstalledAsync(
     ctx.getReactNativeProjectDirectory()
   );
-  if (expoUpdatesVersion === null) {
+  if (expoUpdatesPackageVersion === null) {
     return;
   }
 
@@ -153,6 +153,7 @@ export async function configureExpoUpdatesIfInstalledAsync(ctx: BuildContext<Job
       exp: ctx.appConfig,
       platform: ctx.job.platform,
       logger: ctx.logger,
+      expoUpdatesPackageVersion,
     }));
   if (ctx.metadata?.runtimeVersion && ctx.metadata?.runtimeVersion !== appConfigRuntimeVersion) {
     ctx.markBuildPhaseHasWarnings();
@@ -200,7 +201,7 @@ export async function configureExpoUpdatesIfInstalledAsync(ctx: BuildContext<Job
         ctx.markBuildPhaseHasWarnings();
       }
     }
-  } else if (shouldConfigureClassicUpdatesReleaseChannelAsFallback(expoUpdatesVersion)) {
+  } else if (shouldConfigureClassicUpdatesReleaseChannelAsFallback(expoUpdatesPackageVersion)) {
     await configureClassicExpoUpdatesAsync(ctx);
   }
 
@@ -261,4 +262,15 @@ export function shouldConfigureClassicUpdatesReleaseChannelAsFallback(
   // Anything before SDK 50 should configure classic updates as a fallback. The first version
   // of the expo-updates package published for SDK 50 was 0.19.0
   return semver.lt(expoUpdatesPackageVersion, '0.19.0');
+}
+
+export function isModernExpoUpdatesCLIWithRuntimeVersionCommandSupported(
+  expoUpdatesPackageVersion: string
+): boolean {
+  if (expoUpdatesPackageVersion.includes('canary')) {
+    return true;
+  }
+
+  // TODO(wschurman): add semver check once we know the SDK51 version of expo-updates that supports this
+  return false;
 }

--- a/packages/build-tools/src/utils/expoUpdates.ts
+++ b/packages/build-tools/src/utils/expoUpdates.ts
@@ -1,7 +1,6 @@
 import assert from 'assert';
 
 import { Platform, Job } from '@expo/eas-build-job';
-import { getRuntimeVersionNullableAsync } from '@expo/config-plugins/build/utils/Updates';
 import semver from 'semver';
 
 import {
@@ -23,6 +22,7 @@ import {
 import { BuildContext } from '../context';
 
 import getExpoUpdatesPackageVersionIfInstalledAsync from './getExpoUpdatesPackageVersionIfInstalledAsync';
+import { resolveRuntimeVersionAsync } from './resolveRuntimeVersionAsync';
 
 export async function setRuntimeVersionNativelyAsync(
   ctx: BuildContext<Job>,
@@ -148,11 +148,12 @@ export async function configureExpoUpdatesIfInstalledAsync(ctx: BuildContext<Job
 
   const appConfigRuntimeVersion =
     ctx.job.version?.runtimeVersion ??
-    (await getRuntimeVersionNullableAsync(
-      ctx.getReactNativeProjectDirectory(),
-      ctx.appConfig,
-      ctx.job.platform
-    ));
+    (await resolveRuntimeVersionAsync({
+      projectDir: ctx.getReactNativeProjectDirectory(),
+      exp: ctx.appConfig,
+      platform: ctx.job.platform,
+      logger: ctx.logger,
+    }));
   if (ctx.metadata?.runtimeVersion && ctx.metadata?.runtimeVersion !== appConfigRuntimeVersion) {
     ctx.markBuildPhaseHasWarnings();
     ctx.logger.warn(

--- a/packages/build-tools/src/utils/expoUpdatesCli.ts
+++ b/packages/build-tools/src/utils/expoUpdatesCli.ts
@@ -22,8 +22,11 @@ export async function expoUpdatesCommandAsync(projectDir: string, args: string[]
   try {
     return (await spawnAsync(expoUpdatesCli, args)).stdout;
   } catch (e: any) {
-    if (e.stderr) {
-      if ((e.stderr as string).includes('Invalid command')) {
+    if (e.stderr && typeof e.stderr === 'string') {
+      if (
+        e.stderr.includes('Invalid command') || // SDK 51+
+        e.stderr.includes('commands[command] is not a function') // SDK <= 50
+      ) {
         throw new ExpoUpdatesCLIInvalidCommandError(
           `The command specified by ${args} was not valid in the \`expo-updates\` CLI.`
         );

--- a/packages/build-tools/src/utils/expoUpdatesCli.ts
+++ b/packages/build-tools/src/utils/expoUpdatesCli.ts
@@ -22,15 +22,10 @@ export async function expoUpdatesCommandAsync(projectDir: string, args: string[]
   try {
     return (await spawnAsync(expoUpdatesCli, args)).stdout;
   } catch (e: any) {
-    if (e.stderr && typeof e.stderr === 'string') {
-      if (
-        e.stderr.includes('Invalid command') || // SDK 51+
-        e.stderr.includes('commands[command] is not a function') // SDK <= 50
-      ) {
-        throw new ExpoUpdatesCLIInvalidCommandError(
-          `The command specified by ${args} was not valid in the \`expo-updates\` CLI.`
-        );
-      }
+    if (e.stderr && typeof e.stderr === 'string' && e.stderr.includes('Invalid command')) {
+      throw new ExpoUpdatesCLIInvalidCommandError(
+        `The command specified by ${args} was not valid in the \`expo-updates\` CLI.`
+      );
     }
     throw e;
   }

--- a/packages/build-tools/src/utils/expoUpdatesCli.ts
+++ b/packages/build-tools/src/utils/expoUpdatesCli.ts
@@ -1,0 +1,34 @@
+import spawnAsync from '@expo/spawn-async';
+import resolveFrom, { silent as silentResolveFrom } from 'resolve-from';
+
+export class ExpoUpdatesCLIModuleNotFoundError extends Error {}
+export class ExpoUpdatesCLIInvalidCommandError extends Error {}
+
+export async function expoUpdatesCommandAsync(projectDir: string, args: string[]): Promise<string> {
+  let expoUpdatesCli;
+  try {
+    expoUpdatesCli =
+      silentResolveFrom(projectDir, 'expo-updates/bin/cli') ??
+      resolveFrom(projectDir, 'expo-updates/bin/cli.js');
+  } catch (e: any) {
+    if (e.code === 'MODULE_NOT_FOUND') {
+      throw new ExpoUpdatesCLIModuleNotFoundError(
+        `The \`expo-updates\` package was not found. Follow the installation directions at https://docs.expo.dev/bare/installing-expo-modules/`
+      );
+    }
+    throw e;
+  }
+
+  try {
+    return (await spawnAsync(expoUpdatesCli, args)).stdout;
+  } catch (e: any) {
+    if (e.stderr) {
+      if ((e.stderr as string).includes('Invalid command')) {
+        throw new ExpoUpdatesCLIInvalidCommandError(
+          `The command specified by ${args} was not valid in the \`expo-updates\` CLI.`
+        );
+      }
+    }
+    throw e;
+  }
+}

--- a/packages/build-tools/src/utils/resolveRuntimeVersionAsync.ts
+++ b/packages/build-tools/src/utils/resolveRuntimeVersionAsync.ts
@@ -1,0 +1,46 @@
+import { ExpoConfig } from '@expo/config';
+import { Updates } from '@expo/config-plugins';
+import { bunyan } from '@expo/logger';
+
+import {
+  ExpoUpdatesCLIInvalidCommandError,
+  ExpoUpdatesCLIModuleNotFoundError,
+  expoUpdatesCommandAsync,
+} from './expoUpdatesCli';
+
+export async function resolveRuntimeVersionAsync({
+  exp,
+  platform,
+  projectDir,
+  logger,
+}: {
+  exp: ExpoConfig;
+  platform: 'ios' | 'android';
+  projectDir: string;
+  logger: bunyan;
+}): Promise<string | null> {
+  try {
+    const resolvedRuntimeVersionJSONResult = await expoUpdatesCommandAsync(projectDir, [
+      'runtimeversion:resolve',
+      '--platform',
+      platform,
+    ]);
+    const runtimeVersionResult = JSON.parse(resolvedRuntimeVersionJSONResult);
+    if (runtimeVersionResult.fingerprintSources) {
+      logger.debug(`Resolved fingeprint runtime version for platform "${platform}". Sources:`);
+      logger.debug(runtimeVersionResult.fingerprintSources);
+    }
+    return runtimeVersionResult.runtimeVersion ?? null;
+  } catch (e: any) {
+    // if expo-updates is not installed, there's no need for a runtime version in the build
+    if (e instanceof ExpoUpdatesCLIModuleNotFoundError) {
+      return null;
+    } else if (e instanceof ExpoUpdatesCLIInvalidCommandError) {
+      // fall back to the previous behavior (using the @expo/config-plugins eas-cli dependency rather
+      // than the versioned @expo/config-plugins dependency in the project)
+      return await Updates.getRuntimeVersionNullableAsync(projectDir, exp, platform);
+    }
+
+    throw e;
+  }
+}

--- a/packages/build-tools/src/utils/resolveRuntimeVersionAsync.ts
+++ b/packages/build-tools/src/utils/resolveRuntimeVersionAsync.ts
@@ -2,23 +2,28 @@ import { ExpoConfig } from '@expo/config';
 import { Updates } from '@expo/config-plugins';
 import { bunyan } from '@expo/logger';
 
-import {
-  ExpoUpdatesCLIInvalidCommandError,
-  ExpoUpdatesCLIModuleNotFoundError,
-  expoUpdatesCommandAsync,
-} from './expoUpdatesCli';
+import { ExpoUpdatesCLIModuleNotFoundError, expoUpdatesCommandAsync } from './expoUpdatesCli';
+import { isModernExpoUpdatesCLIWithRuntimeVersionCommandSupported } from './expoUpdates';
 
 export async function resolveRuntimeVersionAsync({
   exp,
   platform,
   projectDir,
   logger,
+  expoUpdatesPackageVersion,
 }: {
   exp: ExpoConfig;
   platform: 'ios' | 'android';
   projectDir: string;
   logger: bunyan;
+  expoUpdatesPackageVersion: string;
 }): Promise<string | null> {
+  if (!isModernExpoUpdatesCLIWithRuntimeVersionCommandSupported(expoUpdatesPackageVersion)) {
+    // fall back to the previous behavior (using the @expo/config-plugins eas-cli dependency rather
+    // than the versioned @expo/config-plugins dependency in the project)
+    return await Updates.getRuntimeVersionNullableAsync(projectDir, exp, platform);
+  }
+
   try {
     const resolvedRuntimeVersionJSONResult = await expoUpdatesCommandAsync(projectDir, [
       'runtimeversion:resolve',
@@ -35,12 +40,7 @@ export async function resolveRuntimeVersionAsync({
     // if expo-updates is not installed, there's no need for a runtime version in the build
     if (e instanceof ExpoUpdatesCLIModuleNotFoundError) {
       return null;
-    } else if (e instanceof ExpoUpdatesCLIInvalidCommandError) {
-      // fall back to the previous behavior (using the @expo/config-plugins eas-cli dependency rather
-      // than the versioned @expo/config-plugins dependency in the project)
-      return await Updates.getRuntimeVersionNullableAsync(projectDir, exp, platform);
     }
-
     throw e;
   }
 }


### PR DESCRIPTION
# Why

This reverts commit https://github.com/expo/eas-build/commit/39e063ac5cb25db8809d86110067b3608911f3f3.

Then, this applies a fix on top of it to support older SDKs.

# How

Revert, re-test with SDK 45-50.

# Test Plan

```
yarn create expo-app kjdasjkds555hjkdashjk50 --template blank@50
eas init
eas update:configure
~/expo/run-with-local-eas-build.sh build --local
```

(the last step uses a local eas-cli to patch the revert in that repo: https://github.com/expo/eas-cli/pull/2265)
