### PR TITLE
[expo-updates] Move runtime version calculation ahead of project mutations

### DIFF
--- a/packages/build-tools/src/android/gradle.ts
+++ b/packages/build-tools/src/android/gradle.ts
@@ -26,7 +26,8 @@ export async function runGradleCommand(
     logger,
     gradleCommand,
     androidDir,
-  }: { logger: bunyan; gradleCommand: string; androidDir: string }
+    extraEnv,
+  }: { logger: bunyan; gradleCommand: string; androidDir: string; extraEnv?: Env }
 ): Promise<void> {
   logger.info(`Running 'gradlew ${gradleCommand}' in ${androidDir}`);
   const spawnPromise = spawn('bash', ['-c', `sh gradlew ${gradleCommand}`], {
@@ -39,7 +40,7 @@ export async function runGradleCommand(
         return line;
       }
     },
-    env: { ...ctx.env, ...resolveVersionOverridesEnvs(ctx) },
+    env: { ...ctx.env, ...extraEnv, ...resolveVersionOverridesEnvs(ctx) },
   });
   if (ctx.env.EAS_BUILD_RUNNER === 'eas-build' && process.platform === 'linux') {
     adjustOOMScore(spawnPromise, logger);
@@ -80,7 +81,7 @@ function adjustOOMScore(spawnPromise: SpawnPromise<SpawnResult>, logger: bunyan)
 }
 
 // Version envs should be set at the beginning of the build, but when building
-// from github those values are resolved latter.
+// from github those values are resolved later.
 function resolveVersionOverridesEnvs(ctx: BuildContext<Job>): Env {
   const extraEnvs: Env = {};
   if (

--- a/packages/build-tools/src/ios/fastlane.ts
+++ b/packages/build-tools/src/ios/fastlane.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 
-import { Ios } from '@expo/eas-build-job';
+import { Env, Ios } from '@expo/eas-build-job';
 import { bunyan } from '@expo/logger';
 import spawn, { SpawnResult } from '@expo/turtle-spawn';
 import fs from 'fs-extra';
@@ -21,11 +21,13 @@ export async function runFastlaneGym<TJob extends Ios.Job>(
     buildConfiguration,
     credentials,
     entitlements,
+    extraEnv,
   }: {
     scheme: string;
     buildConfiguration?: string;
     credentials: Credentials | null;
     entitlements: object | null;
+    extraEnv?: Env;
   }
 ): Promise<void> {
   await ensureGymfileExists(ctx, {
@@ -44,7 +46,7 @@ export async function runFastlaneGym<TJob extends Ios.Job>(
     await runFastlane(['gym'], {
       cwd: path.join(ctx.getReactNativeProjectDirectory(), 'ios'),
       logger: ctx.logger,
-      env: ctx.env,
+      env: { ...ctx.env, ...extraEnv },
     });
   } finally {
     await buildLogger.flush();

--- a/packages/build-tools/src/utils/__tests__/expoUpdates.test.ts
+++ b/packages/build-tools/src/utils/__tests__/expoUpdates.test.ts
@@ -27,10 +27,13 @@ describe(expoUpdates.configureExpoUpdatesIfInstalledAsync, () => {
   it('aborts if expo-updates is not installed', async () => {
     jest.mocked(getExpoUpdatesPackageVersionIfInstalledAsync).mockResolvedValue(null);
 
-    await expoUpdates.configureExpoUpdatesIfInstalledAsync({
-      job: { Platform: Platform.IOS },
-      getReactNativeProjectDirectory: () => '/app',
-    } as any);
+    await expoUpdates.configureExpoUpdatesIfInstalledAsync(
+      {
+        job: { Platform: Platform.IOS },
+        getReactNativeProjectDirectory: () => '/app',
+      } as any,
+      { resolvedRuntimeVersion: '1' }
+    );
 
     expect(androidSetChannelNativelyAsync).not.toBeCalled();
     expect(androidSetClassicReleaseChannelNativelyAsync).not.toBeCalled();
@@ -54,7 +57,9 @@ describe(expoUpdates.configureExpoUpdatesIfInstalledAsync, () => {
       logger: { info: () => {} },
       getReactNativeProjectDirectory: () => '/app',
     } as any;
-    await expoUpdates.configureExpoUpdatesIfInstalledAsync(managedCtx);
+    await expoUpdates.configureExpoUpdatesIfInstalledAsync(managedCtx, {
+      resolvedRuntimeVersion: '1',
+    });
 
     expect(androidSetChannelNativelyAsync).not.toBeCalled();
     expect(androidSetClassicReleaseChannelNativelyAsync).not.toBeCalled();
@@ -81,7 +86,9 @@ describe(expoUpdates.configureExpoUpdatesIfInstalledAsync, () => {
       logger: { info: () => {} },
       getReactNativeProjectDirectory: () => '/app',
     } as any;
-    await expoUpdates.configureExpoUpdatesIfInstalledAsync(managedCtx);
+    await expoUpdates.configureExpoUpdatesIfInstalledAsync(managedCtx, {
+      resolvedRuntimeVersion: '1',
+    });
 
     expect(androidSetChannelNativelyAsync).not.toBeCalled();
     expect(androidSetClassicReleaseChannelNativelyAsync).not.toBeCalled();
@@ -103,7 +110,9 @@ describe(expoUpdates.configureExpoUpdatesIfInstalledAsync, () => {
       logger: { info: () => {} },
       getReactNativeProjectDirectory: () => '/app',
     } as any;
-    await expoUpdates.configureExpoUpdatesIfInstalledAsync(managedCtx);
+    await expoUpdates.configureExpoUpdatesIfInstalledAsync(managedCtx, {
+      resolvedRuntimeVersion: '1',
+    });
 
     expect(androidSetChannelNativelyAsync).not.toBeCalled();
     expect(androidSetClassicReleaseChannelNativelyAsync).not.toBeCalled();
@@ -121,7 +130,9 @@ describe(expoUpdates.configureExpoUpdatesIfInstalledAsync, () => {
       logger: { info: () => {} },
       getReactNativeProjectDirectory: () => '/app',
     } as any;
-    await expoUpdates.configureExpoUpdatesIfInstalledAsync(managedCtx);
+    await expoUpdates.configureExpoUpdatesIfInstalledAsync(managedCtx, {
+      resolvedRuntimeVersion: '1',
+    });
 
     expect(androidSetChannelNativelyAsync).not.toBeCalled();
     expect(androidSetClassicReleaseChannelNativelyAsync).not.toBeCalled();
@@ -140,7 +151,9 @@ describe(expoUpdates.configureExpoUpdatesIfInstalledAsync, () => {
       logger: { info: () => {} },
       getReactNativeProjectDirectory: () => '/app',
     } as any;
-    await expoUpdates.configureExpoUpdatesIfInstalledAsync(managedCtx);
+    await expoUpdates.configureExpoUpdatesIfInstalledAsync(managedCtx, {
+      resolvedRuntimeVersion: '1',
+    });
 
     expect(androidSetChannelNativelyAsync).not.toBeCalled();
     expect(androidSetClassicReleaseChannelNativelyAsync).not.toBeCalled();
@@ -159,7 +172,9 @@ describe(expoUpdates.configureExpoUpdatesIfInstalledAsync, () => {
       logger: { info: () => {} },
       getReactNativeProjectDirectory: () => '/app',
     } as any;
-    await expoUpdates.configureExpoUpdatesIfInstalledAsync(managedCtx);
+    await expoUpdates.configureExpoUpdatesIfInstalledAsync(managedCtx, {
+      resolvedRuntimeVersion: '1',
+    });
 
     expect(iosSetClassicReleaseChannelNativelyAsync).toBeCalledTimes(1);
     expect(androidSetClassicReleaseChannelNativelyAsync).not.toBeCalled();
@@ -176,7 +191,9 @@ describe(expoUpdates.configureExpoUpdatesIfInstalledAsync, () => {
       logger: { info: () => {} },
       getReactNativeProjectDirectory: () => '/app',
     } as any;
-    await expoUpdates.configureExpoUpdatesIfInstalledAsync(managedCtx);
+    await expoUpdates.configureExpoUpdatesIfInstalledAsync(managedCtx, {
+      resolvedRuntimeVersion: '1',
+    });
 
     expect(iosSetClassicReleaseChannelNativelyAsync).not.toBeCalled();
     expect(androidSetClassicReleaseChannelNativelyAsync).not.toBeCalled();
@@ -194,7 +211,9 @@ describe(expoUpdates.configureExpoUpdatesIfInstalledAsync, () => {
       logger: { info: infoLogger, warn: () => {} },
       getReactNativeProjectDirectory: () => '/app',
     } as any;
-    await expoUpdates.configureExpoUpdatesIfInstalledAsync(managedCtx);
+    await expoUpdates.configureExpoUpdatesIfInstalledAsync(managedCtx, {
+      resolvedRuntimeVersion: '1',
+    });
 
     expect(infoLogger).toBeCalledWith(`Using default release channel for 'expo-updates' (default)`);
     expect(iosSetClassicReleaseChannelNativelyAsync).not.toBeCalled();
@@ -213,7 +232,9 @@ describe(expoUpdates.configureExpoUpdatesIfInstalledAsync, () => {
       logger: { info: infoLogger, warn: () => {} },
       getReactNativeProjectDirectory: () => '/app',
     } as any;
-    await expoUpdates.configureExpoUpdatesIfInstalledAsync(managedCtx);
+    await expoUpdates.configureExpoUpdatesIfInstalledAsync(managedCtx, {
+      resolvedRuntimeVersion: '1',
+    });
 
     expect(infoLogger).not.toBeCalledWith(
       `Using default release channel for 'expo-updates' (default)`
@@ -236,7 +257,9 @@ describe(expoUpdates.configureExpoUpdatesIfInstalledAsync, () => {
       logger: { info: infoLogger, warn: () => {} },
       getReactNativeProjectDirectory: () => '/app',
     } as any;
-    await expoUpdates.configureExpoUpdatesIfInstalledAsync(managedCtx);
+    await expoUpdates.configureExpoUpdatesIfInstalledAsync(managedCtx, {
+      resolvedRuntimeVersion: '1',
+    });
 
     expect(infoLogger).not.toBeCalledWith(
       `Using default release channel for 'expo-updates' (default)`

--- a/packages/eas-build-job/src/logs.ts
+++ b/packages/eas-build-job/src/logs.ts
@@ -15,6 +15,7 @@ export enum BuildPhase {
   EAS_BUILD_INTERNAL = 'EAS_BUILD_INTERNAL',
   PREBUILD = 'PREBUILD',
   PREPARE_CREDENTIALS = 'PREPARE_CREDENTIALS',
+  CALCULATE_EXPO_UPDATES_RUNTIME_VERSION = 'CALCULATE_EXPO_UPDATES_RUNTIME_VERSION',
   CONFIGURE_EXPO_UPDATES = 'CONFIGURE_EXPO_UPDATES',
   SAVE_CACHE = 'SAVE_CACHE',
   /**
@@ -75,6 +76,7 @@ export const buildPhaseDisplayName: Record<BuildPhase, string> = {
   [BuildPhase.EAS_BUILD_INTERNAL]: 'Resolve build configuration',
   [BuildPhase.PREBUILD]: 'Prebuild',
   [BuildPhase.PREPARE_CREDENTIALS]: 'Prepare credentials',
+  [BuildPhase.CALCULATE_EXPO_UPDATES_RUNTIME_VERSION]: 'Calculate expo-updates runtime version',
   [BuildPhase.CONFIGURE_EXPO_UPDATES]: 'Configure expo-updates',
   [BuildPhase.SAVE_CACHE]: 'Save cache',
   [BuildPhase.UPLOAD_ARTIFACTS]: 'Upload artifacts',
@@ -133,6 +135,7 @@ export const buildPhaseWebsiteId: Record<BuildPhase, string> = {
   [BuildPhase.EAS_BUILD_INTERNAL]: 'resolve-build-configuration',
   [BuildPhase.PREBUILD]: 'prebuild',
   [BuildPhase.PREPARE_CREDENTIALS]: 'prepare-credentials',
+  [BuildPhase.CALCULATE_EXPO_UPDATES_RUNTIME_VERSION]: 'calculate-expo-updates-runtime-version',
   [BuildPhase.CONFIGURE_EXPO_UPDATES]: 'configure-expo-updates',
   [BuildPhase.SAVE_CACHE]: 'save-cache',
   [BuildPhase.UPLOAD_ARTIFACTS]: 'upload-artifacts',


### PR DESCRIPTION
# Why

Generic projects (including those that do continuous native generation, CNG) are having some issues with fingerprint when built on EAS build. This is because EAS build does mutations of the native files just before build, thus generating a different logical runtime from the fingerprint perspective. (https://github.com/expo/eas-build/blob/main/packages/build-tools/src/android/expoUpdates.ts#L55 for example). https://github.com/expo/expo/pull/27576 was one possible solution, but this PR (in combination with a eas-build PR) is the better solution.

# What to review

- Is there a precedent for passing data between build phases?

# How

This PR (in combination with https://github.com/expo/expo/pull/27597) calculates the fingerprint runtime version ahead of project mutation so that a consistent fingerprint is calculated with the local version.

# Test Plan

Android:
1. Create project using latest canaries
2. Make changes to `eas-build` locally to set this environment variable during a build step before project modification.
3. Run build locally using `eas-build` local instructions.
4. See the following log: `[RUN_GRADLEW] Using fingerprint from EXPO_UPDATES_FINGERPRINT_OVERRIDE: a8715b7f12f5736af20ed1f66daa693d37c43585`, indicating the the override is respected and used
5. Check built aab for overridden fingerprint

iOS: Same, but look for the logs.

Test with a normal SDK 50 project with expo-updates to ensure no regressions.