### PR TITLE
[build-tools] respect modifications made by pre install hook when reading `package.json`

### DIFF
--- a/packages/build-tools/src/common/setup.ts
+++ b/packages/build-tools/src/common/setup.ts
@@ -28,7 +28,7 @@ class DoctorTimeoutError extends Error {}
 class InstallDependenciesTimeoutError extends Error {}
 
 export async function setupAsync<TJob extends Job>(ctx: BuildContext<TJob>): Promise<void> {
-  const packageJson = await ctx.runBuildPhase(BuildPhase.PREPARE_PROJECT, async () => {
+  await ctx.runBuildPhase(BuildPhase.PREPARE_PROJECT, async () => {
     await prepareProjectSourcesAsync(ctx);
     await setUpNpmrcAsync(ctx, ctx.logger);
     if (ctx.job.platform === Platform.IOS && ctx.env.EAS_BUILD_RUNNER === 'eas-build') {
@@ -42,17 +42,17 @@ export async function setupAsync<TJob extends Job>(ctx: BuildContext<TJob>): Pro
       });
       ctx.updateEnv(env);
     }
-    // try to read package.json to see if it exists and is valid
-    return readPackageJson(ctx.getReactNativeProjectDirectory());
   });
 
   await ctx.runBuildPhase(BuildPhase.PRE_INSTALL_HOOK, async () => {
     await runHookIfPresent(ctx, Hook.PRE_INSTALL);
   });
 
-  await ctx.runBuildPhase(BuildPhase.READ_PACKAGE_JSON, async () => {
+  const packageJson = await ctx.runBuildPhase(BuildPhase.READ_PACKAGE_JSON, async () => {
     ctx.logger.info('Using package.json:');
+    const packageJson = readPackageJson(ctx.getReactNativeProjectDirectory());
     ctx.logger.info(JSON.stringify(packageJson, null, 2));
+    return packageJson;
   });
 
   await ctx.runBuildPhase(BuildPhase.INSTALL_DEPENDENCIES, async () => {


### PR DESCRIPTION
# Why

https://github.com/expo/eas-cli/issues/2267

"This seems to be an issue with the nx-generator so maybe this issue can be closed, but it seems that the build agent output for the Read package.json step should respect that the pre-install hook changed the file which it currently does not seem to do."

# How

Read `package.json` during `Read package.json` step


