### PR TITLE
[build-tools] run `resolveRuntimeVersionForExpoUpdatesIfConfiguredAsync` only when `job.updates.channel` is set

### DIFF
--- a/packages/build-tools/src/builders/android.ts
+++ b/packages/build-tools/src/builders/android.ts
@@ -77,6 +77,7 @@ async function buildAsync(ctx: BuildContext<Android.Job>): Promise<void> {
         logger: ctx.logger,
         appConfig: ctx.appConfig,
         platform: ctx.job.platform,
+        channel: ctx.job.updates?.channel,
       });
     }
   );

--- a/packages/build-tools/src/builders/ios.ts
+++ b/packages/build-tools/src/builders/ios.ts
@@ -85,6 +85,7 @@ async function buildAsync(ctx: BuildContext<Ios.Job>): Promise<void> {
           logger: ctx.logger,
           appConfig: ctx.appConfig,
           platform: ctx.job.platform,
+          channel: ctx.job.updates?.channel,
         });
       }
     );

--- a/packages/build-tools/src/steps/functions/calculateEASUpdateRuntimeVersion.ts
+++ b/packages/build-tools/src/steps/functions/calculateEASUpdateRuntimeVersion.ts
@@ -32,6 +32,7 @@ export function calculateEASUpdateRuntimeVersionFunction(): BuildFunction {
         logger: stepCtx.logger,
         appConfig,
         platform: stepCtx.global.staticContext.job.platform,
+        channel: stepCtx.global.staticContext.job.updates?.channel,
       });
       if (resolvedRuntimeVersion) {
         outputs.resolved_eas_update_runtime_version.set(resolvedRuntimeVersion);

--- a/packages/build-tools/src/utils/expoUpdates.ts
+++ b/packages/build-tools/src/utils/expoUpdates.ts
@@ -213,14 +213,16 @@ export async function resolveRuntimeVersionForExpoUpdatesIfConfiguredAsync({
   appConfig,
   platform,
   logger,
+  channel,
 }: {
   cwd: string;
   appConfig: ExpoConfig;
   platform: Platform;
   logger: bunyan;
+  channel?: string;
 }): Promise<string | null> {
   const expoUpdatesPackageVersion = await getExpoUpdatesPackageVersionIfInstalledAsync(cwd);
-  if (expoUpdatesPackageVersion === null) {
+  if (expoUpdatesPackageVersion === null || !channel) {
     return null;
   }
 


### PR DESCRIPTION
# Why

We run other EAS Update configuration steps only when `job.updates.channel` is set (the user set the `channel` in their `eas.json`) and [EAS Update is configured](https://github.com/expo/eas-build/blob/0a3819f36c1244a859c731571116c2f9e6c19112/packages/build-tools/src/utils/expoUpdates.ts#L276-L295):

https://github.com/expo/eas-build/blob/0a3819f36c1244a859c731571116c2f9e6c19112/packages/build-tools/src/utils/expoUpdates.ts#L165-L173

# How

Don't run `resolveRuntimeVersionForExpoUpdatesIfConfiguredAsync` if `channel` is falsy or EAS Update is not configured (`appconfig.url` is invalid or falsy)

# Test Plan

Tests
