### PR TITLE
[build-tools] Add more debug logging to EAS Update steps

### DIFF
--- a/packages/build-tools/src/steps/functions/configureEASUpdateIfInstalled.ts
+++ b/packages/build-tools/src/steps/functions/configureEASUpdateIfInstalled.ts
@@ -68,7 +68,8 @@ export function configureEASUpdateIfInstalledFunction(): BuildFunction {
       }
 
       const expoUpdatesPackageVersion = await getExpoUpdatesPackageVersionIfInstalledAsync(
-        stepCtx.workingDirectory
+        stepCtx.workingDirectory,
+        stepCtx.logger
       );
       if (expoUpdatesPackageVersion === null) {
         if (throwIfNotConfigured) {

--- a/packages/build-tools/src/utils/expoUpdates.ts
+++ b/packages/build-tools/src/utils/expoUpdates.ts
@@ -147,7 +147,8 @@ export async function configureExpoUpdatesIfInstalledAsync(
   { resolvedRuntimeVersion }: { resolvedRuntimeVersion: string | null }
 ): Promise<void> {
   const expoUpdatesPackageVersion = await getExpoUpdatesPackageVersionIfInstalledAsync(
-    ctx.getReactNativeProjectDirectory()
+    ctx.getReactNativeProjectDirectory(),
+    ctx.logger
   );
   if (expoUpdatesPackageVersion === null) {
     return;
@@ -221,7 +222,7 @@ export async function resolveRuntimeVersionForExpoUpdatesIfConfiguredAsync({
   platform: Platform;
   logger: bunyan;
 }): Promise<string | null> {
-  const expoUpdatesPackageVersion = await getExpoUpdatesPackageVersionIfInstalledAsync(cwd);
+  const expoUpdatesPackageVersion = await getExpoUpdatesPackageVersionIfInstalledAsync(cwd, logger);
   if (expoUpdatesPackageVersion === null) {
     return null;
   }

--- a/packages/build-tools/src/utils/getExpoUpdatesPackageVersionIfInstalledAsync.ts
+++ b/packages/build-tools/src/utils/getExpoUpdatesPackageVersionIfInstalledAsync.ts
@@ -1,18 +1,22 @@
+import { bunyan } from '@expo/logger';
 import fs from 'fs-extra';
 import resolveFrom from 'resolve-from';
 
 export default async function getExpoUpdatesPackageVersionIfInstalledAsync(
-  reactNativeProjectDirectory: string
+  reactNativeProjectDirectory: string,
+  logger: bunyan
 ): Promise<string | null> {
   const maybePackageJson = resolveFrom.silent(
     reactNativeProjectDirectory,
     'expo-updates/package.json'
   );
 
+  let versionOuter: string | null = null;
   if (maybePackageJson) {
     const { version } = await fs.readJson(maybePackageJson);
-    return version;
+    versionOuter = version;
   }
 
-  return null;
+  logger.debug(`Resolved expo-updates package version: ${versionOuter}`);
+  return versionOuter;
 }


### PR DESCRIPTION
# Why

The runtime version resolution step I added in https://github.com/expo/eas-build/pull/361 is producing null on EAS build even though it's working on a local build. I'm having trouble setting up turtle-v2 and eas-build combination, so instead I'm opting to just add more debug logs to the builder so hopefully I can figure out what's goin on upon the next deploy.

# How

Add `logger.debug` calls.

# Test Plan

This is tougher to test since it looks like prod turtle uses `LOGGER_LEVEL` env to determine the log level (which I'm not sure how to override yet for a single build), whilst local uses `EAS_LOCAL_BUILD_LOGGER_LEVEL`. Tested with local anyways:

```EAS_LOCAL_BUILD_LOGGER_LEVEL=debug ~/expo/run-with-local-eas-build.sh build --local```
