### PR TITLE
Add `eas/resolve_build_config` function

### DIFF
--- a/packages/build-tools/src/steps/easFunctions.ts
+++ b/packages/build-tools/src/steps/easFunctions.ts
@@ -23,6 +23,7 @@ import { createInstallMaestroBuildFunction } from './functions/installMaestro';
 import { createGetCredentialsForBuildTriggeredByGithubIntegration } from './functions/getCredentialsForBuildTriggeredByGitHubIntegration';
 import { createInstallPodsBuildFunction } from './functions/installPods';
 import { createSendSlackMessageFunction } from './functions/sendSlackMessage';
+import { createResolveBuildConfigBuildFunction } from './functions/resolveBuildConfig';
 
 export function getEasFunctions(ctx: CustomBuildContext): BuildFunction[] {
   return [
@@ -47,5 +48,6 @@ export function getEasFunctions(ctx: CustomBuildContext): BuildFunction[] {
     createGetCredentialsForBuildTriggeredByGithubIntegration(ctx),
     createInstallPodsBuildFunction(),
     createSendSlackMessageFunction(),
+    createResolveBuildConfigBuildFunction(ctx),
   ];
 }

--- a/packages/build-tools/src/steps/functionGroups/build.ts
+++ b/packages/build-tools/src/steps/functionGroups/build.ts
@@ -10,7 +10,6 @@ import { generateGymfileFromTemplateFunction } from '../functions/generateGymfil
 import { runFastlaneFunction } from '../functions/runFastlane';
 import { createFindAndUploadBuildArtifactsBuildFunction } from '../functions/findAndUploadBuildArtifacts';
 import { CustomBuildContext } from '../../customBuildContext';
-import { createGetCredentialsForBuildTriggeredByGithubIntegration } from '../functions/getCredentialsForBuildTriggeredByGitHubIntegration';
 import { resolveAppleTeamIdFromCredentialsFunction } from '../functions/resolveAppleTeamIdFromCredentials';
 import { configureIosCredentialsFunction } from '../functions/configureIosCredentials';
 import { runGradleFunction } from '../functions/runGradle';
@@ -18,6 +17,7 @@ import { configureIosVersionFunction } from '../functions/configureIosVersion';
 import { injectAndroidCredentialsFunction } from '../functions/injectAndroidCredentials';
 import { configureAndroidVersionFunction } from '../functions/configureAndroidVersion';
 import { createSetUpNpmrcBuildFunction } from '../functions/useNpmToken';
+import { createResolveBuildConfigBuildFunction } from '../functions/resolveBuildConfig';
 
 interface HelperFunctionsInput {
   globalCtx: BuildStepGlobalContext;
@@ -79,6 +79,9 @@ function createStepsForIosSimulatorBuild({
     createCheckoutBuildFunction().createBuildStepFromFunctionCall(globalCtx),
     createSetUpNpmrcBuildFunction().createBuildStepFromFunctionCall(globalCtx),
     createInstallNodeModulesBuildFunction().createBuildStepFromFunctionCall(globalCtx),
+    createResolveBuildConfigBuildFunction(buildToolsContext).createBuildStepFromFunctionCall(
+      globalCtx
+    ),
     createPrebuildBuildFunction().createBuildStepFromFunctionCall(globalCtx),
     installPods,
     configureEASUpdate,
@@ -125,9 +128,9 @@ function createStepsForIosBuildWithCredentials({
     createCheckoutBuildFunction().createBuildStepFromFunctionCall(globalCtx),
     createSetUpNpmrcBuildFunction().createBuildStepFromFunctionCall(globalCtx),
     createInstallNodeModulesBuildFunction().createBuildStepFromFunctionCall(globalCtx),
-    createGetCredentialsForBuildTriggeredByGithubIntegration(
-      buildToolsContext
-    ).createBuildStepFromFunctionCall(globalCtx),
+    createResolveBuildConfigBuildFunction(buildToolsContext).createBuildStepFromFunctionCall(
+      globalCtx
+    ),
     resolveAppleTeamIdFromCredentials,
     prebuildStep,
     installPods,
@@ -157,6 +160,9 @@ function createStepsForAndroidBuildWithoutCredentials({
     createCheckoutBuildFunction().createBuildStepFromFunctionCall(globalCtx),
     createSetUpNpmrcBuildFunction().createBuildStepFromFunctionCall(globalCtx),
     createInstallNodeModulesBuildFunction().createBuildStepFromFunctionCall(globalCtx),
+    createResolveBuildConfigBuildFunction(buildToolsContext).createBuildStepFromFunctionCall(
+      globalCtx
+    ),
     createPrebuildBuildFunction().createBuildStepFromFunctionCall(globalCtx),
     configureEASUpdate,
     runGradle.createBuildStepFromFunctionCall(globalCtx, { id: runGradle.id }),
@@ -181,9 +187,9 @@ function createStepsForAndroidBuildWithCredentials({
     createCheckoutBuildFunction().createBuildStepFromFunctionCall(globalCtx),
     createSetUpNpmrcBuildFunction().createBuildStepFromFunctionCall(globalCtx),
     createInstallNodeModulesBuildFunction().createBuildStepFromFunctionCall(globalCtx),
-    createGetCredentialsForBuildTriggeredByGithubIntegration(
-      buildToolsContext
-    ).createBuildStepFromFunctionCall(globalCtx),
+    createResolveBuildConfigBuildFunction(buildToolsContext).createBuildStepFromFunctionCall(
+      globalCtx
+    ),
     createPrebuildBuildFunction().createBuildStepFromFunctionCall(globalCtx),
     configureEASUpdate,
     injectAndroidCredentialsFunction().createBuildStepFromFunctionCall(globalCtx),

--- a/packages/build-tools/src/steps/functions/getCredentialsForBuildTriggeredByGitHubIntegration.ts
+++ b/packages/build-tools/src/steps/functions/getCredentialsForBuildTriggeredByGitHubIntegration.ts
@@ -1,8 +1,8 @@
-import { BuildTrigger } from '@expo/eas-build-job';
 import { BuildFunction } from '@expo/steps';
 
-import { runEasBuildInternalAsync } from '../../common/easBuildInternal';
 import { CustomBuildContext } from '../../customBuildContext';
+
+import { resolveBuildConfigAsync } from './resolveBuildConfig';
 
 export function createGetCredentialsForBuildTriggeredByGithubIntegration(
   ctx: CustomBuildContext
@@ -12,19 +12,12 @@ export function createGetCredentialsForBuildTriggeredByGithubIntegration(
     id: 'get_credentials_for_build_triggered_by_github_integration',
     name: 'Get credentials for build triggered by GitHub integration',
     fn: async (stepCtx, { env }) => {
-      if (ctx.job.triggeredBy === BuildTrigger.GIT_BASED_INTEGRATION) {
-        stepCtx.logger.info('Getting credentials for build triggered by EAS GitHub integration...');
-        const { newJob, newMetadata } = await runEasBuildInternalAsync({
-          job: ctx.job,
-          env,
-          logger: stepCtx.logger,
-          cwd: stepCtx.workingDirectory,
-        });
-        ctx.updateJobInformation(newJob, newMetadata);
-        stepCtx.logger.info('Credentials obtained.');
-      } else {
-        stepCtx.logger.info('Not a build triggered by EAS GitHub integration. Skipping...');
-      }
+      await resolveBuildConfigAsync({
+        logger: stepCtx.logger,
+        env,
+        workingDirectory: stepCtx.workingDirectory,
+        ctx,
+      });
     },
   });
 }

--- a/packages/build-tools/src/steps/functions/resolveBuildConfig.ts
+++ b/packages/build-tools/src/steps/functions/resolveBuildConfig.ts
@@ -1,0 +1,50 @@
+import { BuildTrigger } from '@expo/eas-build-job';
+import { bunyan } from '@expo/logger';
+import { BuildFunction, BuildStepEnv } from '@expo/steps';
+import { omit } from 'lodash';
+
+import { runEasBuildInternalAsync } from '../../common/easBuildInternal';
+import { CustomBuildContext } from '../../customBuildContext';
+
+export function createResolveBuildConfigBuildFunction(ctx: CustomBuildContext): BuildFunction {
+  return new BuildFunction({
+    namespace: 'eas',
+    id: 'resolve_build_config',
+    name: 'Resolve build config',
+    fn: async ({ logger, workingDirectory }, { env }) => {
+      await resolveBuildConfigAsync({ logger, workingDirectory, env, ctx });
+    },
+  });
+}
+
+export async function resolveBuildConfigAsync({
+  logger,
+  workingDirectory,
+  env,
+  ctx,
+}: {
+  logger: bunyan;
+  workingDirectory: string;
+  env: BuildStepEnv;
+  ctx: CustomBuildContext;
+}): Promise<void> {
+  if (ctx.job.triggeredBy === BuildTrigger.GIT_BASED_INTEGRATION) {
+    logger.info('Resolving build config...');
+    const { newJob, newMetadata } = await runEasBuildInternalAsync({
+      job: ctx.job,
+      env,
+      logger,
+      cwd: workingDirectory,
+    });
+    ctx.updateJobInformation(newJob, newMetadata);
+  }
+
+  logger.info('Build config resolved:');
+  logger.info(
+    JSON.stringify(
+      { job: omit(ctx.job, 'secrets', 'projectArchive'), metadata: ctx.metadata },
+      null,
+      2
+    )
+  );
+}


### PR DESCRIPTION
# Why

GitHub build job data is missing a lot of properties, because we don't provide them when we create the build, because we can't, because the config may need to be resolved dynamically, with external dependencies etc.

For this reason `eas build:internal` exists which we call during the build, once all dependencies are installed. We set this up in `get_credentials_for_build_triggered_by_github_integration`. This covered half of the use cases. Turns out we need to call this also in builds that don't need credentials so they have `buildType`, `version` and other properties.

# How

Added `eas/resolve_build_config` function that will be called in _all_ `eas/build` flows. If the build has been triggered by a GitHub trigger, it will call `eas build:internal` to resolve necessary properties, update build information in `www` and in context. It will always print the configuration (with `secrets` and `projectArchive` omitted, as we omit it in the regular build process).

I'm not sure if printing all or even some job properties makes sense. For me, the advantage is that a user can inspect what is the configuration, what properties can they access in `${ eas.job. ... }`. On the other hand it feels noisy. What is your opinion?

# Test Plan

<img width="626" alt="Zrzut ekranu 2024-03-13 o 22 22 41" src="https://github.com/expo/eas-build/assets/1151041/bc0ed085-d88b-4c24-a7e9-f23b37744fa1">

