### PR TITLE
[local-build-plugin] handle `job.loggerLevel` for local builds

### DIFF
--- a/packages/local-build-plugin/src/android.ts
+++ b/packages/local-build-plugin/src/android.ts
@@ -2,7 +2,7 @@ import { Android, ManagedArtifactType, BuildPhase, Env } from '@expo/eas-build-j
 import { Builders, BuildContext, Artifacts } from '@expo/build-tools';
 import omit from 'lodash/omit';
 
-import logger, { logBuffer } from './logger';
+import { logBuffer } from './logger';
 import { BuildParams } from './types';
 import { prepareArtifacts } from './artifacts';
 import config from './config';
@@ -10,7 +10,7 @@ import { runGlobalExpoCliCommandAsync } from './expoCli';
 
 export async function buildAndroidAsync(
   job: Android.Job,
-  { workingdir, env: baseEnv, metadata }: BuildParams
+  { workingdir, env: baseEnv, metadata, logger }: BuildParams
 ): Promise<Artifacts> {
   const versionName = job.version?.versionName;
   const versionCode = job.version?.versionCode;

--- a/packages/local-build-plugin/src/build.ts
+++ b/packages/local-build-plugin/src/build.ts
@@ -5,7 +5,7 @@ import pickBy from 'lodash/pickBy';
 import fs from 'fs-extra';
 import chalk from 'chalk';
 import { Artifacts, SkipNativeBuildError } from '@expo/build-tools';
-import { LoggerLevel } from '@expo/logger';
+import { DEBUG } from 'bunyan';
 
 import { buildAndroidAsync } from './android';
 import config from './config';
@@ -15,7 +15,7 @@ import { createLogger } from './logger';
 
 export async function buildAsync(job: BuildJob, metadata: Metadata): Promise<void> {
   const logger = createLogger(job.loggerLevel);
-  const workingdir = await prepareWorkingdirAsync(logger);
+  const workingdir = await prepareWorkingdirAsync({ logger });
 
   try {
     let username = metadata.username;
@@ -75,7 +75,7 @@ export async function buildAsync(job: BuildJob, metadata: Metadata): Promise<voi
     }
     console.error();
     console.error(chalk.red(`Build failed`));
-    if (config.logger.defaultLoggerLevel === LoggerLevel.DEBUG) {
+    if (logger.level() === DEBUG) {
       console.error(e.innerError);
     }
     throw e;

--- a/packages/local-build-plugin/src/build.ts
+++ b/packages/local-build-plugin/src/build.ts
@@ -5,14 +5,17 @@ import pickBy from 'lodash/pickBy';
 import fs from 'fs-extra';
 import chalk from 'chalk';
 import { Artifacts, SkipNativeBuildError } from '@expo/build-tools';
+import { LoggerLevel } from '@expo/logger';
 
 import { buildAndroidAsync } from './android';
 import config from './config';
 import { buildIosAsync } from './ios';
 import { prepareWorkingdirAsync } from './workingdir';
+import { createLogger } from './logger';
 
 export async function buildAsync(job: BuildJob, metadata: Metadata): Promise<void> {
-  const workingdir = await prepareWorkingdirAsync();
+  const logger = createLogger(job.loggerLevel);
+  const workingdir = await prepareWorkingdirAsync(logger);
 
   try {
     let username = metadata.username;
@@ -48,11 +51,11 @@ export async function buildAsync(job: BuildJob, metadata: Metadata): Promise<voi
     let artifacts: Artifacts | undefined;
     switch (job.platform) {
       case Platform.ANDROID: {
-        artifacts = await buildAndroidAsync(job, { env, workingdir, metadata });
+        artifacts = await buildAndroidAsync(job, { env, workingdir, metadata, logger });
         break;
       }
       case Platform.IOS: {
-        artifacts = await buildIosAsync(job, { env, workingdir, metadata });
+        artifacts = await buildIosAsync(job, { env, workingdir, metadata, logger });
         break;
       }
     }
@@ -72,7 +75,7 @@ export async function buildAsync(job: BuildJob, metadata: Metadata): Promise<voi
     }
     console.error();
     console.error(chalk.red(`Build failed`));
-    if (config.logger.level === 'debug') {
+    if (config.logger.defaultLoggerLevel === LoggerLevel.DEBUG) {
       console.error(e.innerError);
     }
     throw e;

--- a/packages/local-build-plugin/src/config.ts
+++ b/packages/local-build-plugin/src/config.ts
@@ -2,21 +2,27 @@ import path from 'path';
 
 import { v4 as uuidv4 } from 'uuid';
 import envPaths from 'env-paths';
+import { LoggerLevel } from '@expo/logger';
 
 const { temp } = envPaths('eas-build-local');
 
-const envLoggerLevel = process.env.EAS_LOCAL_BUILD_LOGGER_LEVEL;
 const envWorkingdir = process.env.EAS_LOCAL_BUILD_WORKINGDIR;
 const envSkipCleanup = process.env.EAS_LOCAL_BUILD_SKIP_CLEANUP;
 const envSkipNativeBuild = process.env.EAS_LOCAL_BUILD_SKIP_NATIVE_BUILD;
 const envArtifactsDir = process.env.EAS_LOCAL_BUILD_ARTIFACTS_DIR;
 const envArtifactPath = process.env.EAS_LOCAL_BUILD_ARTIFACT_PATH;
 
-if (envLoggerLevel && !['debug', 'info', 'warn', 'error'].includes(envLoggerLevel)) {
+if (
+  process.env.EAS_LOCAL_BUILD_LOGGER_LEVEL &&
+  !Object.values(LoggerLevel).includes(process.env.EAS_LOCAL_BUILD_LOGGER_LEVEL as LoggerLevel)
+) {
   throw new Error(
-    'Invalid value for EAS_LOCAL_BUILD_LOGGER_LEVEL, one of info, warn, or error is expected'
+    `Invalid value for EAS_LOCAL_BUILD_LOGGER_LEVEL, one of ${Object.values(LoggerLevel)
+      .map((ll) => `"${ll}"`)
+      .join(', ')} is expected`
   );
 }
+const envLoggerLevel = process.env.EAS_LOCAL_BUILD_LOGGER_LEVEL as LoggerLevel;
 
 export default {
   workingdir: envWorkingdir ?? path.join(temp, uuidv4()),
@@ -25,6 +31,6 @@ export default {
   artifactsDir: envArtifactsDir ?? process.cwd(),
   artifactPath: envArtifactPath,
   logger: {
-    level: (envLoggerLevel ?? 'info') as 'debug' | 'info' | 'warn' | 'error',
+    defaultLoggerLevel: envLoggerLevel ?? LoggerLevel.INFO,
   },
 };

--- a/packages/local-build-plugin/src/exit.ts
+++ b/packages/local-build-plugin/src/exit.ts
@@ -1,4 +1,4 @@
-import logger from './logger';
+import { createLogger } from './logger';
 
 const handlers: (() => void | Promise<void>)[] = [];
 let shouldExitStatus = false;
@@ -13,7 +13,7 @@ export function listenForInterrupts(): void {
         return;
       }
       handlerInProgress = true;
-      logger.error({ phase: 'ABORT' }, 'Received termination signal.');
+      createLogger().error({ phase: 'ABORT' }, 'Received termination signal.');
       shouldExitStatus = true;
       await Promise.allSettled(
         handlers.map((handler) => {

--- a/packages/local-build-plugin/src/ios.ts
+++ b/packages/local-build-plugin/src/ios.ts
@@ -3,14 +3,14 @@ import { Builders, BuildContext, Artifacts } from '@expo/build-tools';
 import omit from 'lodash/omit';
 
 import { runGlobalExpoCliCommandAsync } from './expoCli';
-import logger, { logBuffer } from './logger';
+import { logBuffer } from './logger';
 import { BuildParams } from './types';
 import { prepareArtifacts } from './artifacts';
 import config from './config';
 
 export async function buildIosAsync(
   job: Ios.Job,
-  { workingdir, env: baseEnv, metadata }: BuildParams
+  { workingdir, env: baseEnv, metadata, logger }: BuildParams
 ): Promise<Artifacts> {
   const buildNumber = job.version?.buildNumber;
   const appVersion = job.version?.appVersion;

--- a/packages/local-build-plugin/src/logger.ts
+++ b/packages/local-build-plugin/src/logger.ts
@@ -4,6 +4,7 @@ import bunyan from 'bunyan';
 import chalk from 'chalk';
 import omit from 'lodash/omit';
 import { LogBuffer } from '@expo/build-tools';
+import { LoggerLevel } from '@expo/logger';
 
 import config from './config';
 
@@ -130,19 +131,19 @@ class PrettyStream extends Writable {
 
 export const logBuffer = new BuildCliLogBuffer(MAX_LINES_IN_BUFFER);
 
-const defaultlogger = bunyan.createLogger({
-  name: 'eas-build-cli',
-  serializers: bunyan.stdSerializers,
-  streams: [
-    {
-      level: config.logger.level,
-      stream: new PrettyStream(),
-    },
-    {
-      level: 'info',
-      stream: logBuffer,
-    },
-  ],
-});
-
-export default defaultlogger;
+export function createLogger(level?: LoggerLevel): bunyan {
+  return bunyan.createLogger({
+    name: 'eas-build-cli',
+    serializers: bunyan.stdSerializers,
+    streams: [
+      {
+        level: level ?? config.logger.defaultLoggerLevel,
+        stream: new PrettyStream(),
+      },
+      {
+        level: LoggerLevel.INFO,
+        stream: logBuffer,
+      },
+    ],
+  });
+}

--- a/packages/local-build-plugin/src/types.ts
+++ b/packages/local-build-plugin/src/types.ts
@@ -1,7 +1,9 @@
 import { Metadata } from '@expo/eas-build-job';
+import { bunyan } from '@expo/logger';
 
 export interface BuildParams {
   workingdir: string;
   env: Record<string, string>;
   metadata: Metadata;
+  logger: bunyan;
 }

--- a/packages/local-build-plugin/src/workingdir.ts
+++ b/packages/local-build-plugin/src/workingdir.ts
@@ -7,7 +7,7 @@ import { bunyan } from '@expo/logger';
 import config from './config';
 import { registerHandler } from './exit';
 
-export async function prepareWorkingdirAsync(logger: bunyan): Promise<string> {
+export async function prepareWorkingdirAsync({ logger }: { logger: bunyan }): Promise<string> {
   const { workingdir } = config;
   logger.info({ phase: 'SETUP_WORKINGDIR' }, `Preparing workingdir ${workingdir}`);
 

--- a/packages/local-build-plugin/src/workingdir.ts
+++ b/packages/local-build-plugin/src/workingdir.ts
@@ -2,12 +2,12 @@ import path from 'path';
 
 import chalk from 'chalk';
 import fs from 'fs-extra';
+import { bunyan } from '@expo/logger';
 
 import config from './config';
-import logger from './logger';
 import { registerHandler } from './exit';
 
-export async function prepareWorkingdirAsync(): Promise<string> {
+export async function prepareWorkingdirAsync(logger: bunyan): Promise<string> {
   const { workingdir } = config;
   logger.info({ phase: 'SETUP_WORKINGDIR' }, `Preparing workingdir ${workingdir}`);
 


### PR DESCRIPTION
# Why

We want to respect `job.loggerLevel` for local builds as well

# How

Use `job.loggerLevel` for logger level

# Test Plan

Tests
