### PR TITLE
Use all `env` for `ifCondition`

### DIFF
--- a/packages/steps/src/BuildStep.ts
+++ b/packages/steps/src/BuildStep.ts
@@ -125,7 +125,7 @@ export class BuildStep extends BuildStepOutputAccessor {
   public readonly fn?: BuildStepFunction;
   public readonly shell: string;
   public readonly ctx: BuildStepContext;
-  public readonly stepEnv: BuildStepEnv;
+  public readonly stepEnvOverrides: BuildStepEnv;
   public readonly ifCondition?: string;
   public status: BuildStepStatus;
 
@@ -222,7 +222,7 @@ export class BuildStep extends BuildStepOutputAccessor {
       buildStepDisplayName: this.displayName,
     });
     this.ctx = ctx.stepCtx({ logger, relativeWorkingDirectory: maybeWorkingDirectory });
-    this.stepEnv = env ?? {};
+    this.stepEnvOverrides = env ?? {};
 
     ctx.registerStep(this);
   }
@@ -471,7 +471,7 @@ export class BuildStep extends BuildStepOutputAccessor {
   }
 
   private get effectiveEnv(): Record<string, unknown> {
-    return { ...this.ctx.global.env, ...this.stepEnv };
+    return { ...this.ctx.global.env, ...this.stepEnvOverrides };
   }
 
   private getScriptEnv({

--- a/packages/steps/src/BuildStep.ts
+++ b/packages/steps/src/BuildStep.ts
@@ -125,7 +125,7 @@ export class BuildStep extends BuildStepOutputAccessor {
   public readonly fn?: BuildStepFunction;
   public readonly shell: string;
   public readonly ctx: BuildStepContext;
-  public readonly env: BuildStepEnv;
+  public readonly stepEnv: BuildStepEnv;
   public readonly ifCondition?: string;
   public status: BuildStepStatus;
 
@@ -222,7 +222,7 @@ export class BuildStep extends BuildStepOutputAccessor {
       buildStepDisplayName: this.displayName,
     });
     this.ctx = ctx.stepCtx({ logger, relativeWorkingDirectory: maybeWorkingDirectory });
-    this.env = env ?? {};
+    this.stepEnv = env ?? {};
 
     ctx.registerStep(this);
   }
@@ -299,7 +299,7 @@ export class BuildStep extends BuildStepOutputAccessor {
         failure: () => hasAnyPreviousStepsFailed,
         always: () => true,
         never: () => false,
-        env: this.env,
+        env: this.effectiveEnv,
         inputs:
           this.inputs?.reduce(
             (acc, input) => {
@@ -470,6 +470,10 @@ export class BuildStep extends BuildStepOutputAccessor {
     });
   }
 
+  private get effectiveEnv(): Record<string, unknown> {
+    return { ...this.ctx.global.env, ...this.stepEnv };
+  }
+
   private getScriptEnv({
     envsDir,
     outputsDir,
@@ -477,7 +481,7 @@ export class BuildStep extends BuildStepOutputAccessor {
     envsDir: string;
     outputsDir: string;
   }): Record<string, string> {
-    const env = { ...this.ctx.global.env, ...this.env };
+    const env = this.effectiveEnv;
     const currentPath = env.PATH ?? process.env.PATH;
     const newPath = currentPath ? `${BIN_PATH}:${currentPath}` : BIN_PATH;
     return {

--- a/packages/steps/src/__tests__/BuildConfigParser-test.ts
+++ b/packages/steps/src/__tests__/BuildConfigParser-test.ts
@@ -122,7 +122,7 @@ describe(BuildConfigParser, () => {
       expect(step1.command).toBe('echo "Hi!"');
       expect(step1.ctx.workingDirectory).toBe(ctx.defaultWorkingDirectory);
       expect(step1.shell).toBe(getDefaultShell());
-      expect(step1.stepEnv).toMatchObject({});
+      expect(step1.stepEnvOverrides).toMatchObject({});
 
       // - run:
       //     name: Say HELLO
@@ -138,7 +138,7 @@ describe(BuildConfigParser, () => {
       expect(step2.command).toMatchSnapshot();
       expect(step2.ctx.workingDirectory).toBe(ctx.defaultWorkingDirectory);
       expect(step2.shell).toBe(getDefaultShell());
-      expect(step2.stepEnv).toMatchObject({});
+      expect(step2.stepEnvOverrides).toMatchObject({});
 
       // - run:
       //     id: id_2137
@@ -152,7 +152,7 @@ describe(BuildConfigParser, () => {
       expect(step3.command).toBe('echo "Step with an ID"');
       expect(step3.ctx.workingDirectory).toBe(ctx.defaultWorkingDirectory);
       expect(step3.shell).toBe(getDefaultShell());
-      expect(step3.stepEnv).toMatchObject({
+      expect(step3.stepEnvOverrides).toMatchObject({
         FOO: 'bar',
         BAR: 'baz',
       });
@@ -169,7 +169,7 @@ describe(BuildConfigParser, () => {
         path.join(ctx.defaultWorkingDirectory, 'relative/path/to/files')
       );
       expect(step4.shell).toBe(getDefaultShell());
-      expect(step4.stepEnv).toMatchObject({});
+      expect(step4.stepEnvOverrides).toMatchObject({});
 
       // - run:
       //     name: List files in another directory
@@ -181,7 +181,7 @@ describe(BuildConfigParser, () => {
       expect(step5.command).toBe('ls -la');
       expect(step5.ctx.workingDirectory).toBe('/home/dsokal');
       expect(step5.shell).toBe(getDefaultShell());
-      expect(step5.stepEnv).toMatchObject({});
+      expect(step5.stepEnvOverrides).toMatchObject({});
 
       // - run:
       //     if: ${ always() }
@@ -194,7 +194,7 @@ describe(BuildConfigParser, () => {
       expect(step6.command).toBe('echo 123');
       expect(step6.ctx.workingDirectory).toBe(ctx.defaultWorkingDirectory);
       expect(step6.shell).toBe('/nib/hsab');
-      expect(step6.stepEnv).toMatchObject({});
+      expect(step6.stepEnvOverrides).toMatchObject({});
       expect(step6.ifCondition).toBe('${ always() }');
     });
 
@@ -343,7 +343,7 @@ describe(BuildConfigParser, () => {
         property2: ['aaa', 'bbb'],
       });
       expect(step1.inputs?.[2].allowedValueTypeName).toBe(BuildStepInputValueTypeName.JSON);
-      expect(step1.stepEnv).toMatchObject({
+      expect(step1.stepEnvOverrides).toMatchObject({
         ENV1: 'value1',
         ENV2: 'value2',
       });
@@ -371,7 +371,7 @@ describe(BuildConfigParser, () => {
         property2: ['value2', { value3: { property3: 'value4' } }],
       });
       expect(step2.inputs?.[2].allowedValueTypeName).toBe(BuildStepInputValueTypeName.JSON);
-      expect(step2.stepEnv).toMatchObject({});
+      expect(step2.stepEnvOverrides).toMatchObject({});
 
       // - say_hi_wojtek
       const step3 = buildSteps[2];
@@ -380,7 +380,7 @@ describe(BuildConfigParser, () => {
       expect(step3.command).toBe('echo "Hi, Wojtek!"');
       expect(step3.ctx.workingDirectory).toBe(ctx.defaultWorkingDirectory);
       expect(step3.shell).toBe(getDefaultShell());
-      expect(step3.stepEnv).toMatchObject({});
+      expect(step3.stepEnvOverrides).toMatchObject({});
 
       // - random:
       //     id: random_number
@@ -392,7 +392,7 @@ describe(BuildConfigParser, () => {
       expect(step4.shell).toBe(getDefaultShell());
       expect(step4.outputs?.[0].id).toBe('value');
       expect(step4.outputs?.[0].required).toBe(true);
-      expect(step4.stepEnv).toMatchObject({});
+      expect(step4.stepEnvOverrides).toMatchObject({});
 
       // - print:
       //     inputs:
@@ -406,7 +406,7 @@ describe(BuildConfigParser, () => {
       expect(step5.inputs?.[0].id).toBe('value');
       expect(step5.inputs?.[0].required).toBe(true);
       expect(step5.inputs?.[0].allowedValueTypeName).toBe(BuildStepInputValueTypeName.STRING);
-      expect(step5.stepEnv).toMatchObject({});
+      expect(step5.stepEnvOverrides).toMatchObject({});
 
       // - say_hi_2:
       //     inputs:
@@ -442,7 +442,7 @@ describe(BuildConfigParser, () => {
       expect(step6.inputs?.[3].defaultValue).toBe(undefined);
       expect(step6.inputs?.[3].allowedValues).toEqual(undefined);
       expect(step6.inputs?.[3].allowedValueTypeName).toBe(BuildStepInputValueTypeName.NUMBER);
-      expect(step6.stepEnv).toMatchObject({});
+      expect(step6.stepEnvOverrides).toMatchObject({});
 
       const { buildFunctions } = workflow;
       expect(Object.keys(buildFunctions).length).toBe(6);

--- a/packages/steps/src/__tests__/BuildConfigParser-test.ts
+++ b/packages/steps/src/__tests__/BuildConfigParser-test.ts
@@ -122,7 +122,7 @@ describe(BuildConfigParser, () => {
       expect(step1.command).toBe('echo "Hi!"');
       expect(step1.ctx.workingDirectory).toBe(ctx.defaultWorkingDirectory);
       expect(step1.shell).toBe(getDefaultShell());
-      expect(step1.env).toMatchObject({});
+      expect(step1.stepEnv).toMatchObject({});
 
       // - run:
       //     name: Say HELLO
@@ -138,7 +138,7 @@ describe(BuildConfigParser, () => {
       expect(step2.command).toMatchSnapshot();
       expect(step2.ctx.workingDirectory).toBe(ctx.defaultWorkingDirectory);
       expect(step2.shell).toBe(getDefaultShell());
-      expect(step2.env).toMatchObject({});
+      expect(step2.stepEnv).toMatchObject({});
 
       // - run:
       //     id: id_2137
@@ -152,7 +152,7 @@ describe(BuildConfigParser, () => {
       expect(step3.command).toBe('echo "Step with an ID"');
       expect(step3.ctx.workingDirectory).toBe(ctx.defaultWorkingDirectory);
       expect(step3.shell).toBe(getDefaultShell());
-      expect(step3.env).toMatchObject({
+      expect(step3.stepEnv).toMatchObject({
         FOO: 'bar',
         BAR: 'baz',
       });
@@ -169,7 +169,7 @@ describe(BuildConfigParser, () => {
         path.join(ctx.defaultWorkingDirectory, 'relative/path/to/files')
       );
       expect(step4.shell).toBe(getDefaultShell());
-      expect(step4.env).toMatchObject({});
+      expect(step4.stepEnv).toMatchObject({});
 
       // - run:
       //     name: List files in another directory
@@ -181,7 +181,7 @@ describe(BuildConfigParser, () => {
       expect(step5.command).toBe('ls -la');
       expect(step5.ctx.workingDirectory).toBe('/home/dsokal');
       expect(step5.shell).toBe(getDefaultShell());
-      expect(step5.env).toMatchObject({});
+      expect(step5.stepEnv).toMatchObject({});
 
       // - run:
       //     if: ${ always() }
@@ -194,7 +194,7 @@ describe(BuildConfigParser, () => {
       expect(step6.command).toBe('echo 123');
       expect(step6.ctx.workingDirectory).toBe(ctx.defaultWorkingDirectory);
       expect(step6.shell).toBe('/nib/hsab');
-      expect(step6.env).toMatchObject({});
+      expect(step6.stepEnv).toMatchObject({});
       expect(step6.ifCondition).toBe('${ always() }');
     });
 
@@ -343,7 +343,7 @@ describe(BuildConfigParser, () => {
         property2: ['aaa', 'bbb'],
       });
       expect(step1.inputs?.[2].allowedValueTypeName).toBe(BuildStepInputValueTypeName.JSON);
-      expect(step1.env).toMatchObject({
+      expect(step1.stepEnv).toMatchObject({
         ENV1: 'value1',
         ENV2: 'value2',
       });
@@ -371,7 +371,7 @@ describe(BuildConfigParser, () => {
         property2: ['value2', { value3: { property3: 'value4' } }],
       });
       expect(step2.inputs?.[2].allowedValueTypeName).toBe(BuildStepInputValueTypeName.JSON);
-      expect(step2.env).toMatchObject({});
+      expect(step2.stepEnv).toMatchObject({});
 
       // - say_hi_wojtek
       const step3 = buildSteps[2];
@@ -380,7 +380,7 @@ describe(BuildConfigParser, () => {
       expect(step3.command).toBe('echo "Hi, Wojtek!"');
       expect(step3.ctx.workingDirectory).toBe(ctx.defaultWorkingDirectory);
       expect(step3.shell).toBe(getDefaultShell());
-      expect(step3.env).toMatchObject({});
+      expect(step3.stepEnv).toMatchObject({});
 
       // - random:
       //     id: random_number
@@ -392,7 +392,7 @@ describe(BuildConfigParser, () => {
       expect(step4.shell).toBe(getDefaultShell());
       expect(step4.outputs?.[0].id).toBe('value');
       expect(step4.outputs?.[0].required).toBe(true);
-      expect(step4.env).toMatchObject({});
+      expect(step4.stepEnv).toMatchObject({});
 
       // - print:
       //     inputs:
@@ -406,7 +406,7 @@ describe(BuildConfigParser, () => {
       expect(step5.inputs?.[0].id).toBe('value');
       expect(step5.inputs?.[0].required).toBe(true);
       expect(step5.inputs?.[0].allowedValueTypeName).toBe(BuildStepInputValueTypeName.STRING);
-      expect(step5.env).toMatchObject({});
+      expect(step5.stepEnv).toMatchObject({});
 
       // - say_hi_2:
       //     inputs:
@@ -442,7 +442,7 @@ describe(BuildConfigParser, () => {
       expect(step6.inputs?.[3].defaultValue).toBe(undefined);
       expect(step6.inputs?.[3].allowedValues).toEqual(undefined);
       expect(step6.inputs?.[3].allowedValueTypeName).toBe(BuildStepInputValueTypeName.NUMBER);
-      expect(step6.env).toMatchObject({});
+      expect(step6.stepEnv).toMatchObject({});
 
       const { buildFunctions } = workflow;
       expect(Object.keys(buildFunctions).length).toBe(6);

--- a/packages/steps/src/__tests__/BuildFunction-test.ts
+++ b/packages/steps/src/__tests__/BuildFunction-test.ts
@@ -274,7 +274,7 @@ describe(BuildFunction, () => {
           ENV2: 'env2',
         },
       });
-      expect(step.env).toMatchObject({
+      expect(step.stepEnvOverrides).toMatchObject({
         ENV1: 'env1',
         ENV2: 'env2',
       });

--- a/packages/steps/src/__tests__/BuildStep-test.ts
+++ b/packages/steps/src/__tests__/BuildStep-test.ts
@@ -1017,14 +1017,17 @@ describe(BuildStep.prototype.shouldExecuteStep, () => {
 
   it('returns true when a dynamic expression matches', () => {
     const ctx = createGlobalContextMock();
+    ctx.updateEnv({
+      NODE_ENV: 'production',
+    });
     const step = new BuildStep(ctx, {
       id: 'test1',
       displayName: 'Test 1',
       command: 'echo 123',
       env: {
-        NODE_ENV: 'production',
+        LOCAL_ENV: 'true',
       },
-      ifCondition: '${ env.NODE_ENV === "production" }',
+      ifCondition: '${ env.NODE_ENV === "production" && env.LOCAL_ENV === "true" }',
     });
     expect(step.shouldExecuteStep(false)).toBe(true);
   });


### PR DESCRIPTION
# Why

I thought `this.env` contains all env variables, I was wrong.

# How

Renamed `this.env` to `this.stepEnvOverrides` so it's clear it doesn't contain all the env variables. Added `this.effectiveEnv`. Used in `ifCondition`.

# Test Plan

Adjusted test.