### PR TITLE
[build-tools] Pass through workflow from job to expo-updates CLI commands

### DIFF
--- a/packages/build-tools/src/builders/android.ts
+++ b/packages/build-tools/src/builders/android.ts
@@ -77,6 +77,7 @@ async function buildAsync(ctx: BuildContext<Android.Job>): Promise<void> {
         logger: ctx.logger,
         appConfig: ctx.appConfig,
         platform: ctx.job.platform,
+        workflow: ctx.job.type,
       });
     }
   );
@@ -105,7 +106,12 @@ async function buildAsync(ctx: BuildContext<Android.Job>): Promise<void> {
       gradleCommand,
       androidDir: path.join(ctx.getReactNativeProjectDirectory(), 'android'),
       ...(resolvedExpoUpdatesRuntimeVersion
-        ? { extraEnv: { EXPO_UPDATES_FINGERPRINT_OVERRIDE: resolvedExpoUpdatesRuntimeVersion } }
+        ? {
+            extraEnv: {
+              EXPO_UPDATES_FINGERPRINT_OVERRIDE: resolvedExpoUpdatesRuntimeVersion,
+              EXPO_UPDATES_WORKFLOW_OVERRIDE: ctx.job.type,
+            },
+          }
         : null),
     });
   });

--- a/packages/build-tools/src/builders/ios.ts
+++ b/packages/build-tools/src/builders/ios.ts
@@ -85,6 +85,7 @@ async function buildAsync(ctx: BuildContext<Ios.Job>): Promise<void> {
           logger: ctx.logger,
           appConfig: ctx.appConfig,
           platform: ctx.job.platform,
+          workflow: ctx.job.type,
         });
       }
     );

--- a/packages/build-tools/src/steps/functions/calculateEASUpdateRuntimeVersion.ts
+++ b/packages/build-tools/src/steps/functions/calculateEASUpdateRuntimeVersion.ts
@@ -1,4 +1,4 @@
-import { Platform } from '@expo/eas-build-job';
+import { Platform, Workflow } from '@expo/eas-build-job';
 import {
   BuildFunction,
   BuildStepInput,
@@ -20,6 +20,12 @@ export function calculateEASUpdateRuntimeVersionFunction(ctx: CustomBuildContext
         id: 'platform',
         defaultValue: ctx.job.platform,
         required: !ctx.job.platform,
+        allowedValueTypeName: BuildStepInputValueTypeName.STRING,
+      }),
+      BuildStepInput.createProvider({
+        id: 'workflow',
+        defaultValue: ctx.job.type,
+        required: !ctx.job.type,
         allowedValueTypeName: BuildStepInputValueTypeName.STRING,
       }),
     ],
@@ -47,6 +53,7 @@ export function calculateEASUpdateRuntimeVersionFunction(ctx: CustomBuildContext
         logger: stepCtx.logger,
         appConfig,
         platform: inputs.platform.value as Platform,
+        workflow: inputs.workflow.value as Workflow,
       });
       if (resolvedRuntimeVersion) {
         outputs.resolved_eas_update_runtime_version.set(resolvedRuntimeVersion);

--- a/packages/build-tools/src/utils/expoUpdates.ts
+++ b/packages/build-tools/src/utils/expoUpdates.ts
@@ -1,6 +1,6 @@
 import assert from 'assert';
 
-import { Platform, Job, BuildJob } from '@expo/eas-build-job';
+import { Platform, Job, BuildJob, Workflow } from '@expo/eas-build-job';
 import semver from 'semver';
 import { ExpoConfig } from '@expo/config';
 import { bunyan } from '@expo/logger';
@@ -215,11 +215,13 @@ export async function resolveRuntimeVersionForExpoUpdatesIfConfiguredAsync({
   cwd,
   appConfig,
   platform,
+  workflow,
   logger,
 }: {
   cwd: string;
   appConfig: ExpoConfig;
   platform: Platform;
+  workflow: Workflow;
   logger: bunyan;
 }): Promise<string | null> {
   const expoUpdatesPackageVersion = await getExpoUpdatesPackageVersionIfInstalledAsync(cwd, logger);
@@ -231,6 +233,7 @@ export async function resolveRuntimeVersionForExpoUpdatesIfConfiguredAsync({
     projectDir: cwd,
     exp: appConfig,
     platform,
+    workflow,
     logger,
     expoUpdatesPackageVersion,
   });

--- a/packages/build-tools/src/utils/resolveRuntimeVersionAsync.ts
+++ b/packages/build-tools/src/utils/resolveRuntimeVersionAsync.ts
@@ -1,6 +1,7 @@
 import { ExpoConfig } from '@expo/config';
 import { Updates } from '@expo/config-plugins';
 import { bunyan } from '@expo/logger';
+import { Workflow } from '@expo/eas-build-job';
 
 import { ExpoUpdatesCLIModuleNotFoundError, expoUpdatesCommandAsync } from './expoUpdatesCli';
 import { isModernExpoUpdatesCLIWithRuntimeVersionCommandSupported } from './expoUpdates';
@@ -8,12 +9,14 @@ import { isModernExpoUpdatesCLIWithRuntimeVersionCommandSupported } from './expo
 export async function resolveRuntimeVersionAsync({
   exp,
   platform,
+  workflow,
   projectDir,
   logger,
   expoUpdatesPackageVersion,
 }: {
   exp: ExpoConfig;
   platform: 'ios' | 'android';
+  workflow: Workflow;
   projectDir: string;
   logger: bunyan;
   expoUpdatesPackageVersion: string;
@@ -32,7 +35,7 @@ export async function resolveRuntimeVersionAsync({
 
     const resolvedRuntimeVersionJSONResult = await expoUpdatesCommandAsync(
       projectDir,
-      ['runtimeversion:resolve', '--platform', platform, ...extraArgs],
+      ['runtimeversion:resolve', '--platform', platform, '--workflow', workflow, ...extraArgs],
       {
         logger,
       }

--- a/packages/eas-build-job/src/generic.ts
+++ b/packages/eas-build-job/src/generic.ts
@@ -34,6 +34,7 @@ export namespace Generic {
     builderEnvironment: BuilderEnvironmentSchemaZ,
     // We use this to discern between Android.Job, Ios.Job and Generic.Job.
     platform: z.never().optional(),
+    type: z.never().optional(),
     triggeredBy: z.literal(BuildTrigger.GIT_BASED_INTEGRATION),
     loggerLevel: z.nativeEnum(LoggerLevel).optional(),
   });


### PR DESCRIPTION
# Why

`eas-build` change corresponding to https://github.com/expo/expo/pull/28403, which allows passing the workflow through from the job. This is necessary in EAS Build since it does prebuild, and workflow auto-detection in expo-updates depends on the presence of native directories or lack thereof, as well as their gitignore status.

Because our default gitignore doesn't ignore the native directories, prebuilt will make the detection code think it's a generic workflow.

# How

Pass workflow through. Note that in this library, there's a third workflow enum "UNKNOWN", which if passed through to the expo-updates CLIs will throw. This is on purpose as we shouldn't be running those CLIs for jobs where the workflow is unknown. Note that eas-cli only ever generates generic or managed when constructing a normal build job (the only type of job where these are run).

# Test Plan

Follow test plan of https://github.com/expo/expo/pull/28403 to create the project, then run the following to ensure runtime version resolution works with new arg:

`~/expo/run-with-local-eas-build.sh build --local`
