### PR TITLE
Add `npx -y` to `eas-cli` call

### DIFF
--- a/packages/build-tools/resources/__eas/update-publish.yml
+++ b/packages/build-tools/resources/__eas/update-publish.yml
@@ -7,4 +7,4 @@ build:
 
     - eas/install_node_modules
 
-    - run: npx -y eas-cli update --auto
+    - run: npx -y eas-cli@latest update --auto

--- a/packages/build-tools/resources/__eas/update-publish.yml
+++ b/packages/build-tools/resources/__eas/update-publish.yml
@@ -1,5 +1,5 @@
 build:
-  name: EAS Update in the Cloud
+  name: EAS Update – Publish
   steps:
     - eas/checkout
 
@@ -7,4 +7,4 @@ build:
 
     - eas/install_node_modules
 
-    - run: eas update --auto
+    - run: npx -y eas-cli update --auto


### PR DESCRIPTION
# Why

`eas` is not a globally known command in the workflow.

# How

Consulted @szdziedzic, looked at https://github.com/expo/eas-build/blob/e15bbd61ccd025b2846d480e0cf454db962b934d/packages/build-tools/src/common/easBuildInternal.ts#L116, added `npx -y` and `eas-cli` instead of `eas`.

Also added `@latest`.

Also renamed to `__eas/update-publish.yml`. https://github.com/expo/universe/pull/15197

# Test Plan

Confirmed it works on my machine.