### PR TITLE
[build-tools] pass env vars to expo updates CLI

### DIFF
--- a/packages/build-tools/src/builders/android.ts
+++ b/packages/build-tools/src/builders/android.ts
@@ -78,6 +78,7 @@ async function buildAsync(ctx: BuildContext<Android.Job>): Promise<void> {
         appConfig: ctx.appConfig,
         platform: ctx.job.platform,
         workflow: ctx.job.type,
+        env: ctx.env,
       });
     }
   );

--- a/packages/build-tools/src/builders/ios.ts
+++ b/packages/build-tools/src/builders/ios.ts
@@ -86,6 +86,7 @@ async function buildAsync(ctx: BuildContext<Ios.Job>): Promise<void> {
           appConfig: ctx.appConfig,
           platform: ctx.job.platform,
           workflow: ctx.job.type,
+          env: ctx.env,
         });
       }
     );

--- a/packages/build-tools/src/steps/functions/calculateEASUpdateRuntimeVersion.ts
+++ b/packages/build-tools/src/steps/functions/calculateEASUpdateRuntimeVersion.ts
@@ -54,6 +54,7 @@ export function calculateEASUpdateRuntimeVersionFunction(ctx: CustomBuildContext
         appConfig,
         platform: inputs.platform.value as Platform,
         workflow: inputs.workflow.value as Workflow,
+        env,
       });
       if (resolvedRuntimeVersion) {
         outputs.resolved_eas_update_runtime_version.set(resolvedRuntimeVersion);

--- a/packages/build-tools/src/utils/expoUpdates.ts
+++ b/packages/build-tools/src/utils/expoUpdates.ts
@@ -4,6 +4,7 @@ import { Platform, Job, BuildJob, Workflow } from '@expo/eas-build-job';
 import semver from 'semver';
 import { ExpoConfig } from '@expo/config';
 import { bunyan } from '@expo/logger';
+import { BuildStepEnv } from '@expo/steps';
 
 import {
   androidSetRuntimeVersionNativelyAsync,
@@ -217,12 +218,14 @@ export async function resolveRuntimeVersionForExpoUpdatesIfConfiguredAsync({
   platform,
   workflow,
   logger,
+  env,
 }: {
   cwd: string;
   appConfig: ExpoConfig;
   platform: Platform;
   workflow: Workflow;
   logger: bunyan;
+  env: BuildStepEnv;
 }): Promise<string | null> {
   const expoUpdatesPackageVersion = await getExpoUpdatesPackageVersionIfInstalledAsync(cwd, logger);
   if (expoUpdatesPackageVersion === null) {
@@ -236,6 +239,7 @@ export async function resolveRuntimeVersionForExpoUpdatesIfConfiguredAsync({
     workflow,
     logger,
     expoUpdatesPackageVersion,
+    env,
   });
 
   logger.info(`Resolved runtime version: ${resolvedRuntimeVersion}`);

--- a/packages/build-tools/src/utils/expoUpdatesCli.ts
+++ b/packages/build-tools/src/utils/expoUpdatesCli.ts
@@ -1,6 +1,7 @@
 import resolveFrom, { silent as silentResolveFrom } from 'resolve-from';
 import spawnAsync from '@expo/turtle-spawn';
 import { bunyan } from '@expo/logger';
+import { BuildStepEnv } from '@expo/steps';
 
 export class ExpoUpdatesCLIModuleNotFoundError extends Error {}
 export class ExpoUpdatesCLIInvalidCommandError extends Error {}
@@ -9,7 +10,7 @@ export class ExpoUpdatesCLICommandFailedError extends Error {}
 export async function expoUpdatesCommandAsync(
   projectDir: string,
   args: string[],
-  { logger }: { logger: bunyan }
+  { logger, env }: { logger: bunyan; env: BuildStepEnv }
 ): Promise<string> {
   let expoUpdatesCli;
   try {
@@ -30,6 +31,7 @@ export async function expoUpdatesCommandAsync(
       stdio: 'pipe',
       cwd: projectDir,
       logger,
+      env,
     });
     return spawnResult.stdout;
   } catch (e: any) {

--- a/packages/build-tools/src/utils/resolveRuntimeVersionAsync.ts
+++ b/packages/build-tools/src/utils/resolveRuntimeVersionAsync.ts
@@ -2,6 +2,7 @@ import { ExpoConfig } from '@expo/config';
 import { Updates } from '@expo/config-plugins';
 import { bunyan } from '@expo/logger';
 import { Workflow } from '@expo/eas-build-job';
+import { BuildStepEnv } from '@expo/steps';
 
 import { ExpoUpdatesCLIModuleNotFoundError, expoUpdatesCommandAsync } from './expoUpdatesCli';
 import { isModernExpoUpdatesCLIWithRuntimeVersionCommandSupported } from './expoUpdates';
@@ -13,6 +14,7 @@ export async function resolveRuntimeVersionAsync({
   projectDir,
   logger,
   expoUpdatesPackageVersion,
+  env,
 }: {
   exp: ExpoConfig;
   platform: 'ios' | 'android';
@@ -20,6 +22,7 @@ export async function resolveRuntimeVersionAsync({
   projectDir: string;
   logger: bunyan;
   expoUpdatesPackageVersion: string;
+  env: BuildStepEnv;
 }): Promise<string | null> {
   if (!isModernExpoUpdatesCLIWithRuntimeVersionCommandSupported(expoUpdatesPackageVersion)) {
     logger.debug('Using expo-updates config plugin for runtime version resolution');
@@ -38,6 +41,7 @@ export async function resolveRuntimeVersionAsync({
       ['runtimeversion:resolve', '--platform', platform, '--workflow', workflow, ...extraArgs],
       {
         logger,
+        env,
       }
     );
     const runtimeVersionResult = JSON.parse(resolvedRuntimeVersionJSONResult);


### PR DESCRIPTION
# Why

https://exponent-internal.slack.com/archives/C02123T524U/p1714578839191219

# How

pass env vars to expo updates cli

# Test Plan

tests