### PR TITLE
[build-tools] Add `resources` to `build-tools` package

### DIFF
--- a/packages/build-tools/package.json
+++ b/packages/build-tools/package.json
@@ -5,6 +5,7 @@
   "types": "dist/index.d.ts",
   "files": [
     "dist",
+    "resources",
     "templates",
     "bin"
   ],


### PR DESCRIPTION
# Why

`resources` directory is missing in the _real_ package which causes EAS Preview Updates job to fail. https://expoio.sentry.io/issues/3586517651/?environment=staging&project=1837720&query=is%3Aunresolved+issue.priority%3A%5Bhigh%2C+medium%5D&referrer=issue-stream&statsPeriod=7d&stream_index=0

# How

Added `resources` to `files` in `package.json`.

# Test Plan

Ran `npm pack` and confirmed `resources` was added to the tarball.