### PR TITLE
[eas-build-job] move images constants to `eas-build-job` package

### DIFF
--- a/packages/eas-build-job/src/android.ts
+++ b/packages/eas-build-job/src/android.ts
@@ -14,6 +14,7 @@ import {
   BuildTrigger,
   BuildMode,
 } from './common';
+import { AndroidWorkerImageWithAliases, androidWorkerImages } from './images';
 
 export interface Keystore {
   dataBase64: string;
@@ -35,7 +36,8 @@ export enum BuildType {
 }
 
 export interface BuilderEnvironment {
-  image?: string;
+  // TODO: make it required on 15th March 2025
+  image?: AndroidWorkerImageWithAliases;
   node?: string;
   pnpm?: string;
   yarn?: string;
@@ -46,7 +48,8 @@ export interface BuilderEnvironment {
 }
 
 const BuilderEnvironmentSchema = Joi.object({
-  image: Joi.string(),
+  // TODO: make it required on 15th March 2025
+  image: Joi.string().valid(...androidWorkerImages),
   node: Joi.string(),
   yarn: Joi.string(),
   pnpm: Joi.string(),

--- a/packages/eas-build-job/src/images.ts
+++ b/packages/eas-build-job/src/images.ts
@@ -1,0 +1,64 @@
+export const workerImageAliases = ['default', 'latest', 'sdk-50', 'sdk-49'] as const;
+
+export const iosWorkerImagesWithoutAliases = [
+  'macos-monterey-12.1-xcode-13.2',
+  'macos-monterey-12.3-xcode-13.3',
+  'macos-monterey-12.4-xcode-13.4',
+  'macos-monterey-12.6-xcode-14.0',
+  'macos-monterey-12.6-xcode-14.1',
+  'macos-monterey-12.6-xcode-14.2',
+  'macos-ventura-13.3-xcode-14.3',
+  'macos-ventura-13.4-xcode-14.3.1',
+  'macos-ventura-13.6-xcode-15.0',
+  'macos-ventura-13.6-xcode-15.1',
+  'macos-ventura-13.6-xcode-15.2',
+] as const;
+
+export const iosWorkerImages = [...workerImageAliases, ...iosWorkerImagesWithoutAliases] as const;
+
+export const androidWorkerImagesWithoutAliases = [
+  'ubuntu-20.04-jdk-8-ndk-r19c',
+  'ubuntu-20.04-jdk-11-ndk-r19c',
+  'ubuntu-20.04-jdk-8-ndk-r21e',
+  'ubuntu-20.04-jdk-11-ndk-r21e',
+  'ubuntu-22.04-jdk-8-ndk-r21e',
+  'ubuntu-22.04-jdk-11-ndk-r21e',
+  'ubuntu-22.04-jdk-17-ndk-r21e',
+] as const;
+
+export const androidWorkerImages = [
+  ...workerImageAliases,
+  ...androidWorkerImagesWithoutAliases,
+] as const;
+
+export const androidImagesWithJavaVersionLowerThen11 = [
+  'ubuntu-20.04-jdk-8-ndk-r19c',
+  'ubuntu-20.04-jdk-11-ndk-r19c',
+  'ubuntu-20.04-jdk-8-ndk-r21e',
+  'ubuntu-20.04-jdk-11-ndk-r21e',
+  'ubuntu-22.04-jdk-8-ndk-r21e',
+  'ubuntu-22.04-jdk-11-ndk-r21e',
+];
+export type WorkerImageAlias = (typeof workerImageAliases)[number];
+
+export type IosWorkerImageWithAliases = (typeof iosWorkerImages)[number];
+
+export type AndroidWorkerImageWithAliases = (typeof androidWorkerImages)[number];
+
+export type IosWorkerImageWithoutAliases = (typeof iosWorkerImagesWithoutAliases)[number];
+
+export type AndroidWorkerImageWithoutAliases = (typeof androidWorkerImagesWithoutAliases)[number];
+
+export type IosWorkerImageAliasToImageMapping = Record<
+  WorkerImageAlias,
+  IosWorkerImageWithoutAliases
+>;
+
+export type AndroidWorkerImageAliasToImageMapping = Record<
+  WorkerImageAlias,
+  AndroidWorkerImageWithoutAliases
+>;
+
+export function isImageAlias(image: string): image is WorkerImageAlias {
+  return workerImageAliases.includes(image as WorkerImageAlias);
+}

--- a/packages/eas-build-job/src/index.ts
+++ b/packages/eas-build-job/src/index.ts
@@ -19,3 +19,4 @@ export * from './logs';
 export * as errors from './errors';
 export * from './artifacts';
 export * from './context';
+export * from './images';

--- a/packages/eas-build-job/src/ios.ts
+++ b/packages/eas-build-job/src/ios.ts
@@ -14,6 +14,7 @@ import {
   BuildTrigger,
   BuildMode,
 } from './common';
+import { IosWorkerImageWithAliases, iosWorkerImages } from './images';
 
 export type DistributionType = 'store' | 'internal' | 'simulator';
 
@@ -43,7 +44,8 @@ export interface DistributionCertificate {
   password: string;
 }
 export interface BuilderEnvironment {
-  image?: string;
+  // TODO: make it required on 15th March 2025
+  image?: IosWorkerImageWithAliases;
   node?: string;
   yarn?: string;
   bun?: string;
@@ -56,7 +58,8 @@ export interface BuilderEnvironment {
 }
 
 const BuilderEnvironmentSchema = Joi.object({
-  image: Joi.string(),
+  // TODO: make it required on 15th March 2025
+  image: Joi.string().valid(...iosWorkerImages),
   node: Joi.string(),
   yarn: Joi.string(),
   pnpm: Joi.string(),


### PR DESCRIPTION
# Why

We want to share them between EAS CLI and Turtle service because we want to resolve the image client side.

# How

Move constants from Turtle service to this lib

# Test Plan

Tests
