### PR TITLE
[build-tools] Improve debuggability of command output in updates runtime version resolution

### DIFF
--- a/packages/build-tools/src/utils/resolveRuntimeVersionAsync.ts
+++ b/packages/build-tools/src/utils/resolveRuntimeVersionAsync.ts
@@ -37,10 +37,10 @@ export async function resolveRuntimeVersionAsync({
       ...extraArgs,
     ]);
     const runtimeVersionResult = JSON.parse(resolvedRuntimeVersionJSONResult);
-    if (runtimeVersionResult.fingerprintSources) {
-      logger.debug(`Resolved fingeprint runtime version for platform "${platform}". Sources:`);
-      logger.debug(runtimeVersionResult.fingerprintSources);
-    }
+
+    logger.debug('runtimeversion:resolve output:');
+    logger.debug(runtimeVersionResult);
+
     return runtimeVersionResult.runtimeVersion ?? null;
   } catch (e: any) {
     // if expo-updates is not installed, there's no need for a runtime version in the build


### PR DESCRIPTION
# Why

Follow-up to https://github.com/expo/eas-build/pull/374 that tweaks debug logging a bit more.

Now that I have debug logging enabled in staging for my test project, I can see that it is calling the CLI. But for some reason the result is still null for expo-updates runtime version resolution here.

I also added a test post-install hook just to be sure:
```
"eas-build-post-install": "npx expo-updates runtimeversion:resolve --platform android --debug"
```
and that looks fine (fingerprints), so it's very puzzling why this is failing to resolve.

# How

Always print output of command to debug logger.

# Test Plan

Inspect.
