### PR TITLE
[build-tools] use correct dir to read `eas.json` from for custom builds

### DIFF
--- a/packages/build-tools/src/builders/custom.ts
+++ b/packages/build-tools/src/builders/custom.ts
@@ -18,7 +18,7 @@ export async function runCustomBuildAsync(ctx: BuildContext<BuildJob>): Promise<
   if (ctx.job.triggeredBy === BuildTrigger.GIT_BASED_INTEGRATION) {
     // We need to setup envs from eas.json
     const env = await resolveEnvFromBuildProfileAsync(ctx, {
-      cwd: customBuildCtx.projectSourceDirectory,
+      cwd: path.join(customBuildCtx.projectSourceDirectory, ctx.job.projectRootDirectory ?? '.'),
     });
     ctx.updateEnv(env);
     customBuildCtx.updateEnv(ctx.env);


### PR DESCRIPTION
# Why

https://discord.com/channels/695411232856997968/1227710666954248213/1227710666954248213

we used the incorrect dir to load the eas.json

# How

Use correct dir

based on https://github.com/expo/eas-build/blob/a6c4aeb1190b2efab22c59d13052f0e686aea505/packages/build-tools/src/context.ts#L290

# Test Plan

tests, test on staging later on