### PR TITLE
[build-tools] Fill in min expo-updates version for expo-updates CLI

### DIFF
--- a/packages/build-tools/src/utils/expoUpdates.ts
+++ b/packages/build-tools/src/utils/expoUpdates.ts
@@ -302,6 +302,6 @@ export function isModernExpoUpdatesCLIWithRuntimeVersionCommandSupported(
     return true;
   }
 
-  // TODO(wschurman): add semver check once we know the SDK51 version of expo-updates that supports this
-  return false;
+  // Anything SDK 51 or greater uses the expo-updates CLI
+  return semver.gte(expoUpdatesPackageVersion, '0.25.4');
 }


### PR DESCRIPTION
# Why

Now that we know roughly the version of expo-updates that this is supported in, we can hardcode it like we do with others. Need to do this with eas-cli as well.

Closes ENG-12103.

# How

Hardcode.

# Test Plan

Inspect.
