### PR TITLE
[ENG-11416][build-tools] run `eas build:internal --auto-submit` based on github trigger options data

### DIFF
--- a/packages/build-tools/src/common/easBuildInternal.ts
+++ b/packages/build-tools/src/common/easBuildInternal.ts
@@ -33,11 +33,28 @@ export async function runEasBuildInternalAsync<TJob extends Job>({
   newMetadata: Metadata;
 }> {
   const { cmd, args, extraEnv } = await resolveEasCommandPrefixAndEnvAsync();
-  const { buildProfile } = job;
+  const { buildProfile, gitHubTriggerOptions } = job;
   assert(buildProfile, 'build profile is missing in a build from git-based integration.');
+
+  const autoSubmitArgs = [];
+  if (gitHubTriggerOptions?.submitProfile) {
+    autoSubmitArgs.push('--auto-submit-with-profile');
+    autoSubmitArgs.push(gitHubTriggerOptions.submitProfile);
+  } else if (gitHubTriggerOptions?.autoSubmit) {
+    autoSubmitArgs.push('--auto-submit');
+  }
+
   const result = await spawn(
     cmd,
-    [...args, 'build:internal', '--platform', job.platform, '--profile', buildProfile],
+    [
+      ...args,
+      'build:internal',
+      '--platform',
+      job.platform,
+      '--profile',
+      buildProfile,
+      ...autoSubmitArgs,
+    ],
     {
       cwd,
       env: {

--- a/packages/build-tools/src/common/easBuildInternal.ts
+++ b/packages/build-tools/src/common/easBuildInternal.ts
@@ -33,14 +33,14 @@ export async function runEasBuildInternalAsync<TJob extends Job>({
   newMetadata: Metadata;
 }> {
   const { cmd, args, extraEnv } = await resolveEasCommandPrefixAndEnvAsync();
-  const { buildProfile, gitHubTriggerOptions } = job;
+  const { buildProfile, githubTriggerOptions } = job;
   assert(buildProfile, 'build profile is missing in a build from git-based integration.');
 
   const autoSubmitArgs = [];
-  if (gitHubTriggerOptions?.submitProfile) {
+  if (githubTriggerOptions?.submitProfile) {
     autoSubmitArgs.push('--auto-submit-with-profile');
-    autoSubmitArgs.push(gitHubTriggerOptions.submitProfile);
-  } else if (gitHubTriggerOptions?.autoSubmit) {
+    autoSubmitArgs.push(githubTriggerOptions.submitProfile);
+  } else if (githubTriggerOptions?.autoSubmit) {
     autoSubmitArgs.push('--auto-submit');
   }
 


### PR DESCRIPTION
# Why

Companion to https://github.com/expo/eas-build/pull/357

Use `githubTriggerOptions` data to run the `eas build:internal --auto-submit` command when needed.

# How

Use `githubTriggerOptions` data to run the `eas build:internal --auto-submit` command when needed.

# Test Plan

TBA
