### PR TITLE
[build-tools] custom builds equivalent of move runtime version calculation ahead of mutations

### DIFF
--- a/packages/build-tools/src/builders/android.ts
+++ b/packages/build-tools/src/builders/android.ts
@@ -72,7 +72,12 @@ async function buildAsync(ctx: BuildContext<Android.Job>): Promise<void> {
   const resolvedExpoUpdatesRuntimeVersion = await ctx.runBuildPhase(
     BuildPhase.CALCULATE_EXPO_UPDATES_RUNTIME_VERSION,
     async () => {
-      return await resolveRuntimeVersionForExpoUpdatesIfConfiguredAsync(ctx);
+      return await resolveRuntimeVersionForExpoUpdatesIfConfiguredAsync({
+        cwd: ctx.getReactNativeProjectDirectory(),
+        logger: ctx.logger,
+        appConfig: ctx.appConfig,
+        platform: ctx.job.platform,
+      });
     }
   );
 

--- a/packages/build-tools/src/builders/ios.ts
+++ b/packages/build-tools/src/builders/ios.ts
@@ -80,7 +80,12 @@ async function buildAsync(ctx: BuildContext<Ios.Job>): Promise<void> {
     const resolvedExpoUpdatesRuntimeVersion = await ctx.runBuildPhase(
       BuildPhase.CALCULATE_EXPO_UPDATES_RUNTIME_VERSION,
       async () => {
-        return await resolveRuntimeVersionForExpoUpdatesIfConfiguredAsync(ctx);
+        return await resolveRuntimeVersionForExpoUpdatesIfConfiguredAsync({
+          cwd: ctx.getReactNativeProjectDirectory(),
+          logger: ctx.logger,
+          appConfig: ctx.appConfig,
+          platform: ctx.job.platform,
+        });
       }
     );
 

--- a/packages/build-tools/src/steps/easFunctions.ts
+++ b/packages/build-tools/src/steps/easFunctions.ts
@@ -24,6 +24,7 @@ import { createGetCredentialsForBuildTriggeredByGithubIntegration } from './func
 import { createInstallPodsBuildFunction } from './functions/installPods';
 import { createSendSlackMessageFunction } from './functions/sendSlackMessage';
 import { createResolveBuildConfigBuildFunction } from './functions/resolveBuildConfig';
+import { calculateEASUpdateRuntimeVersionFunction } from './functions/calculateEASUpdateRuntimeVersion';
 
 export function getEasFunctions(ctx: CustomBuildContext): BuildFunction[] {
   return [
@@ -49,5 +50,6 @@ export function getEasFunctions(ctx: CustomBuildContext): BuildFunction[] {
     createInstallPodsBuildFunction(),
     createSendSlackMessageFunction(),
     createResolveBuildConfigBuildFunction(ctx),
+    calculateEASUpdateRuntimeVersionFunction(),
   ];
 }

--- a/packages/build-tools/src/steps/functionGroups/build.ts
+++ b/packages/build-tools/src/steps/functionGroups/build.ts
@@ -18,6 +18,7 @@ import { injectAndroidCredentialsFunction } from '../functions/injectAndroidCred
 import { configureAndroidVersionFunction } from '../functions/configureAndroidVersion';
 import { createSetUpNpmrcBuildFunction } from '../functions/useNpmToken';
 import { createResolveBuildConfigBuildFunction } from '../functions/resolveBuildConfig';
+import { calculateEASUpdateRuntimeVersionFunction } from '../functions/calculateEASUpdateRuntimeVersion';
 
 interface HelperFunctionsInput {
   globalCtx: BuildStepGlobalContext;
@@ -65,6 +66,10 @@ function createStepsForIosSimulatorBuild({
   globalCtx,
   buildToolsContext,
 }: HelperFunctionsInput): BuildStep[] {
+  const calculateEASUpdateRuntimeVersion =
+    calculateEASUpdateRuntimeVersionFunction().createBuildStepFromFunctionCall(globalCtx, {
+      id: 'calculate_eas_update_runtime_version',
+    });
   const installPods = createInstallPodsBuildFunction().createBuildStepFromFunctionCall(globalCtx, {
     workingDirectory: './ios',
   });
@@ -72,9 +77,17 @@ function createStepsForIosSimulatorBuild({
     configureEASUpdateIfInstalledFunction().createBuildStepFromFunctionCall(globalCtx, {
       callInputs: {
         throw_if_not_configured: false,
+        resolved_eas_update_runtime_version:
+          '${ steps.calculate_eas_update_runtime_version.resolved_eas_update_runtime_version }',
       },
     });
-  const runFastlane = runFastlaneFunction();
+  const runFastlane = runFastlaneFunction().createBuildStepFromFunctionCall(globalCtx, {
+    id: 'run_fastlane',
+    callInputs: {
+      resolved_eas_update_runtime_version:
+        '${ steps.calculate_eas_update_runtime_version.resolved_eas_update_runtime_version }',
+    },
+  });
   return [
     createCheckoutBuildFunction().createBuildStepFromFunctionCall(globalCtx),
     createSetUpNpmrcBuildFunction().createBuildStepFromFunctionCall(globalCtx),
@@ -83,10 +96,11 @@ function createStepsForIosSimulatorBuild({
       globalCtx
     ),
     createPrebuildBuildFunction().createBuildStepFromFunctionCall(globalCtx),
+    calculateEASUpdateRuntimeVersion,
     installPods,
     configureEASUpdate,
     generateGymfileFromTemplateFunction().createBuildStepFromFunctionCall(globalCtx),
-    runFastlane.createBuildStepFromFunctionCall(globalCtx, { id: runFastlane.id }),
+    runFastlane,
     createFindAndUploadBuildArtifactsBuildFunction(
       buildToolsContext
     ).createBuildStepFromFunctionCall(globalCtx),
@@ -101,6 +115,10 @@ function createStepsForIosBuildWithCredentials({
     resolveAppleTeamIdFromCredentialsFunction().createBuildStepFromFunctionCall(globalCtx, {
       id: 'resolve_apple_team_id_from_credentials',
     });
+  const calculateEASUpdateRuntimeVersion =
+    calculateEASUpdateRuntimeVersionFunction().createBuildStepFromFunctionCall(globalCtx, {
+      id: 'calculate_eas_update_runtime_version',
+    });
   const prebuildStep = createPrebuildBuildFunction().createBuildStepFromFunctionCall(globalCtx, {
     callInputs: {
       apple_team_id: '${ steps.resolve_apple_team_id_from_credentials.apple_team_id }',
@@ -113,6 +131,8 @@ function createStepsForIosBuildWithCredentials({
     configureEASUpdateIfInstalledFunction().createBuildStepFromFunctionCall(globalCtx, {
       callInputs: {
         throw_if_not_configured: false,
+        resolved_eas_update_runtime_version:
+          '${ steps.calculate_eas_update_runtime_version.resolved_eas_update_runtime_version }',
       },
     });
   const generateGymfile = generateGymfileFromTemplateFunction().createBuildStepFromFunctionCall(
@@ -123,7 +143,13 @@ function createStepsForIosBuildWithCredentials({
       },
     }
   );
-  const runFastlane = runFastlaneFunction();
+  const runFastlane = runFastlaneFunction().createBuildStepFromFunctionCall(globalCtx, {
+    id: 'run_fastlane',
+    callInputs: {
+      resolved_eas_update_runtime_version:
+        '${ steps.calculate_eas_update_runtime_version.resolved_eas_update_runtime_version }',
+    },
+  });
   return [
     createCheckoutBuildFunction().createBuildStepFromFunctionCall(globalCtx),
     createSetUpNpmrcBuildFunction().createBuildStepFromFunctionCall(globalCtx),
@@ -133,12 +159,13 @@ function createStepsForIosBuildWithCredentials({
     ),
     resolveAppleTeamIdFromCredentials,
     prebuildStep,
+    calculateEASUpdateRuntimeVersion,
     installPods,
     configureEASUpdate,
     configureIosCredentialsFunction().createBuildStepFromFunctionCall(globalCtx),
     configureIosVersionFunction().createBuildStepFromFunctionCall(globalCtx),
     generateGymfile,
-    runFastlane.createBuildStepFromFunctionCall(globalCtx, { id: runFastlane.id }),
+    runFastlane,
     createFindAndUploadBuildArtifactsBuildFunction(
       buildToolsContext
     ).createBuildStepFromFunctionCall(globalCtx),
@@ -149,13 +176,25 @@ function createStepsForAndroidBuildWithoutCredentials({
   globalCtx,
   buildToolsContext,
 }: HelperFunctionsInput): BuildStep[] {
+  const calculateEASUpdateRuntimeVersion =
+    calculateEASUpdateRuntimeVersionFunction().createBuildStepFromFunctionCall(globalCtx, {
+      id: 'calculate_eas_update_runtime_version',
+    });
   const configureEASUpdate =
     configureEASUpdateIfInstalledFunction().createBuildStepFromFunctionCall(globalCtx, {
       callInputs: {
         throw_if_not_configured: false,
+        resolved_eas_update_runtime_version:
+          '${ steps.calculate_eas_update_runtime_version.resolved_eas_update_runtime_version }',
       },
     });
-  const runGradle = runGradleFunction();
+  const runGradle = runGradleFunction().createBuildStepFromFunctionCall(globalCtx, {
+    id: 'run_gradle',
+    callInputs: {
+      resolved_eas_update_runtime_version:
+        '${ steps.calculate_eas_update_runtime_version.resolved_eas_update_runtime_version }',
+    },
+  });
   return [
     createCheckoutBuildFunction().createBuildStepFromFunctionCall(globalCtx),
     createSetUpNpmrcBuildFunction().createBuildStepFromFunctionCall(globalCtx),
@@ -164,8 +203,9 @@ function createStepsForAndroidBuildWithoutCredentials({
       globalCtx
     ),
     createPrebuildBuildFunction().createBuildStepFromFunctionCall(globalCtx),
+    calculateEASUpdateRuntimeVersion,
     configureEASUpdate,
-    runGradle.createBuildStepFromFunctionCall(globalCtx, { id: runGradle.id }),
+    runGradle,
     createFindAndUploadBuildArtifactsBuildFunction(
       buildToolsContext
     ).createBuildStepFromFunctionCall(globalCtx),
@@ -176,13 +216,25 @@ function createStepsForAndroidBuildWithCredentials({
   globalCtx,
   buildToolsContext,
 }: HelperFunctionsInput): BuildStep[] {
+  const calculateEASUpdateRuntimeVersion =
+    calculateEASUpdateRuntimeVersionFunction().createBuildStepFromFunctionCall(globalCtx, {
+      id: 'calculate_eas_update_runtime_version',
+    });
   const configureEASUpdate =
     configureEASUpdateIfInstalledFunction().createBuildStepFromFunctionCall(globalCtx, {
       callInputs: {
         throw_if_not_configured: false,
+        resolved_eas_update_runtime_version:
+          '${ steps.calculate_eas_update_runtime_version.resolved_eas_update_runtime_version }',
       },
     });
-  const runGradle = runGradleFunction();
+  const runGradle = runGradleFunction().createBuildStepFromFunctionCall(globalCtx, {
+    id: 'run_gradle',
+    callInputs: {
+      resolved_eas_update_runtime_version:
+        '${ steps.calculate_eas_update_runtime_version.resolved_eas_update_runtime_version }',
+    },
+  });
   return [
     createCheckoutBuildFunction().createBuildStepFromFunctionCall(globalCtx),
     createSetUpNpmrcBuildFunction().createBuildStepFromFunctionCall(globalCtx),
@@ -191,10 +243,11 @@ function createStepsForAndroidBuildWithCredentials({
       globalCtx
     ),
     createPrebuildBuildFunction().createBuildStepFromFunctionCall(globalCtx),
+    calculateEASUpdateRuntimeVersion,
     configureEASUpdate,
     injectAndroidCredentialsFunction().createBuildStepFromFunctionCall(globalCtx),
     configureAndroidVersionFunction().createBuildStepFromFunctionCall(globalCtx),
-    runGradle.createBuildStepFromFunctionCall(globalCtx, { id: runGradle.id }),
+    runGradle,
     createFindAndUploadBuildArtifactsBuildFunction(
       buildToolsContext
     ).createBuildStepFromFunctionCall(globalCtx),

--- a/packages/build-tools/src/steps/functions/calculateEASUpdateRuntimeVersion.ts
+++ b/packages/build-tools/src/steps/functions/calculateEASUpdateRuntimeVersion.ts
@@ -1,0 +1,43 @@
+import { BuildFunction, BuildStepOutput } from '@expo/steps';
+
+import { resolveRuntimeVersionForExpoUpdatesIfConfiguredAsync } from '../../utils/expoUpdates';
+import { readAppConfig } from '../../utils/appConfig';
+
+export function calculateEASUpdateRuntimeVersionFunction(): BuildFunction {
+  return new BuildFunction({
+    namespace: 'eas',
+    id: 'calculate_eas_update_runtime_version',
+    name: 'Calculate EAS Update Runtime Version',
+    outputProviders: [
+      BuildStepOutput.createProvider({
+        id: 'resolved_eas_update_runtime_version',
+        required: false,
+      }),
+    ],
+    fn: async (stepCtx, { env, outputs }) => {
+      const appConfig = readAppConfig({
+        projectDir: stepCtx.workingDirectory,
+        env: Object.keys(env).reduce(
+          (acc, key) => {
+            acc[key] = env[key] ?? '';
+            return acc;
+          },
+          {} as Record<string, string>
+        ),
+        logger: stepCtx.logger,
+        sdkVersion: stepCtx.global.staticContext.metadata?.sdkVersion,
+      }).exp;
+      const resolvedRuntimeVersion = await resolveRuntimeVersionForExpoUpdatesIfConfiguredAsync({
+        cwd: stepCtx.workingDirectory,
+        logger: stepCtx.logger,
+        appConfig,
+        platform: stepCtx.global.staticContext.job.platform,
+      });
+      if (resolvedRuntimeVersion) {
+        outputs.resolved_eas_update_runtime_version.set(resolvedRuntimeVersion);
+      } else {
+        stepCtx.logger.info('Skipped because EAS Update is not configured');
+      }
+    },
+  });
+}

--- a/packages/build-tools/src/steps/functions/configureEASUpdateIfInstalled.ts
+++ b/packages/build-tools/src/steps/functions/configureEASUpdateIfInstalled.ts
@@ -30,6 +30,11 @@ export function configureEASUpdateIfInstalledFunction(): BuildFunction {
         defaultValue: true,
         allowedValueTypeName: BuildStepInputValueTypeName.BOOLEAN,
       }),
+      BuildStepInput.createProvider({
+        id: 'resolved_eas_update_runtime_version',
+        required: false,
+        allowedValueTypeName: BuildStepInputValueTypeName.STRING,
+      }),
     ],
     fn: async (stepCtx, { env, inputs }) => {
       assert(stepCtx.global.staticContext.job, 'Job is not defined');
@@ -51,6 +56,9 @@ export function configureEASUpdateIfInstalledFunction(): BuildFunction {
 
       const releaseChannelInput = inputs.channel.value as string | undefined;
       const runtimeVersionInput = inputs.runtime_version.value as string | undefined;
+      const resolvedRuntimeVersionInput = inputs.resolved_eas_update_runtime_version.value as
+        | string
+        | undefined;
       const throwIfNotConfigured = inputs.throw_if_not_configured.value as boolean;
       if (runtimeVersionInput && !semver.valid(runtimeVersionInput)) {
         throw new Error(
@@ -74,7 +82,6 @@ export function configureEASUpdateIfInstalledFunction(): BuildFunction {
       }
 
       await configureEASUpdateAsync({
-        expoUpdatesPackageVersion,
         job,
         workingDirectory: stepCtx.workingDirectory,
         logger: stepCtx.logger,
@@ -82,7 +89,9 @@ export function configureEASUpdateIfInstalledFunction(): BuildFunction {
         inputs: {
           runtimeVersion: runtimeVersionInput,
           channel: releaseChannelInput,
+          resolvedRuntimeVersion: resolvedRuntimeVersionInput,
         },
+        metadata: stepCtx.global.staticContext.metadata,
       });
     },
   });

--- a/packages/build-tools/src/steps/functions/runGradle.ts
+++ b/packages/build-tools/src/steps/functions/runGradle.ts
@@ -23,6 +23,11 @@ export function runGradleFunction(): BuildFunction {
         required: false,
         allowedValueTypeName: BuildStepInputValueTypeName.STRING,
       }),
+      BuildStepInput.createProvider({
+        id: 'resolved_eas_update_runtime_version',
+        required: false,
+        allowedValueTypeName: BuildStepInputValueTypeName.STRING,
+      }),
     ],
     outputProviders: [
       BuildStepOutput.createProvider({
@@ -45,12 +50,18 @@ export function runGradleFunction(): BuildFunction {
         stepCtx.global.staticContext.job,
         inputs.command.value as string | undefined
       );
+      const resolvedEASUpdateRuntimeVersion = inputs.resolved_eas_update_runtime_version.value as
+        | string
+        | undefined;
       try {
         await runGradleCommand({
           logger: stepCtx.logger,
           gradleCommand: command,
           androidDir: path.join(stepCtx.workingDirectory, 'android'),
           env,
+          ...(resolvedEASUpdateRuntimeVersion
+            ? { extraEnv: { EXPO_UPDATES_FINGERPRINT_OVERRIDE: resolvedEASUpdateRuntimeVersion } }
+            : null),
         });
       } catch (error) {
         outputs[BuildStepOutputName.STATUS_TEXT].set(BuildStatusText.ERROR);

--- a/packages/build-tools/src/steps/utils/__tests__/expoUpdates.test.ts
+++ b/packages/build-tools/src/steps/utils/__tests__/expoUpdates.test.ts
@@ -22,7 +22,6 @@ describe(configureEASUpdateAsync, () => {
 
   it('aborts if updates.url (app config) is set but updates.channel (eas.json) is not', async () => {
     await configureEASUpdateAsync({
-      expoUpdatesPackageVersion: '1.0',
       job: { platform: Platform.IOS } as unknown as Job,
       workingDirectory: '/app',
       logger: createLogger({
@@ -34,6 +33,7 @@ describe(configureEASUpdateAsync, () => {
         },
       } as unknown as ExpoConfig,
       inputs: {},
+      metadata: null,
     });
 
     expect(androidSetChannelNativelyAsync).not.toBeCalled();
@@ -44,7 +44,6 @@ describe(configureEASUpdateAsync, () => {
 
   it('configures for EAS if updates.channel (eas.json) and updates.url (app config) are set', async () => {
     await configureEASUpdateAsync({
-      expoUpdatesPackageVersion: '1.0',
       job: {
         updates: {
           channel: 'main',
@@ -61,6 +60,7 @@ describe(configureEASUpdateAsync, () => {
         },
       } as unknown as ExpoConfig,
       inputs: {},
+      metadata: null,
     });
 
     expect(androidSetChannelNativelyAsync).not.toBeCalled();
@@ -71,7 +71,6 @@ describe(configureEASUpdateAsync, () => {
 
   it('configures for EAS if the updates.channel and releaseChannel are both set', async () => {
     await configureEASUpdateAsync({
-      expoUpdatesPackageVersion: '1.0',
       job: {
         updates: { channel: 'main' },
         releaseChannel: 'default',
@@ -87,6 +86,7 @@ describe(configureEASUpdateAsync, () => {
         },
       } as unknown as ExpoConfig,
       inputs: {},
+      metadata: null,
     });
 
     expect(androidSetChannelNativelyAsync).not.toBeCalled();

--- a/packages/build-tools/src/steps/utils/android/gradle.ts
+++ b/packages/build-tools/src/steps/utils/android/gradle.ts
@@ -11,11 +11,13 @@ export async function runGradleCommand({
   gradleCommand,
   androidDir,
   env,
+  extraEnv,
 }: {
   logger: bunyan;
   gradleCommand: string;
   androidDir: string;
   env: BuildStepEnv;
+  extraEnv?: BuildStepEnv;
 }): Promise<void> {
   logger.info(`Running 'gradlew ${gradleCommand}' in ${androidDir}`);
   const spawnPromise = spawn('bash', ['-c', `sh gradlew ${gradleCommand}`], {
@@ -28,7 +30,7 @@ export async function runGradleCommand({
         return line;
       }
     },
-    env,
+    env: { ...env, ...extraEnv },
   });
   if (env.EAS_BUILD_RUNNER === 'eas-build' && process.platform === 'linux') {
     adjustOOMScore(spawnPromise, logger);

--- a/packages/build-tools/src/steps/utils/ios/fastlane.ts
+++ b/packages/build-tools/src/steps/utils/ios/fastlane.ts
@@ -1,8 +1,8 @@
 import path from 'path';
 
 import { bunyan } from '@expo/logger';
-import { Env } from '@expo/eas-build-job';
 import spawn, { SpawnResult } from '@expo/turtle-spawn';
+import { BuildStepEnv } from '@expo/steps';
 
 import { XcodeBuildLogger } from './xcpretty';
 
@@ -11,11 +11,13 @@ export async function runFastlaneGym({
   logger,
   buildLogsDirectory,
   env,
+  extraEnv,
 }: {
   workingDir: string;
   logger: bunyan;
   buildLogsDirectory: string;
-  env: Env;
+  env: BuildStepEnv;
+  extraEnv?: BuildStepEnv;
 }): Promise<void> {
   const buildLogger = new XcodeBuildLogger(logger, workingDir);
   void buildLogger.watchLogFiles(buildLogsDirectory);
@@ -24,6 +26,7 @@ export async function runFastlaneGym({
       cwd: path.join(workingDir, 'ios'),
       logger,
       env,
+      extraEnv,
     });
   } finally {
     await buildLogger.flush();
@@ -36,10 +39,12 @@ export async function runFastlane(
     logger,
     env,
     cwd,
+    extraEnv,
   }: {
     logger?: bunyan;
-    env?: Record<string, string>;
+    env?: BuildStepEnv;
     cwd?: string;
+    extraEnv?: BuildStepEnv;
   } = {}
 ): Promise<SpawnResult> {
   const fastlaneEnvVars = {
@@ -49,6 +54,7 @@ export async function runFastlane(
     FASTLANE_HIDE_TIMESTAMP: 'true',
     LC_ALL: 'en_US.UTF-8',
     ...(env ?? process.env),
+    ...extraEnv,
   };
   return await spawn('fastlane', fastlaneArgs, {
     env: fastlaneEnvVars,

--- a/packages/build-tools/src/utils/expoUpdates.ts
+++ b/packages/build-tools/src/utils/expoUpdates.ts
@@ -2,6 +2,8 @@ import assert from 'assert';
 
 import { Platform, Job } from '@expo/eas-build-job';
 import semver from 'semver';
+import { ExpoConfig } from '@expo/config';
+import { bunyan } from '@expo/logger';
 
 import {
   androidSetRuntimeVersionNativelyAsync,
@@ -206,25 +208,31 @@ export async function configureExpoUpdatesIfInstalledAsync(
   }
 }
 
-export async function resolveRuntimeVersionForExpoUpdatesIfConfiguredAsync(
-  ctx: BuildContext<Job>
-): Promise<string | null> {
-  const expoUpdatesPackageVersion = await getExpoUpdatesPackageVersionIfInstalledAsync(
-    ctx.getReactNativeProjectDirectory()
-  );
+export async function resolveRuntimeVersionForExpoUpdatesIfConfiguredAsync({
+  cwd,
+  appConfig,
+  platform,
+  logger,
+}: {
+  cwd: string;
+  appConfig: ExpoConfig;
+  platform: Platform;
+  logger: bunyan;
+}): Promise<string | null> {
+  const expoUpdatesPackageVersion = await getExpoUpdatesPackageVersionIfInstalledAsync(cwd);
   if (expoUpdatesPackageVersion === null) {
     return null;
   }
 
   const resolvedRuntimeVersion = await resolveRuntimeVersionAsync({
-    projectDir: ctx.getReactNativeProjectDirectory(),
-    exp: ctx.appConfig,
-    platform: ctx.job.platform,
-    logger: ctx.logger,
+    projectDir: cwd,
+    exp: appConfig,
+    platform,
+    logger,
     expoUpdatesPackageVersion,
   });
 
-  ctx.logger.info(`Resolved runtime version: ${resolvedRuntimeVersion}`);
+  logger.info(`Resolved runtime version: ${resolvedRuntimeVersion}`);
   return resolvedRuntimeVersion;
 }
 


### PR DESCRIPTION
# Why

Custom builds equivalent of https://github.com/expo/eas-build/pull/361

# How

Create a new function `eas/calculate_eas_update_runtime_version`. Use the output of this function as an input to `eas/configure_eas_update`, `eas/run_gradle`, and `eas/run_fastlane` functions.

Apply changes to `eas/build`.

Refactor `eas/configure_eas_update` to do the same as its equivalent in the standard build process.

# Test Plan

Tests, run builds locally