### PR TITLE
[eas-build-job] allow to set build logger level in job object

### DIFF
--- a/packages/eas-build-job/package.json
+++ b/packages/eas-build-job/package.json
@@ -26,6 +26,7 @@
     "typescript": "^5.3.3"
   },
   "dependencies": {
+    "@expo/logger": "1.0.57",
     "joi": "^17.11.0",
     "semver": "^7.5.4",
     "zod": "^3.22.4"

--- a/packages/eas-build-job/src/__tests__/android.test.ts
+++ b/packages/eas-build-job/src/__tests__/android.test.ts
@@ -1,4 +1,5 @@
 import Joi from 'joi';
+import { LoggerLevel } from '@expo/logger';
 
 import * as Android from '../android';
 import { ArchiveSourceType, BuildMode, BuildTrigger, Platform, Workflow } from '../common';
@@ -257,6 +258,24 @@ describe('Android.JobSchema', () => {
         submitProfile: 'default',
       },
       secrets,
+    };
+    const { value, error } = Android.JobSchema.validate(job, joiOptions);
+    expect(value).toMatchObject(job);
+    expect(error).toBeFalsy();
+  });
+
+  test('can set github trigger options', () => {
+    const job = {
+      mode: BuildMode.BUILD,
+      type: Workflow.UNKNOWN,
+      platform: Platform.ANDROID,
+      projectArchive: {
+        type: ArchiveSourceType.URL,
+        url: 'https://expo.dev/builds/123',
+      },
+      projectRootDirectory: '.',
+      secrets,
+      loggerLevel: LoggerLevel.DEBUG,
     };
     const { value, error } = Android.JobSchema.validate(job, joiOptions);
     expect(value).toMatchObject(job);

--- a/packages/eas-build-job/src/__tests__/ios.test.ts
+++ b/packages/eas-build-job/src/__tests__/ios.test.ts
@@ -1,4 +1,5 @@
 import Joi from 'joi';
+import { LoggerLevel } from '@expo/logger';
 
 import { ArchiveSourceType, BuildMode, Platform, Workflow } from '../common';
 import * as Ios from '../ios';
@@ -253,6 +254,26 @@ describe('Ios.JobSchema', () => {
       secrets: {
         buildCredentials,
       },
+    };
+    const { value, error } = Ios.JobSchema.validate(job, joiOptions);
+    expect(value).toMatchObject(job);
+    expect(error).toBeFalsy();
+  });
+
+  test('can set loggerLevel', () => {
+    const job = {
+      mode: BuildMode.BUILD,
+      type: Workflow.UNKNOWN,
+      platform: Platform.IOS,
+      projectArchive: {
+        type: ArchiveSourceType.URL,
+        url: 'https://expo.dev/builds/123',
+      },
+      projectRootDirectory: '.',
+      secrets: {
+        buildCredentials,
+      },
+      loggerLevel: LoggerLevel.INFO,
     };
     const { value, error } = Ios.JobSchema.validate(job, joiOptions);
     expect(value).toMatchObject(job);

--- a/packages/eas-build-job/src/android.ts
+++ b/packages/eas-build-job/src/android.ts
@@ -1,4 +1,5 @@
 import Joi from 'joi';
+import { LoggerLevel } from '@expo/logger';
 
 import {
   ArchiveSource,
@@ -111,6 +112,7 @@ export interface Job {
     autoSubmit: boolean;
     submitProfile?: string;
   };
+  loggerLevel?: LoggerLevel;
 }
 
 const SecretsSchema = Joi.object({
@@ -174,4 +176,5 @@ export const JobSchema = Joi.object({
     autoSubmit: Joi.boolean().default(false),
     submitProfile: Joi.string(),
   }),
+  loggerLevel: Joi.string().valid(...Object.values(LoggerLevel)),
 }).oxor('releaseChannel', 'updates.channel');

--- a/packages/eas-build-job/src/generic.ts
+++ b/packages/eas-build-job/src/generic.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { LoggerLevel } from '@expo/logger';
 
 import { ArchiveSourceSchemaZ, BuildTrigger, EnvironmentSecretZ } from './common';
 
@@ -34,5 +35,6 @@ export namespace Generic {
     // We use this to discern between Android.Job, Ios.Job and Generic.Job.
     platform: z.never().optional(),
     triggeredBy: z.literal(BuildTrigger.GIT_BASED_INTEGRATION),
+    loggerLevel: z.nativeEnum(LoggerLevel).optional(),
   });
 }

--- a/packages/eas-build-job/src/ios.ts
+++ b/packages/eas-build-job/src/ios.ts
@@ -1,4 +1,5 @@
 import Joi from 'joi';
+import { LoggerLevel } from '@expo/logger';
 
 import {
   ArchiveSource,
@@ -125,6 +126,7 @@ export interface Job {
     autoSubmit: boolean;
     submitProfile?: string;
   };
+  loggerLevel?: LoggerLevel;
 }
 
 const SecretsSchema = Joi.object({
@@ -210,4 +212,5 @@ export const JobSchema = Joi.object({
     autoSubmit: Joi.boolean().default(false),
     submitProfile: Joi.string(),
   }),
+  loggerLevel: Joi.string().valid(...Object.values(LoggerLevel)),
 }).oxor('releaseChannel', 'updates.channel');


### PR DESCRIPTION
# Why

We currently set the logger level globally per `worker` service, so we never see debug logs in staging/production because the level there is just `info`. It might be helpful to allow setting logger level on a per-build basis.

I want to allow people to use it like `eas build ... --logger-level debug`

https://exponent-internal.slack.com/archives/C02123T524U/p1711730641664359

@wschurman highlighted a need for something like this

# How

Add `loggerLevel` to the job object

# Test Plan

Tests
