### PR TITLE
Allow dynamic expressions in `if` conditions

### DIFF
--- a/packages/steps/package.json
+++ b/packages/steps/package.json
@@ -54,6 +54,7 @@
     "arg": "^5.0.2",
     "fs-extra": "^11.2.0",
     "joi": "^17.11.0",
+    "jsep": "^1.3.8",
     "lodash.clonedeep": "^4.5.0",
     "lodash.get": "^4.4.2",
     "this-file": "^2.0.3",

--- a/packages/steps/src/BuildConfig.ts
+++ b/packages/steps/src/BuildConfig.ts
@@ -13,10 +13,7 @@ import {
   BuildStepInputValueType,
 } from './BuildStepInput.js';
 import { BuildStepEnv } from './BuildStepEnv.js';
-import {
-  BUILD_STEP_IF_CONDITION_EXPRESSION_REGEXP,
-  BUILD_STEP_OR_BUILD_GLOBAL_CONTEXT_REFERENCE_REGEX,
-} from './utils/template.js';
+import { BUILD_STEP_OR_BUILD_GLOBAL_CONTEXT_REFERENCE_REGEX } from './utils/template.js';
 
 export type BuildFunctions = Record<string, BuildFunctionConfig>;
 
@@ -194,10 +191,7 @@ const BuildFunctionCallSchema = Joi.object({
   workingDirectory: Joi.string(),
   shell: Joi.string(),
   env: Joi.object().pattern(Joi.string(), Joi.string().allow('')),
-  if: Joi.string().pattern(
-    BUILD_STEP_IF_CONDITION_EXPRESSION_REGEXP,
-    'allowed "if" condition values regex'
-  ),
+  if: Joi.string(),
 }).rename('working_directory', 'workingDirectory');
 
 const BuildStepConfigSchema = Joi.any<BuildStepConfig>()

--- a/packages/steps/src/BuildStep.ts
+++ b/packages/steps/src/BuildStep.ts
@@ -293,8 +293,6 @@ export class BuildStep extends BuildStepOutputAccessor {
       ifCondition = ifCondition.slice(2, -1);
     }
 
-    ifCondition = this.interpolateInputsAndGlobalContextInTemplate(ifCondition);
-
     return Boolean(
       jsepEval(ifCondition, {
         success: () => !hasAnyPreviousStepsFailed,
@@ -302,7 +300,18 @@ export class BuildStep extends BuildStepOutputAccessor {
         always: () => true,
         never: () => false,
         env: this.env,
-        ctx: this.ctx,
+        inputs:
+          this.inputs?.reduce(
+            (acc, input) => {
+              acc[input.id] = input.value;
+              return acc;
+            },
+            {} as Record<string, unknown>
+          ) ?? {},
+        eas: {
+          runtimePlatform: this.ctx.global.runtimePlatform,
+          ...this.ctx.global.staticContext,
+        },
       })
     );
   }

--- a/packages/steps/src/__tests__/BuildConfig-test.ts
+++ b/packages/steps/src/__tests__/BuildConfig-test.ts
@@ -284,26 +284,6 @@ describe(validateConfig, () => {
             validateConfig(BuildConfigSchema, buildConfig);
           }).toThrowError(/"build.steps\[0\].run.env.ENV1" must be a string/);
         });
-        test('invalid if statement', () => {
-          const buildConfig = {
-            build: {
-              steps: [
-                {
-                  run: {
-                    command: 'echo 123',
-                    if: 'error',
-                  },
-                },
-              ],
-            },
-          };
-
-          expect(() => {
-            validateConfig(BuildConfigSchema, buildConfig);
-          }).toThrowError(
-            /"build.steps\[0\].run.if" with value "error" fails to match the allowed "if" condition values regex pattern/
-          );
-        });
         test('valid command', () => {
           const buildConfig = {
             build: {
@@ -515,30 +495,6 @@ describe(validateConfig, () => {
           expect(() => {
             validateConfig(BuildConfigSchema, buildConfig);
           }).toThrowError(/"build.steps\[0\].say_hi.env.ENV1" must be a string/);
-        });
-        test('invalid if statement', () => {
-          const buildConfig = {
-            build: {
-              steps: [
-                {
-                  say_hi: {
-                    if: 'error',
-                  },
-                },
-              ],
-            },
-            functions: {
-              say_hi: {
-                command: 'echo "Hi!"',
-              },
-            },
-          };
-
-          expect(() => {
-            validateConfig(BuildConfigSchema, buildConfig);
-          }).toThrowError(
-            /"build.steps\[0\].say_hi.if" with value "error" fails to match the allowed "if" condition values regex pattern/
-          );
         });
         test('call with inputs boolean', () => {
           const buildConfig = {

--- a/packages/steps/src/__tests__/BuildStep-test.ts
+++ b/packages/steps/src/__tests__/BuildStep-test.ts
@@ -1043,6 +1043,40 @@ describe(BuildStep.prototype.shouldExecuteStep, () => {
     expect(step.shouldExecuteStep(false)).toBe(true);
   });
 
+  it('returns true when an input matches', () => {
+    const ctx = createGlobalContextMock();
+    const step = new BuildStep(ctx, {
+      id: 'test1',
+      displayName: 'Test 1',
+      command: 'echo 123',
+      env: {
+        NODE_ENV: 'production',
+      },
+      inputs: [
+        new BuildStepInput(ctx, {
+          id: 'foo1',
+          stepDisplayName: 'Test 1',
+          defaultValue: 'bar',
+          required: true,
+          allowedValueTypeName: BuildStepInputValueTypeName.STRING,
+        }),
+      ],
+      ifCondition: 'inputs.foo1 === "bar"',
+    });
+    expect(step.shouldExecuteStep(false)).toBe(true);
+  });
+
+  it('returns true when an eas value matches', () => {
+    const ctx = createGlobalContextMock({ runtimePlatform: BuildRuntimePlatform.LINUX });
+    const step = new BuildStep(ctx, {
+      id: 'test1',
+      displayName: 'Test 1',
+      command: 'echo 123',
+      ifCondition: 'eas.runtimePlatform === "linux"',
+    });
+    expect(step.shouldExecuteStep(false)).toBe(true);
+  });
+
   it('returns true when if condition is success and previous steps have not failed', () => {
     const ctx = createGlobalContextMock();
     const step = new BuildStep(ctx, {

--- a/packages/steps/src/__tests__/BuildStep-test.ts
+++ b/packages/steps/src/__tests__/BuildStep-test.ts
@@ -1015,6 +1015,34 @@ describe(BuildStep.prototype.shouldExecuteStep, () => {
     expect(step.shouldExecuteStep(hasAnyPreviousStepsFailed)).toBe(false);
   });
 
+  it('returns true when a dynamic expression matches', () => {
+    const ctx = createGlobalContextMock();
+    const step = new BuildStep(ctx, {
+      id: 'test1',
+      displayName: 'Test 1',
+      command: 'echo 123',
+      env: {
+        NODE_ENV: 'production',
+      },
+      ifCondition: '${ env.NODE_ENV === "production" }',
+    });
+    expect(step.shouldExecuteStep(false)).toBe(true);
+  });
+
+  it('returns true when a simplified dynamic expression matches', () => {
+    const ctx = createGlobalContextMock();
+    const step = new BuildStep(ctx, {
+      id: 'test1',
+      displayName: 'Test 1',
+      command: 'echo 123',
+      env: {
+        NODE_ENV: 'production',
+      },
+      ifCondition: "env.NODE_ENV === 'production'",
+    });
+    expect(step.shouldExecuteStep(false)).toBe(true);
+  });
+
   it('returns true when if condition is success and previous steps have not failed', () => {
     const ctx = createGlobalContextMock();
     const step = new BuildStep(ctx, {

--- a/packages/steps/src/utils/__tests__/jsepEval-test.ts
+++ b/packages/steps/src/utils/__tests__/jsepEval-test.ts
@@ -1,0 +1,38 @@
+import { jsepEval } from '../jsepEval.js';
+
+const TEST_CASES = [
+  ['1 + 1', 2],
+  ['1 + 3', 4],
+  ['1 +3', 4],
+  ['"a" + 3', 'a3'],
+  ['true', true],
+  ['false', false],
+  ['!false', true],
+  ['"a" !== "b"', true],
+  ['"a" === "b"', false],
+  ['("a" === "a") && false', false],
+  ['("a" === "a") || false', true],
+  ['this.missing', undefined],
+  ['this["missing"]', undefined],
+  ['1 + eas', 2, { eas: 1 }],
+  ['1 + eas.jobCount', 10, { eas: { jobCount: 9 } }],
+  [
+    'success() && env.NODE_ENV === "staging"',
+    true,
+    { success: () => true, env: { NODE_ENV: 'staging' } },
+  ],
+  [
+    'success() && env.NODE_ENV === "staging"',
+    false,
+    { success: () => true, env: { NODE_ENV: 'production' } },
+  ],
+  ['0 == 1 ? "a" : "b"', 'b'],
+] as const;
+
+describe(jsepEval, () => {
+  it('works', () => {
+    for (const [expr, expectation, context] of TEST_CASES) {
+      expect(jsepEval(expr, context)).toBe(expectation);
+    }
+  });
+});

--- a/packages/steps/src/utils/jsepEval.ts
+++ b/packages/steps/src/utils/jsepEval.ts
@@ -1,0 +1,171 @@
+// https://github.com/Sensative/jsep-eval/blob/master/src/jsep-eval.js
+
+import assert from 'assert';
+
+import get from 'lodash.get';
+import jsep from 'jsep';
+
+const binaryOperatorFunctions = {
+  '===': (a: any, b: any) => a === b,
+  '!==': (a: any, b: any) => a !== b,
+  '==': (a: any, b: any) => a == b, // eslint-disable-line
+  '!=': (a: any, b: any) => a != b, // eslint-disable-line
+  '>': (a: any, b: any) => a > b,
+  '<': (a: any, b: any) => a < b,
+  '>=': (a: any, b: any) => a >= b,
+  '<=': (a: any, b: any) => a <= b,
+  '+': (a: any, b: any) => a + b,
+  '-': (a: any, b: any) => a - b,
+  '*': (a: any, b: any) => a * b,
+  '/': (a: any, b: any) => a / b,
+  '%': (a: any, b: any) => a % b, // remainder
+  '**': (a: any, b: any) => a ** b, // exponentiation
+  '&': (a: any, b: any) => a & b, // bitwise AND
+  '|': (a: any, b: any) => a | b, // bitwise OR
+  '^': (a: any, b: any) => a ^ b, // bitwise XOR
+  '<<': (a: any, b: any) => a << b, // left shift
+  '>>': (a: any, b: any) => a >> b, // sign-propagating right shift
+  '>>>': (a: any, b: any) => a >>> b, // zero-fill right shift
+  // Let's make a home for the logical operators here as well
+  '||': (a: any, b: any) => a || b,
+  '&&': (a: any, b: any) => a && b,
+};
+type BinaryOperator = keyof typeof binaryOperatorFunctions;
+
+const unaryOperatorFunctions = {
+  '!': (a: any) => !a,
+  '~': (a: any) => ~a, // bitwise NOT
+  '+': (a: any) => +a, // unary plus
+  '-': (a: any) => -a, // unary negation
+  '++': (a: any) => ++a, // increment
+  '--': (a: any) => --a, // decrement
+};
+type UnaryOperator = keyof typeof unaryOperatorFunctions;
+
+function isValid<T extends jsep.ExpressionType>(
+  expression: jsep.Expression,
+  types: T[]
+): expression is jsep.CoreExpression & { type: T } {
+  return types.includes(expression.type as T);
+}
+
+const getParameterPath = (
+  node: jsep.Identifier | jsep.MemberExpression,
+  context: Record<string, unknown>
+): string => {
+  // the easy case: 'IDENTIFIER's
+  if (node.type === 'Identifier') {
+    return node.name;
+  }
+  // Otherwise it's a MEMBER expression
+  // EXAMPLES:  a[b] (computed)
+  //            a.b (not computed)
+  const computed = node.computed;
+  const object = node.object;
+  const property = node.property;
+
+  // object is either 'IDENTIFIER', 'MEMBER', or 'THIS'
+  assert(
+    isValid(object, ['MemberExpression', 'Identifier', 'ThisExpression']),
+    'Invalid object type'
+  );
+  assert(property, 'Member expression property is missing');
+
+  let objectPath = '';
+  if (object.type === 'ThisExpression') {
+    objectPath = '';
+  } else if (typeof node.name === 'string') {
+    objectPath = node.name;
+  } else {
+    objectPath = getParameterPath(object, context);
+  }
+
+  if (computed) {
+    // if computed -> evaluate anew
+    const propertyPath = evaluateExpressionNode(property, context);
+    return objectPath + '[' + propertyPath + ']';
+  } else {
+    assert(isValid(property, ['MemberExpression', 'Identifier']), 'Invalid object type');
+    const propertyPath = property.name ?? getParameterPath(property, context);
+    return (objectPath ? objectPath + '.' : '') + propertyPath;
+  }
+};
+
+const evaluateExpressionNode = (node: jsep.Expression, context: Record<string, unknown>): any => {
+  switch (node.type as jsep.ExpressionType) {
+    case 'Literal': {
+      return (node as jsep.Literal).value;
+    }
+    case 'ThisExpression': {
+      return context;
+    }
+    case 'Compound': {
+      const compoundNode = node as jsep.Compound;
+      const expressions = compoundNode.body.map((el) => evaluateExpressionNode(el, context));
+      return expressions.pop();
+    }
+    case 'UnaryExpression': {
+      const unaryNode = node as jsep.UnaryExpression;
+      if (!(unaryNode.operator in unaryOperatorFunctions)) {
+        throw new Error(`Unsupported unary operator: ${unaryNode.operator}`);
+      }
+      const operatorFn = unaryOperatorFunctions[unaryNode.operator as UnaryOperator];
+      const argument = evaluateExpressionNode(unaryNode.argument, context);
+      return operatorFn(argument);
+    }
+    case 'BinaryExpression': {
+      const binaryNode = node as jsep.BinaryExpression;
+      if (!(binaryNode.operator in binaryOperatorFunctions)) {
+        throw new Error(`Unsupported binary operator: ${binaryNode.operator}`);
+      }
+      const operator = binaryOperatorFunctions[binaryNode.operator as BinaryOperator];
+      const left = evaluateExpressionNode(binaryNode.left, context);
+      const right = evaluateExpressionNode(binaryNode.right, context);
+      return operator(left, right);
+    }
+    case 'ConditionalExpression': {
+      const conditionalNode = node as jsep.ConditionalExpression;
+      const test = evaluateExpressionNode(conditionalNode.test, context);
+      const consequent = evaluateExpressionNode(conditionalNode.consequent, context);
+      const alternate = evaluateExpressionNode(conditionalNode.alternate, context);
+      return test ? consequent : alternate;
+    }
+    case 'CallExpression': {
+      const allowedCalleeTypes: jsep.ExpressionType[] = [
+        'MemberExpression',
+        'Identifier',
+        'ThisExpression',
+      ];
+      const callNode = node as jsep.CallExpression;
+      if (!allowedCalleeTypes.includes(callNode.callee.type as jsep.ExpressionType)) {
+        throw new Error(
+          `Invalid function callee type: ${
+            callNode.callee.type
+          }. Expected one of ${allowedCalleeTypes.join(', ')}.`
+        );
+      }
+      const callee = evaluateExpressionNode(callNode.callee, context);
+      const args = callNode.arguments.map((arg) => evaluateExpressionNode(arg, context));
+      // eslint-disable-next-line prefer-spread
+      return callee.apply(null, args);
+    }
+    case 'Identifier': // !!! fall-through to MEMBER !!! //
+    case 'MemberExpression': {
+      const path = getParameterPath(node as jsep.Identifier | jsep.MemberExpression, context);
+      return get(context, path);
+    }
+    case 'ArrayExpression': {
+      const elements = (node as jsep.ArrayExpression).elements.map((el) =>
+        evaluateExpressionNode(el, context)
+      );
+      return elements;
+    }
+    default:
+      throw new Error(`Unsupported expression type: ${node.type}`);
+  }
+};
+
+export const jsepEval = (expression: string, context?: Record<string, unknown>): any => {
+  const tree = jsep(expression);
+  return evaluateExpressionNode(tree, context ?? {});
+};

--- a/packages/steps/src/utils/template.ts
+++ b/packages/steps/src/utils/template.ts
@@ -10,8 +10,6 @@ export const BUILD_STEP_INPUT_EXPRESSION_REGEXP = /\${\s*(inputs\.[\S]+)\s*}/;
 export const BUILD_STEP_OUTPUT_EXPRESSION_REGEXP = /\${\s*(steps\.[\S]+)\s*}/;
 export const BUILD_GLOBAL_CONTEXT_EXPRESSION_REGEXP = /\${\s*(eas\.[\S]+)\s*}/;
 export const BUILD_STEP_OR_BUILD_GLOBAL_CONTEXT_REFERENCE_REGEX = /\${\s*((steps|eas)\.[\S]+)\s*}/;
-export const BUILD_STEP_IF_CONDITION_EXPRESSION_REGEXP =
-  /\${\s*(always|success|failure|never)\(\)\s*}/;
 
 export function interpolateWithInputs(
   templateString: string,
@@ -51,24 +49,6 @@ export function interpolateObjectWithOutputs(
     }
   });
   return interpolableObjectCopy;
-}
-
-/**
- * Returns the selected status check from the if statement template.
- * Example: `${ success() }` -> `success`
- */
-export function getSelectedStatusCheckFromIfStatementTemplate(
-  ifCondition: string
-): 'success' | 'failure' | 'always' | 'never' {
-  const matched = ifCondition.match(new RegExp(BUILD_STEP_IF_CONDITION_EXPRESSION_REGEXP, 'g'));
-  if (!matched) {
-    // this should never happen because of regex pattern validation
-    throw new BuildConfigError(`Invalid if condition template.`);
-  }
-  const [, selectedStatusCheck] = nullthrows(
-    matched[0].match(BUILD_STEP_IF_CONDITION_EXPRESSION_REGEXP)
-  );
-  return selectedStatusCheck as 'success' | 'failure' | 'always' | 'never';
 }
 
 export function getObjectValueForInterpolation(

--- a/yarn.lock
+++ b/yarn.lock
@@ -5914,6 +5914,11 @@ js-yaml@^3.10.0, js-yaml@^3.13.1:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
+jsep@^1.3.8:
+  version "1.3.8"
+  resolved "https://registry.yarnpkg.com/jsep/-/jsep-1.3.8.tgz#facb6eb908d085d71d950bd2b24b757c7b8a46d7"
+  integrity sha512-qofGylTGgYj9gZFsHuyWAN4jr35eJ66qJCK4eKDnldohuUoQFbU3iZn2zjvEbd9wOAhP9Wx5DsAAduTyE1PSWQ==
+
 jsesc@^2.5.1:
   version "2.5.2"
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-2.5.2.tgz#80564d2e483dacf6e8ef209650a67df3f0c283a4"


### PR DESCRIPTION
# Why

https://exponent-internal.slack.com/archives/C04GPRQCEBG/p1711393879642069?thread_ts=1711392256.213759&cid=C04GPRQCEBG

ENG-10698

# How

I looked briefly at existing libraries for parsing JS expressions and this seemed small and powerful enough. `jsep` parses the expression and then we use our own, slightly changed and typed copy of [`jsep-eval`](https://github.com/Sensative/jsep-eval/blob/master/src/jsep-eval.js).

I scrapped this quickly together and it looks quite backwards compatible.

I don't plan to do a full release with docs of this yet -- I'm thinking of just having enough to solve the aforementioned use case.

# Test Plan

Added tests.