### PR TITLE
[ci] add `workflow_dispatch` as licence workflow trigger as well

### DIFF
--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -7,6 +7,7 @@ on:
       - main
     paths:
       - .github/workflows/license.yml
+  workflow_dispatch:
 
 jobs:
   test:


### PR DESCRIPTION
# Why

https://github.com/expo/eas-build/actions/workflows/license.yml failed and I want to allow us to easily run it again

# How

add workflow_dispatch

# Test Plan

dispatch the workflow after it lands
