### PR TITLE
Fix missing `npmrc` template

### DIFF
--- a/packages/build-tools/src/steps/functions/useNpmToken.ts
+++ b/packages/build-tools/src/steps/functions/useNpmToken.ts
@@ -5,7 +5,7 @@ import { BuildFunction } from '@expo/steps';
 
 import { findPackagerRootDir } from '../../utils/packageManager';
 
-const NPMRC_TEMPLATE_PATH = path.join(__dirname, '../../templates/npmrc');
+const NPMRC_TEMPLATE_PATH = path.join(__dirname, '../../../templates/npmrc');
 
 export function createSetUpNpmrcBuildFunction(): BuildFunction {
   return new BuildFunction({


### PR DESCRIPTION
# Why

https://discord.com/channels/695411232856997968/1219896632225697834

# How

Fixed path to `npmrc`.

# Test Plan

I `cd`ed into the directory where the file is "require"d and verified path with `cat` with an additional `../` does read the file.