### PR TITLE
[build-tools] don't error the build if `eas/checkout` is called multiple times

### DIFF
--- a/packages/build-tools/src/steps/functions/checkout.ts
+++ b/packages/build-tools/src/steps/functions/checkout.ts
@@ -7,6 +7,10 @@ export function createCheckoutBuildFunction(): BuildFunction {
     id: 'checkout',
     name: 'Checkout',
     fn: async (stepsCtx) => {
+      if (stepsCtx.global.wasCheckedOut()) {
+        stepsCtx.logger.info('Project directory is already checked out');
+        return;
+      }
       stepsCtx.logger.info('Checking out project directory');
       await fs.move(
         stepsCtx.global.projectSourceDirectory,

--- a/packages/steps/src/BuildStepContext.ts
+++ b/packages/steps/src/BuildStepContext.ts
@@ -133,6 +133,10 @@ export class BuildStepGlobalContext {
     );
   }
 
+  public wasCheckedOut(): boolean {
+    return this.didCheckOut;
+  }
+
   public serialize(): SerializedBuildStepGlobalContext {
     return {
       stepsInternalBuildDirectory: this.stepsInternalBuildDirectory,


### PR DESCRIPTION
# Why

Don't error the build if `eas/checkout` is called multiple times. Just skip "checkout" if it was already done.

# How

Check if `eas/checkout` was already called. If it was, don't error the build, but skip running it again.

# Test Plan

Tests, run test builds
