### PR TITLE
Export `runGenericJobAsync`

### DIFF
--- a/packages/build-tools/src/builders/__tests__/custom.test.ts
+++ b/packages/build-tools/src/builders/__tests__/custom.test.ts
@@ -1,4 +1,4 @@
-import { Job } from '@expo/eas-build-job';
+import { BuildJob } from '@expo/eas-build-job';
 import { vol } from 'memfs';
 
 import { runCustomBuildAsync } from '../custom';
@@ -19,7 +19,7 @@ afterEach(() => {
 });
 
 describe(runCustomBuildAsync, () => {
-  let ctx: BuildContext<Job>;
+  let ctx: BuildContext<BuildJob>;
 
   beforeEach(() => {
     const job = createTestIosJob();

--- a/packages/build-tools/src/builders/custom.ts
+++ b/packages/build-tools/src/builders/custom.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 
-import { BuildJob, BuildPhase, BuildTrigger, Ios, Job, Platform } from '@expo/eas-build-job';
+import { BuildJob, BuildPhase, BuildTrigger, Ios, Platform } from '@expo/eas-build-job';
 import { BuildConfigParser, BuildStepGlobalContext, errors } from '@expo/steps';
 import nullthrows from 'nullthrows';
 
@@ -12,21 +12,16 @@ import { resolveEnvFromBuildProfileAsync } from '../common/easBuildInternal';
 import { getEasFunctionGroups } from '../steps/easFunctionGroups';
 import { findAndUploadXcodeBuildLogsAsync } from '../ios/xcodeBuildLogs';
 
-export async function runCustomBuildAsync<T extends Job>(ctx: BuildContext<T>): Promise<Artifacts> {
+export async function runCustomBuildAsync(ctx: BuildContext<BuildJob>): Promise<Artifacts> {
   const customBuildCtx = new CustomBuildContext(ctx);
   await prepareProjectSourcesAsync(ctx, customBuildCtx.projectSourceDirectory);
   if (ctx.job.triggeredBy === BuildTrigger.GIT_BASED_INTEGRATION) {
-    // TODO: Add support for resolving env from job profile.
-
-    // If platform is present, the job must be BuildJob
-    if (ctx.job.platform) {
-      // We need to setup envs from eas.json
-      const env = await resolveEnvFromBuildProfileAsync(ctx as BuildContext<BuildJob>, {
-        cwd: customBuildCtx.projectSourceDirectory,
-      });
-      ctx.updateEnv(env);
-      customBuildCtx.updateEnv(ctx.env);
-    }
+    // We need to setup envs from eas.json
+    const env = await resolveEnvFromBuildProfileAsync(ctx, {
+      cwd: customBuildCtx.projectSourceDirectory,
+    });
+    ctx.updateEnv(env);
+    customBuildCtx.updateEnv(ctx.env);
   }
   const relativeConfigPath = nullthrows(
     ctx.job.customBuildConfig?.path,

--- a/packages/build-tools/src/builders/index.ts
+++ b/packages/build-tools/src/builders/index.ts
@@ -1,5 +1,4 @@
 import androidBuilder from './android';
 import iosBuilder from './ios';
-import { runCustomBuildAsync as genericBuilder } from './custom';
 
-export { androidBuilder, iosBuilder, genericBuilder };
+export { androidBuilder, iosBuilder };

--- a/packages/build-tools/src/builders/index.ts
+++ b/packages/build-tools/src/builders/index.ts
@@ -1,4 +1,5 @@
 import androidBuilder from './android';
 import iosBuilder from './ios';
+import { runCustomBuildAsync as genericBuilder } from './custom';
 
-export { androidBuilder, iosBuilder };
+export { androidBuilder, iosBuilder, genericBuilder };

--- a/packages/build-tools/src/context.ts
+++ b/packages/build-tools/src/context.ts
@@ -75,7 +75,7 @@ export interface BuildContextOptions {
 
 export class SkipNativeBuildError extends Error {}
 
-export class BuildContext<TJob extends Job> {
+export class BuildContext<TJob extends Job = Job> {
   public readonly workingdir: string;
   public logger: bunyan;
   public readonly logBuffer: LogBuffer;

--- a/packages/build-tools/src/customBuildContext.ts
+++ b/packages/build-tools/src/customBuildContext.ts
@@ -68,7 +68,7 @@ export class CustomBuildContext<TJob extends Job = Job> implements ExternalBuild
     };
   }
 
-  public hasBuildJob(): this is BuildContext<BuildJob> {
+  public hasBuildJob(): this is CustomBuildContext<BuildJob> {
     return Boolean(this.job.platform);
   }
 

--- a/packages/build-tools/src/generic.ts
+++ b/packages/build-tools/src/generic.ts
@@ -13,9 +13,7 @@ import { getEasFunctionGroups } from './steps/easFunctionGroups';
 export async function runGenericJobAsync(ctx: BuildContext<Generic.Job>): Promise<void> {
   const customBuildCtx = new CustomBuildContext(ctx);
 
-  await ctx.runBuildPhase(BuildPhase.PREPARE_PROJECT, async () => {
-    await prepareProjectSourcesAsync(ctx, customBuildCtx.projectSourceDirectory);
-  });
+  await prepareProjectSourcesAsync(ctx, customBuildCtx.projectSourceDirectory);
 
   const relativeConfigPath = nullthrows(
     ctx.job.customBuildConfig?.path,

--- a/packages/build-tools/src/generic.ts
+++ b/packages/build-tools/src/generic.ts
@@ -1,0 +1,49 @@
+import path from 'path';
+
+import { BuildPhase, Generic } from '@expo/eas-build-job';
+import { BuildConfigParser, BuildStepGlobalContext, errors } from '@expo/steps';
+import nullthrows from 'nullthrows';
+
+import { BuildContext } from './context';
+import { prepareProjectSourcesAsync } from './common/projectSources';
+import { getEasFunctions } from './steps/easFunctions';
+import { CustomBuildContext } from './customBuildContext';
+import { getEasFunctionGroups } from './steps/easFunctionGroups';
+
+export async function runGenericJobAsync(ctx: BuildContext<Generic.Job>): Promise<void> {
+  const customBuildCtx = new CustomBuildContext(ctx);
+
+  await ctx.runBuildPhase(BuildPhase.PREPARE_PROJECT, async () => {
+    await prepareProjectSourcesAsync(ctx, customBuildCtx.projectSourceDirectory);
+  });
+
+  const relativeConfigPath = nullthrows(
+    ctx.job.customBuildConfig?.path,
+    'Missing job definition file path.'
+  );
+  const configPath = path.join(customBuildCtx.projectSourceDirectory, relativeConfigPath);
+
+  const globalContext = new BuildStepGlobalContext(customBuildCtx, false);
+
+  const parser = new BuildConfigParser(globalContext, {
+    externalFunctions: getEasFunctions(customBuildCtx),
+    externalFunctionGroups: getEasFunctionGroups(customBuildCtx),
+    configPath,
+  });
+
+  const workflow = await ctx.runBuildPhase(BuildPhase.PARSE_CUSTOM_WORKFLOW_CONFIG, async () => {
+    try {
+      return await parser.parseAsync();
+    } catch (parseError: any) {
+      ctx.logger.error('Failed to parse the job definition file.');
+      if (parseError instanceof errors.BuildWorkflowError) {
+        for (const err of parseError.errors) {
+          ctx.logger.error({ err });
+        }
+      }
+      throw parseError;
+    }
+  });
+
+  await workflow.executeAsync();
+}

--- a/packages/build-tools/src/index.ts
+++ b/packages/build-tools/src/index.ts
@@ -17,3 +17,5 @@ export { PackageManager } from './utils/packageManager';
 export { findAndUploadXcodeBuildLogsAsync } from './ios/xcodeBuildLogs';
 
 export { Hook, runHookIfPresent } from './utils/hooks';
+
+export * from './generic';

--- a/packages/build-tools/src/utils/__tests__/hooks.test.ts
+++ b/packages/build-tools/src/utils/__tests__/hooks.test.ts
@@ -1,4 +1,4 @@
-import { Job } from '@expo/eas-build-job';
+import { BuildJob } from '@expo/eas-build-job';
 import spawn from '@expo/turtle-spawn';
 import { vol } from 'memfs';
 
@@ -19,14 +19,14 @@ const loggerMock = {
   child: () => loggerMock,
 };
 
-let ctx: BuildContext<Job>;
+let ctx: BuildContext<BuildJob>;
 
 describe(runHookIfPresent, () => {
   beforeEach(() => {
     vol.reset();
     (spawn as jest.Mock).mockReset();
 
-    ctx = new BuildContext({ projectRootDirectory: '.' } as Job, {
+    ctx = new BuildContext({ projectRootDirectory: '.' } as BuildJob, {
       workingdir: '/workingdir',
       logBuffer: { getLogs: () => [], getPhaseLogs: () => [] },
       logger: loggerMock as any,

--- a/packages/build-tools/src/utils/hooks.ts
+++ b/packages/build-tools/src/utils/hooks.ts
@@ -1,4 +1,4 @@
-import { Job } from '@expo/eas-build-job';
+import { BuildJob } from '@expo/eas-build-job';
 import spawn from '@expo/turtle-spawn';
 
 import { BuildContext } from '../context';
@@ -19,7 +19,7 @@ export enum Hook {
   ON_BUILD_CANCEL = 'eas-build-on-cancel',
 }
 
-export async function runHookIfPresent<TJob extends Job>(
+export async function runHookIfPresent<TJob extends BuildJob>(
   ctx: BuildContext<TJob>,
   hook: Hook,
   { extraEnvs }: { extraEnvs?: Record<string, string> } = {}


### PR DESCRIPTION
# Why

We'll use it to trigger generic jobs. For a second I thought we could reuse `runCustomBuildAsync`, but then I figured maybe it's better to have something separate.

Also, wraps preparing project with a build phase. We don't have this in custom build. I think it makes sense to track the time of archive / Git repository download? Or maybe not?

# How

Copied `runCustomBuildAsync`, removed a bunch of things. Reverted changes to `runCustomBuildAsync` done recently.

# Test Plan

This adds something new, so should be ok.