### PR TITLE
[steps] [Issue 2261] Fix multiline text messages

### DIFF
--- a/packages/build-tools/src/steps/functions/__tests__/sendSlackMessage.test.ts
+++ b/packages/build-tools/src/steps/functions/__tests__/sendSlackMessage.test.ts
@@ -72,7 +72,34 @@ describe(createSendSlackMessageFunction, () => {
     await buildStep.executeAsync();
     expect(fetchMock).toHaveBeenCalledWith('https://slack.hook.url', {
       method: 'POST',
-      body: '{"text":"Line 1\nLine 2\n\nLine 3"}',
+      body: '{"text":"Line 1\\nLine 2\\n\\nLine 3"}',
+      headers: { 'Content-Type': 'application/json' },
+    });
+    expect(loggerInfoMock).toHaveBeenCalledTimes(4);
+    expect(loggerInfoMock).toHaveBeenCalledWith('Sending Slack message');
+    expect(loggerInfoMock).toHaveBeenCalledWith('Slack message sent successfully');
+    expect(loggerWarnMock).not.toHaveBeenCalled();
+  });
+
+  it('calls the webhook when using multiline plain text input with doubly escaped new lines', async () => {
+    fetchMock.mockImplementation(() => Promise.resolve({ status: 200, ok: true } as Response));
+    const buildStep = sendSlackMessage.createBuildStepFromFunctionCall(
+      createGlobalContextMock({}),
+      {
+        callInputs: {
+          message: 'Line 1\\nLine 2\\n\\nLine 3',
+        },
+        env: {
+          SLACK_HOOK_URL: 'https://slack.hook.url',
+        },
+        id: sendSlackMessage.id,
+      }
+    );
+    mockLogger(buildStep.ctx.logger);
+    await buildStep.executeAsync();
+    expect(fetchMock).toHaveBeenCalledWith('https://slack.hook.url', {
+      method: 'POST',
+      body: '{"text":"Line 1\\nLine 2\\n\\nLine 3"}',
       headers: { 'Content-Type': 'application/json' },
     });
     expect(loggerInfoMock).toHaveBeenCalledTimes(4);

--- a/packages/build-tools/src/steps/functions/sendSlackMessage.ts
+++ b/packages/build-tools/src/steps/functions/sendSlackMessage.ts
@@ -65,8 +65,7 @@ async function sendSlackMessageAsync({
 }): Promise<void> {
   logger.info('Sending Slack message');
 
-  let body = slackPayload ? slackPayload : { text: slackMessage };
-  body = fixEscapeCharactersInObject(body);
+  const body = slackPayload ? slackPayload : { text: slackMessage };
   let fetchResult: Response;
   try {
     fetchResult = await fetch(slackHookUrl, {
@@ -85,16 +84,4 @@ async function sendSlackMessageAsync({
     );
   }
   logger.info('Slack message sent successfully');
-}
-
-function fixEscapeCharactersInObject(body: Record<string, any>): Record<string, any> {
-  for (const property of Object.keys(body)) {
-    if (typeof body[property] === 'string') {
-      body[property] = body[property].replace(/\\n/g, '\n');
-    } else if (typeof body[property] === 'object') {
-      const fixedObject = fixEscapeCharactersInObject(body[property]);
-      body[property] = fixedObject;
-    }
-  }
-  return body;
 }

--- a/packages/build-tools/src/steps/functions/sendSlackMessage.ts
+++ b/packages/build-tools/src/steps/functions/sendSlackMessage.ts
@@ -70,7 +70,7 @@ async function sendSlackMessageAsync({
   try {
     fetchResult = await fetch(slackHookUrl, {
       method: 'POST',
-      body: JSON.stringify(body),
+      body: JSON.stringify(body).replace(/\\n/g, '\n'),
       headers: { 'Content-Type': 'application/json' },
     });
   } catch (error) {

--- a/packages/steps/src/__tests__/BuildStepInput-test.ts
+++ b/packages/steps/src/__tests__/BuildStepInput-test.ts
@@ -120,6 +120,42 @@ describe(BuildStepInput, () => {
     expect(i.value).toEqual('linux');
   });
 
+  test('context value string with newline characters', () => {
+    const ctx = createGlobalContextMock({
+      staticContextContent: {
+        foo: {
+          bar: 'Line 1\nLine 2\n\nLine 3',
+        },
+      } as unknown as BuildStaticContext,
+    });
+    const i = new BuildStepInput(ctx, {
+      id: 'foo',
+      stepDisplayName: BuildStep.getDisplayName({ id: 'test1' }),
+      defaultValue: '${ eas.foo.bar }',
+      required: true,
+      allowedValueTypeName: BuildStepInputValueTypeName.STRING,
+    });
+    expect(i.value).toEqual('Line 1\nLine 2\n\nLine 3');
+  });
+
+  test('context value string with doubly escaped newline characters', () => {
+    const ctx = createGlobalContextMock({
+      staticContextContent: {
+        foo: {
+          bar: 'Line 1\\nLine 2\\n\\nLine 3',
+        },
+      } as unknown as BuildStaticContext,
+    });
+    const i = new BuildStepInput(ctx, {
+      id: 'foo',
+      stepDisplayName: BuildStep.getDisplayName({ id: 'test1' }),
+      defaultValue: '${ eas.foo.bar }',
+      required: true,
+      allowedValueTypeName: BuildStepInputValueTypeName.STRING,
+    });
+    expect(i.value).toEqual('Line 1\nLine 2\n\nLine 3');
+  });
+
   test('context value number', () => {
     const ctx = createGlobalContextMock({
       staticContextContent: {
@@ -317,6 +353,66 @@ describe(BuildStepInput, () => {
         bazfoo: 'bazfoo',
         bazbar: 'in_val_1',
         bazbaz: ['bazbaz', 'val_1', 'in_val_1'],
+      },
+    });
+  });
+
+  test('context values in an object with newline characters', () => {
+    const ctx = createGlobalContextMock({
+      staticContextContent: {
+        context_val_1: 'Line 1\nLine 2\n\nLine 3',
+      } as unknown as BuildStaticContext,
+    });
+    const i = new BuildStepInput(ctx, {
+      id: 'foo',
+      stepDisplayName: BuildStep.getDisplayName({ id: 'test1' }),
+      required: true,
+      allowedValueTypeName: BuildStepInputValueTypeName.JSON,
+    });
+    i.set({
+      foo: 'foo',
+      bar: '${ eas.context_val_1 }',
+      baz: {
+        bazfoo: 'bazfoo',
+        bazbaz: ['bazbaz', '${ eas.context_val_1 }'],
+      },
+    });
+    expect(i.value).toEqual({
+      foo: 'foo',
+      bar: 'Line 1\nLine 2\n\nLine 3',
+      baz: {
+        bazfoo: 'bazfoo',
+        bazbaz: ['bazbaz', 'Line 1\nLine 2\n\nLine 3'],
+      },
+    });
+  });
+
+  test('context values in an object with doubly escaped newline characters', () => {
+    const ctx = createGlobalContextMock({
+      staticContextContent: {
+        context_val_1: 'Line 1\\nLine 2\\n\\nLine 3',
+      } as unknown as BuildStaticContext,
+    });
+    const i = new BuildStepInput(ctx, {
+      id: 'foo',
+      stepDisplayName: BuildStep.getDisplayName({ id: 'test1' }),
+      required: true,
+      allowedValueTypeName: BuildStepInputValueTypeName.JSON,
+    });
+    i.set({
+      foo: 'foo',
+      bar: '${ eas.context_val_1 }',
+      baz: {
+        bazfoo: 'bazfoo',
+        bazbaz: ['bazbaz', '${ eas.context_val_1 }'],
+      },
+    });
+    expect(i.value).toEqual({
+      foo: 'foo',
+      bar: 'Line 1\nLine 2\n\nLine 3',
+      baz: {
+        bazfoo: 'bazfoo',
+        bazbaz: ['bazbaz', 'Line 1\nLine 2\n\nLine 3'],
       },
     });
   });


### PR DESCRIPTION
# Why

https://github.com/expo/eas-cli/issues/2261
New line characters for messages dynamically generated in previous steps were incorrectly escaped, which resulted in incorrect formatting of the message received over Slack

# How

Added a function that fixes incorrect escape characters when getting values from all inputs

# Test Plan

Automated tests pass
Added more tests to cover multiline input as well as incorrectly escaped multiline input based on manual tests
Tested manually
|Config|
|-|
|![Screenshot 2024-03-08 at 13 23 17](https://github.com/expo/eas-build/assets/2974455/1ae37db8-11a2-4bd1-b0fe-e65c0a4bcc83)|

|Before|After|
|-|-|
|<img width="1026" alt="Screenshot 2024-03-08 at 13 22 45" src="https://github.com/expo/eas-build/assets/2974455/fafa04a8-83db-4288-9710-4233f7e6599f">|<img width="1026" alt="Screenshot 2024-03-08 at 13 22 53" src="https://github.com/expo/eas-build/assets/2974455/ad72dda1-c54b-4d26-b9f6-2d0b27d5f49a">|
