### PR TITLE
[build-tools] Add EXPO_TOKEN to eas-cli call

### DIFF
--- a/packages/build-tools/resources/__eas/update-publish.yml
+++ b/packages/build-tools/resources/__eas/update-publish.yml
@@ -7,4 +7,7 @@ build:
 
     - eas/install_node_modules
 
-    - run: npx -y eas-cli@latest update --auto
+    - run:
+        name: Publish update
+        command: |
+          EXPO_TOKEN="${ eas.job.secrets.robotAccessToken }" npx -y eas-cli@latest update --auto


### PR DESCRIPTION
# Why

We need to expose the `robotAccessToken` if we want to use it.

# How

Used `command` interpolation. From what I could see we don't interpolate values in `env`. I checked that when interpolating, undefined falls back to `''`, so this should not break development (where we won't have `robotAccessToken` and instead rely on already authenticated `eas-cli`).

# Test Plan

Will test on staging.