### PR TITLE
[ENG-11416][eas-build-job] add github build trigger options to job object

### DIFF
--- a/packages/eas-build-job/src/__tests__/android.test.ts
+++ b/packages/eas-build-job/src/__tests__/android.test.ts
@@ -244,7 +244,7 @@ describe('Android.JobSchema', () => {
 
   test('can set github trigger options', () => {
     const job = {
-      mode: BuildMode.CUSTOM,
+      mode: BuildMode.BUILD,
       type: Workflow.UNKNOWN,
       platform: Platform.ANDROID,
       projectArchive: {
@@ -256,6 +256,7 @@ describe('Android.JobSchema', () => {
         autoSubmit: true,
         submitProfile: 'default',
       },
+      secrets,
     };
     const { value, error } = Android.JobSchema.validate(job, joiOptions);
     expect(value).toMatchObject(job);

--- a/packages/eas-build-job/src/__tests__/android.test.ts
+++ b/packages/eas-build-job/src/__tests__/android.test.ts
@@ -241,4 +241,24 @@ describe('Android.JobSchema', () => {
     expect(value).toMatchObject(customBuildJob);
     expect(error).toBeFalsy();
   });
+
+  test('can set github trigger options', () => {
+    const job = {
+      mode: BuildMode.CUSTOM,
+      type: Workflow.UNKNOWN,
+      platform: Platform.ANDROID,
+      projectArchive: {
+        type: ArchiveSourceType.URL,
+        url: 'https://expo.dev/builds/123',
+      },
+      projectRootDirectory: '.',
+      githubTriggerOptions: {
+        autoSubmit: true,
+        submitProfile: 'default',
+      },
+    };
+    const { value, error } = Android.JobSchema.validate(job, joiOptions);
+    expect(value).toMatchObject(job);
+    expect(error).toBeFalsy();
+  });
 });

--- a/packages/eas-build-job/src/__tests__/ios.test.ts
+++ b/packages/eas-build-job/src/__tests__/ios.test.ts
@@ -238,9 +238,9 @@ describe('Ios.JobSchema', () => {
 
   test('can set github trigger options', () => {
     const job = {
-      mode: BuildMode.CUSTOM,
+      mode: BuildMode.BUILD,
       type: Workflow.UNKNOWN,
-      platform: Platform.ANDROID,
+      platform: Platform.IOS,
       projectArchive: {
         type: ArchiveSourceType.URL,
         url: 'https://expo.dev/builds/123',
@@ -249,6 +249,9 @@ describe('Ios.JobSchema', () => {
       githubTriggerOptions: {
         autoSubmit: true,
         submitProfile: 'default',
+      },
+      secrets: {
+        buildCredentials,
       },
     };
     const { value, error } = Ios.JobSchema.validate(job, joiOptions);

--- a/packages/eas-build-job/src/__tests__/ios.test.ts
+++ b/packages/eas-build-job/src/__tests__/ios.test.ts
@@ -235,4 +235,24 @@ describe('Ios.JobSchema', () => {
       '"value" contains a conflict between optional exclusive peers [releaseChannel, updates.channel]'
     );
   });
+
+  test('can set github trigger options', () => {
+    const job = {
+      mode: BuildMode.CUSTOM,
+      type: Workflow.UNKNOWN,
+      platform: Platform.ANDROID,
+      projectArchive: {
+        type: ArchiveSourceType.URL,
+        url: 'https://expo.dev/builds/123',
+      },
+      projectRootDirectory: '.',
+      githubTriggerOptions: {
+        autoSubmit: true,
+        submitProfile: 'default',
+      },
+    };
+    const { value, error } = Ios.JobSchema.validate(job, joiOptions);
+    expect(value).toMatchObject(job);
+    expect(error).toBeFalsy();
+  });
 });

--- a/packages/eas-build-job/src/android.ts
+++ b/packages/eas-build-job/src/android.ts
@@ -107,6 +107,10 @@ export interface Job {
     prebuildCommand?: string;
   };
   expoBuildUrl?: string;
+  gitHubTriggerOptions?: {
+    autoSubmit: boolean;
+    submitProfile?: string;
+  };
 }
 
 const SecretsSchema = Joi.object({
@@ -166,4 +170,8 @@ export const JobSchema = Joi.object({
     prebuildCommand: Joi.string(),
   }),
   expoBuildUrl: Joi.string().uri().optional(),
+  githubTriggerOptions: Joi.object({
+    autoSubmit: Joi.boolean().default(false),
+    submitProfile: Joi.string(),
+  }),
 }).oxor('releaseChannel', 'updates.channel');

--- a/packages/eas-build-job/src/android.ts
+++ b/packages/eas-build-job/src/android.ts
@@ -107,7 +107,7 @@ export interface Job {
     prebuildCommand?: string;
   };
   expoBuildUrl?: string;
-  gitHubTriggerOptions?: {
+  githubTriggerOptions?: {
     autoSubmit: boolean;
     submitProfile?: string;
   };

--- a/packages/eas-build-job/src/ios.ts
+++ b/packages/eas-build-job/src/ios.ts
@@ -121,7 +121,7 @@ export interface Job {
     prebuildCommand?: string;
   };
   expoBuildUrl?: string;
-  gitHubTriggerOptions?: {
+  githubTriggerOptions?: {
     autoSubmit: boolean;
     submitProfile?: string;
   };

--- a/packages/eas-build-job/src/ios.ts
+++ b/packages/eas-build-job/src/ios.ts
@@ -121,6 +121,10 @@ export interface Job {
     prebuildCommand?: string;
   };
   expoBuildUrl?: string;
+  gitHubTriggerOptions?: {
+    autoSubmit: boolean;
+    submitProfile?: string;
+  };
 }
 
 const SecretsSchema = Joi.object({
@@ -202,4 +206,8 @@ export const JobSchema = Joi.object({
     prebuildCommand: Joi.string(),
   }),
   expoBuildUrl: Joi.string().uri().optional(),
+  githubTriggerOptions: Joi.object({
+    autoSubmit: Joi.boolean().default(false),
+    submitProfile: Joi.string(),
+  }),
 }).oxor('releaseChannel', 'updates.channel');


### PR DESCRIPTION
# Why

Companion to https://github.com/expo/eas-cli/pull/2271

We need this information so we know whether to use the `--auto-submit` flag in Turtle worker when running `eas build:internal`. This information should be provided by WWW.

# How

Add `githubTriggerOptions` to the job object

# Test Plan

Tests
