### PR TITLE
[build-tools] [ENG-11883] Add retries to artifact upload

### DIFF
--- a/packages/build-tools/src/__tests__/context.test.ts
+++ b/packages/build-tools/src/__tests__/context.test.ts
@@ -102,7 +102,7 @@ describe('uploadArtifact', () => {
       type: ManagedArtifactType.APPLICATION_ARCHIVE,
       paths: [],
     };
-    expect(ctx.uploadArtifact({ artifact, logger: mockLogger })).rejects.toThrow(finalError);
+    await expect(ctx.uploadArtifact({ artifact, logger: mockLogger })).rejects.toThrow(finalError);
     expect(ctx.artifacts[artifact.type]).toBeUndefined();
   });
 });

--- a/packages/build-tools/src/__tests__/context.test.ts
+++ b/packages/build-tools/src/__tests__/context.test.ts
@@ -1,0 +1,108 @@
+import { createLogger } from '@expo/logger';
+import { ManagedArtifactType } from '@expo/eas-build-job';
+
+import { BuildContext } from '../context';
+
+import { createTestIosJob } from './utils/job';
+
+const mockLogger = createLogger({ name: 'mock-logger' });
+
+describe('uploadArtifact', () => {
+  it('uploads artifact if successful first time', async () => {
+    const job = createTestIosJob();
+    const ctx = new BuildContext(job, {
+      workingdir: '/workingdir',
+      logBuffer: { getLogs: () => [], getPhaseLogs: () => [] },
+      logger: mockLogger,
+      env: {},
+      runGlobalExpoCliCommand: jest.fn(),
+      uploadArtifact: jest.fn().mockImplementation(() => Promise.resolve('bucketKey')),
+    });
+    (ctx as any).ARTIFACT_UPLOAD_RETRY_INTERVAL_MS = 500;
+    const artifact = {
+      type: ManagedArtifactType.APPLICATION_ARCHIVE,
+      paths: [],
+    };
+    await ctx.uploadArtifact({ artifact, logger: mockLogger });
+    expect(ctx.artifacts[artifact.type]).toEqual('bucketKey');
+  });
+  it('uploads artifact if fails first time and then succeeds', async () => {
+    const job = createTestIosJob();
+    const ctx = new BuildContext(job, {
+      workingdir: '/workingdir',
+      logBuffer: { getLogs: () => [], getPhaseLogs: () => [] },
+      logger: mockLogger,
+      env: {},
+      runGlobalExpoCliCommand: jest.fn(),
+      uploadArtifact: jest
+        .fn()
+        .mockImplementationOnce(() => {
+          throw new Error('Upload failed once');
+        })
+        .mockImplementation(() => Promise.resolve('bucketKey')),
+    });
+    (ctx as any).ARTIFACT_UPLOAD_RETRY_INTERVAL_MS = 500;
+    const artifact = {
+      type: ManagedArtifactType.APPLICATION_ARCHIVE,
+      paths: [],
+    };
+    await ctx.uploadArtifact({ artifact, logger: mockLogger });
+    expect(ctx.artifacts[artifact.type]).toEqual('bucketKey');
+  });
+  it('uploads artifact if fails twice and then succeeds', async () => {
+    const job = createTestIosJob();
+    const ctx = new BuildContext(job, {
+      workingdir: '/workingdir',
+      logBuffer: { getLogs: () => [], getPhaseLogs: () => [] },
+      logger: mockLogger,
+      env: {},
+      runGlobalExpoCliCommand: jest.fn(),
+      uploadArtifact: jest
+        .fn()
+        .mockImplementationOnce(() => {
+          throw new Error('Upload failed once');
+        })
+        .mockImplementationOnce(() => {
+          throw new Error('Upload failed twice');
+        })
+        .mockImplementation(() => Promise.resolve('bucketKey')),
+    });
+    (ctx as any).ARTIFACT_UPLOAD_RETRY_INTERVAL_MS = 500;
+    const artifact = {
+      type: ManagedArtifactType.APPLICATION_ARCHIVE,
+      paths: [],
+    };
+    await ctx.uploadArtifact({ artifact, logger: mockLogger });
+    expect(ctx.artifacts[artifact.type]).toEqual('bucketKey');
+  });
+  it('does not upload artifact if fails three times', async () => {
+    const job = createTestIosJob();
+    const finalError = new Error('Upload failed thrice');
+    const ctx = new BuildContext(job, {
+      workingdir: '/workingdir',
+      logBuffer: { getLogs: () => [], getPhaseLogs: () => [] },
+      logger: mockLogger,
+      env: {},
+      runGlobalExpoCliCommand: jest.fn(),
+      uploadArtifact: jest
+        .fn()
+        .mockImplementationOnce(() => {
+          throw new Error('Upload failed once');
+        })
+        .mockImplementationOnce(() => {
+          throw new Error('Upload failed twice');
+        })
+        .mockImplementationOnce(() => {
+          throw finalError;
+        })
+        .mockImplementation(() => Promise.resolve('bucketKey')),
+    });
+    (ctx as any).ARTIFACT_UPLOAD_RETRY_INTERVAL_MS = 500;
+    const artifact = {
+      type: ManagedArtifactType.APPLICATION_ARCHIVE,
+      paths: [],
+    };
+    expect(ctx.uploadArtifact({ artifact, logger: mockLogger })).rejects.toThrow(finalError);
+    expect(ctx.artifacts[artifact.type]).toBeUndefined();
+  });
+});

--- a/packages/build-tools/src/__tests__/context.test.ts
+++ b/packages/build-tools/src/__tests__/context.test.ts
@@ -18,7 +18,7 @@ describe('uploadArtifact', () => {
       runGlobalExpoCliCommand: jest.fn(),
       uploadArtifact: jest.fn().mockImplementation(() => Promise.resolve('bucketKey')),
     });
-    (ctx as any).ARTIFACT_UPLOAD_RETRY_INTERVAL_MS = 500;
+    (ctx as any).ARTIFACT_UPLOAD_RETRY_INTERVAL_MS = 500; // reduced for testing, normally 30s
     const artifact = {
       type: ManagedArtifactType.APPLICATION_ARCHIVE,
       paths: [],
@@ -41,7 +41,7 @@ describe('uploadArtifact', () => {
         })
         .mockImplementation(() => Promise.resolve('bucketKey')),
     });
-    (ctx as any).ARTIFACT_UPLOAD_RETRY_INTERVAL_MS = 500;
+    (ctx as any).ARTIFACT_UPLOAD_RETRY_INTERVAL_MS = 500; // reduced for testing, normally 30s
     const artifact = {
       type: ManagedArtifactType.APPLICATION_ARCHIVE,
       paths: [],
@@ -67,7 +67,7 @@ describe('uploadArtifact', () => {
         })
         .mockImplementation(() => Promise.resolve('bucketKey')),
     });
-    (ctx as any).ARTIFACT_UPLOAD_RETRY_INTERVAL_MS = 500;
+    (ctx as any).ARTIFACT_UPLOAD_RETRY_INTERVAL_MS = 500; // reduced for testing, normally 30s
     const artifact = {
       type: ManagedArtifactType.APPLICATION_ARCHIVE,
       paths: [],
@@ -97,7 +97,7 @@ describe('uploadArtifact', () => {
         })
         .mockImplementation(() => Promise.resolve('bucketKey')),
     });
-    (ctx as any).ARTIFACT_UPLOAD_RETRY_INTERVAL_MS = 500;
+    (ctx as any).ARTIFACT_UPLOAD_RETRY_INTERVAL_MS = 500; // reduced for testing, normally 30s
     const artifact = {
       type: ManagedArtifactType.APPLICATION_ARCHIVE,
       paths: [],

--- a/packages/build-tools/src/__tests__/context.test.ts
+++ b/packages/build-tools/src/__tests__/context.test.ts
@@ -7,6 +7,17 @@ import { createTestIosJob } from './utils/job';
 
 const mockLogger = createLogger({ name: 'mock-logger' });
 
+class DNSError extends Error {
+  private readonly _code: string = 'ENOTFOUND';
+  constructor(message: string, code?: string) {
+    super(message);
+    this._code = code ?? this._code;
+  }
+  public get code(): string {
+    return this._code;
+  }
+}
+
 describe('uploadArtifact', () => {
   it('uploads artifact if successful first time', async () => {
     const job = createTestIosJob();
@@ -26,7 +37,7 @@ describe('uploadArtifact', () => {
     await ctx.uploadArtifact({ artifact, logger: mockLogger });
     expect(ctx.artifacts[artifact.type]).toEqual('bucketKey');
   });
-  it('uploads artifact if fails first time and then succeeds', async () => {
+  it('uploads artifact if fails first time with DNS error and then succeeds', async () => {
     const job = createTestIosJob();
     const ctx = new BuildContext(job, {
       workingdir: '/workingdir',
@@ -37,7 +48,7 @@ describe('uploadArtifact', () => {
       uploadArtifact: jest
         .fn()
         .mockImplementationOnce(() => {
-          throw new Error('Upload failed once');
+          throw new DNSError('Upload failed once');
         })
         .mockImplementation(() => Promise.resolve('bucketKey')),
     });
@@ -49,7 +60,7 @@ describe('uploadArtifact', () => {
     await ctx.uploadArtifact({ artifact, logger: mockLogger });
     expect(ctx.artifacts[artifact.type]).toEqual('bucketKey');
   });
-  it('uploads artifact if fails twice and then succeeds', async () => {
+  it('uploads artifact if fails twice with DNS error and then succeeds', async () => {
     const job = createTestIosJob();
     const ctx = new BuildContext(job, {
       workingdir: '/workingdir',
@@ -60,10 +71,10 @@ describe('uploadArtifact', () => {
       uploadArtifact: jest
         .fn()
         .mockImplementationOnce(() => {
-          throw new Error('Upload failed once');
+          throw new DNSError('Upload failed once');
         })
         .mockImplementationOnce(() => {
-          throw new Error('Upload failed twice');
+          throw new DNSError('Upload failed twice', 'EAI_AGAIN');
         })
         .mockImplementation(() => Promise.resolve('bucketKey')),
     });
@@ -75,9 +86,9 @@ describe('uploadArtifact', () => {
     await ctx.uploadArtifact({ artifact, logger: mockLogger });
     expect(ctx.artifacts[artifact.type]).toEqual('bucketKey');
   });
-  it('does not upload artifact if fails three times', async () => {
+  it('does not upload artifact if fails three times with DNS error', async () => {
     const job = createTestIosJob();
-    const finalError = new Error('Upload failed thrice');
+    const finalError = new DNSError('Upload failed thrice');
     const ctx = new BuildContext(job, {
       workingdir: '/workingdir',
       logBuffer: { getLogs: () => [], getPhaseLogs: () => [] },
@@ -87,10 +98,10 @@ describe('uploadArtifact', () => {
       uploadArtifact: jest
         .fn()
         .mockImplementationOnce(() => {
-          throw new Error('Upload failed once');
+          throw new DNSError('Upload failed once');
         })
         .mockImplementationOnce(() => {
-          throw new Error('Upload failed twice');
+          throw new DNSError('Upload failed twice');
         })
         .mockImplementationOnce(() => {
           throw finalError;

--- a/packages/build-tools/src/__tests__/context.test.ts
+++ b/packages/build-tools/src/__tests__/context.test.ts
@@ -9,10 +9,12 @@ const mockLogger = createLogger({ name: 'mock-logger' });
 
 class DNSError extends Error {
   private readonly _code: string = 'ENOTFOUND';
+
   constructor(message: string, code?: string) {
     super(message);
     this._code = code ?? this._code;
   }
+
   public get code(): string {
     return this._code;
   }
@@ -34,9 +36,12 @@ describe('uploadArtifact', () => {
       type: ManagedArtifactType.APPLICATION_ARCHIVE,
       paths: [],
     };
+
     await ctx.uploadArtifact({ artifact, logger: mockLogger });
+
     expect(ctx.artifacts[artifact.type]).toEqual('bucketKey');
   });
+
   it('uploads artifact if fails first time with DNS error and then succeeds', async () => {
     const job = createTestIosJob();
     const ctx = new BuildContext(job, {
@@ -57,9 +62,12 @@ describe('uploadArtifact', () => {
       type: ManagedArtifactType.APPLICATION_ARCHIVE,
       paths: [],
     };
+
     await ctx.uploadArtifact({ artifact, logger: mockLogger });
+
     expect(ctx.artifacts[artifact.type]).toEqual('bucketKey');
   });
+
   it('uploads artifact if fails twice with DNS error and then succeeds', async () => {
     const job = createTestIosJob();
     const ctx = new BuildContext(job, {
@@ -83,9 +91,12 @@ describe('uploadArtifact', () => {
       type: ManagedArtifactType.APPLICATION_ARCHIVE,
       paths: [],
     };
+
     await ctx.uploadArtifact({ artifact, logger: mockLogger });
+
     expect(ctx.artifacts[artifact.type]).toEqual('bucketKey');
   });
+
   it('does not upload artifact if fails three times with DNS error', async () => {
     const job = createTestIosJob();
     const finalError = new DNSError('Upload failed thrice');
@@ -113,9 +124,12 @@ describe('uploadArtifact', () => {
       type: ManagedArtifactType.APPLICATION_ARCHIVE,
       paths: [],
     };
+
     await expect(ctx.uploadArtifact({ artifact, logger: mockLogger })).rejects.toThrow(finalError);
+
     expect(ctx.artifacts[artifact.type]).toBeUndefined();
   });
+
   it('does not upload artifact if fails once with an error different than DNS error', async () => {
     const job = createTestIosJob();
     const firstError = new Error('Upload failed with a different kind of error');
@@ -137,7 +151,9 @@ describe('uploadArtifact', () => {
       type: ManagedArtifactType.APPLICATION_ARCHIVE,
       paths: [],
     };
+
     await expect(ctx.uploadArtifact({ artifact, logger: mockLogger })).rejects.toThrow(firstError);
+
     expect(ctx.artifacts[artifact.type]).toBeUndefined();
   });
 });


### PR DESCRIPTION
# Why

https://linear.app/expo/issue/ENG-11883/retry-uploading-artifacts-to-gcs-in-turtle-workers

# How

Wrapped the inner call to upload function within `BuildContext.uploadArtifact()` in a retry.
Set the options to try 2 more times with 30s interval.

# Test Plan

Added automated tests to check the behaviour