### PR TITLE
[build-tools] Use @expo/turtle-spawn instead of @expo/spawn-async and specify stdio and cwd

### DIFF
--- a/packages/build-tools/src/utils/resolveRuntimeVersionAsync.ts
+++ b/packages/build-tools/src/utils/resolveRuntimeVersionAsync.ts
@@ -30,16 +30,17 @@ export async function resolveRuntimeVersionAsync({
 
     const extraArgs = logger.debug() ? ['--debug'] : [];
 
-    const resolvedRuntimeVersionJSONResult = await expoUpdatesCommandAsync(projectDir, [
-      'runtimeversion:resolve',
-      '--platform',
-      platform,
-      ...extraArgs,
-    ]);
+    const resolvedRuntimeVersionJSONResult = await expoUpdatesCommandAsync(
+      projectDir,
+      ['runtimeversion:resolve', '--platform', platform, ...extraArgs],
+      {
+        logger,
+      }
+    );
     const runtimeVersionResult = JSON.parse(resolvedRuntimeVersionJSONResult);
 
     logger.debug('runtimeversion:resolve output:');
-    logger.debug(runtimeVersionResult);
+    logger.debug(resolvedRuntimeVersionJSONResult);
 
     return runtimeVersionResult.runtimeVersion ?? null;
   } catch (e: any) {


### PR DESCRIPTION
# Why

As suggested by @sjchmiela on slack, one possible reason we're seeing a discrepancy between prod and local is the presence of the `stdio: 'pipe'` option to `spawnAsync`.

# How

Update call.

# Test Plan

Run locally using same process as https://github.com/expo/eas-build/pull/374 test plan, ensure it still works.
