### PR TITLE
[build-tools] Upload Xcode logs for custom builds behind the scenes

### DIFF
--- a/packages/build-tools/src/__mocks__/fs.ts
+++ b/packages/build-tools/src/__mocks__/fs.ts
@@ -1,6 +1,6 @@
 import { fs } from 'memfs';
 
-fs.mkdirSync('/tmp');
+fs.mkdirSync('/tmp', { recursive: true });
 if (process.env.TMPDIR) {
   fs.mkdirSync(process.env.TMPDIR, { recursive: true });
 }

--- a/packages/build-tools/src/__mocks__/fs/promises.ts
+++ b/packages/build-tools/src/__mocks__/fs/promises.ts
@@ -1,0 +1,15 @@
+import { fs } from 'memfs';
+
+fs.mkdirSync('/tmp', { recursive: true });
+if (process.env.TMPDIR) {
+  fs.mkdirSync(process.env.TMPDIR, { recursive: true });
+}
+
+const fsRealpath = fs.realpath;
+(fsRealpath as any).native = fsRealpath;
+
+const fsRm = (path: string, options: object): Promise<void> => {
+  return fs.promises.rm(path, options);
+};
+
+module.exports = { ...fs.promises, realpath: fsRealpath, rm: fsRm };

--- a/packages/build-tools/src/builders/__tests__/custom.test.ts
+++ b/packages/build-tools/src/builders/__tests__/custom.test.ts
@@ -1,0 +1,67 @@
+import { Job } from '@expo/eas-build-job';
+import { vol } from 'memfs';
+
+import { runCustomBuildAsync } from '../custom';
+import { BuildContext } from '../../context';
+import { createMockLogger } from '../../__tests__/utils/logger';
+import { createTestIosJob } from '../../__tests__/utils/job';
+import { findAndUploadXcodeBuildLogsAsync } from '../../ios/xcodeBuildLogs';
+
+jest.mock('fs');
+jest.mock('fs/promises');
+jest.mock('../../common/projectSources');
+jest.mock('../../ios/xcodeBuildLogs');
+
+const findAndUploadXcodeBuildLogsAsyncMock = jest.mocked(findAndUploadXcodeBuildLogsAsync);
+
+afterEach(() => {
+  vol.reset();
+});
+
+describe(runCustomBuildAsync, () => {
+  let ctx: BuildContext<Job>;
+
+  beforeEach(() => {
+    const job = createTestIosJob();
+    vol.mkdirSync('/workingdir/env', { recursive: true });
+    vol.mkdirSync('/workingdir/temporary-custom-build', { recursive: true });
+    vol.fromJSON(
+      {
+        'test.yaml': `
+          build:
+            steps:
+              - eas/checkout
+          `,
+      },
+      '/workingdir/temporary-custom-build'
+    );
+
+    ctx = new BuildContext(
+      {
+        ...job,
+        customBuildConfig: {
+          path: 'test.yaml',
+        },
+      },
+      {
+        workingdir: '/workingdir',
+        logBuffer: { getLogs: () => [], getPhaseLogs: () => [] },
+        logger: createMockLogger(),
+        env: {},
+        runGlobalExpoCliCommand: jest.fn(),
+        uploadArtifact: jest.fn(),
+      }
+    );
+  });
+
+  it('calls findAndUploadXcodeBuildLogsAsync in an iOS job if its artifacts is empty', async () => {
+    await runCustomBuildAsync(ctx);
+    expect(findAndUploadXcodeBuildLogsAsyncMock).toHaveBeenCalled();
+  });
+
+  it('does not call findAndUploadXcodeBuildLogsAsync in an iOS job if artifacts is already present', async () => {
+    ctx.artifacts.XCODE_BUILD_LOGS = 'uploaded';
+    await runCustomBuildAsync(ctx);
+    expect(findAndUploadXcodeBuildLogsAsyncMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/build-tools/src/steps/functions/__tests__/findAndUploadBuildArtifacts.test.ts
+++ b/packages/build-tools/src/steps/functions/__tests__/findAndUploadBuildArtifacts.test.ts
@@ -1,0 +1,91 @@
+import { ManagedArtifactType } from '@expo/eas-build-job';
+import { vol } from 'memfs';
+
+import { createGlobalContextMock } from '../../../__tests__/utils/context';
+import { createTestIosJob } from '../../../__tests__/utils/job';
+import { createMockLogger } from '../../../__tests__/utils/logger';
+import { BuildContext } from '../../../context';
+import { CustomBuildContext } from '../../../customBuildContext';
+import { createFindAndUploadBuildArtifactsBuildFunction } from '../findAndUploadBuildArtifacts';
+
+jest.mock('fs');
+
+describe(createFindAndUploadBuildArtifactsBuildFunction, () => {
+  const contextUploadArtifact = jest.fn();
+  const ctx = new BuildContext(createTestIosJob({}), {
+    env: {},
+    logBuffer: { getLogs: () => [], getPhaseLogs: () => [] },
+    logger: createMockLogger(),
+    uploadArtifact: contextUploadArtifact,
+    workingdir: '',
+    runGlobalExpoCliCommand: jest.fn(),
+  });
+  const customContext = new CustomBuildContext(ctx);
+  const findAndUploadBuildArtifacts = createFindAndUploadBuildArtifactsBuildFunction(customContext);
+
+  it('throws first error', async () => {
+    const globalContext = createGlobalContextMock({});
+    const buildStep = findAndUploadBuildArtifacts.createBuildStepFromFunctionCall(
+      globalContext,
+      {}
+    );
+
+    await expect(buildStep.executeAsync()).rejects.toThrow('There are no files matching pattern');
+  });
+
+  it('does not throw error if it uploads artifact', async () => {
+    const globalContext = createGlobalContextMock({});
+    vol.fromJSON(
+      {
+        'ios/build/test.ipa': '',
+      },
+      globalContext.defaultWorkingDirectory
+    );
+    const buildStep = findAndUploadBuildArtifacts.createBuildStepFromFunctionCall(
+      globalContext,
+      {}
+    );
+
+    await expect(buildStep.executeAsync()).resolves.not.toThrow();
+  });
+
+  it('throws build artifacts error', async () => {
+    const globalContext = createGlobalContextMock({});
+    ctx.job.buildArtifactPaths = ['worker.log'];
+    vol.fromJSON(
+      {
+        'ios/build/test.ipa': '',
+      },
+      globalContext.defaultWorkingDirectory
+    );
+    const buildStep = findAndUploadBuildArtifacts.createBuildStepFromFunctionCall(
+      globalContext,
+      {}
+    );
+
+    await expect(buildStep.executeAsync()).rejects.toThrow('No such file or directory worker.log');
+  });
+
+  it('upload build artifacts and throws application archive error', async () => {
+    const globalContext = createGlobalContextMock({});
+    ctx.job.buildArtifactPaths = ['worker.log'];
+    vol.fromJSON(
+      {
+        'worker.log': '',
+      },
+      globalContext.defaultWorkingDirectory
+    );
+    const buildStep = findAndUploadBuildArtifacts.createBuildStepFromFunctionCall(
+      globalContext,
+      {}
+    );
+    await expect(buildStep.executeAsync()).rejects.toThrow('There are no files matching pattern');
+    expect(contextUploadArtifact).toHaveBeenCalledWith(
+      expect.objectContaining({
+        artifact: expect.objectContaining({
+          type: ManagedArtifactType.BUILD_ARTIFACTS,
+        }),
+      })
+    );
+  });
+});


### PR DESCRIPTION
# Why

They're good to have to debug things. https://exponent-internal.slack.com/archives/C04GPRQCEBG/p1709836166859129

# How

Added fail-safe uploading Xcode logs behind the scenes to custom builds. Also refactored `findAndUploadArtifacts` a bit. One notable change is changing `cwd` for uploading build artifacts from `projectTargetDirectory` to `workingDirectory`. This is what `applicationArchivePath` uses. Which one should it be? Why?

# Test Plan

Added some tests.