### PR TITLE
[build-tools][build-job] Remove classic updates concepts

### DIFF
--- a/packages/build-tools/src/android/__tests__/expoUpdates.test.ts
+++ b/packages/build-tools/src/android/__tests__/expoUpdates.test.ts
@@ -5,10 +5,8 @@ import { AndroidConfig } from '@expo/config-plugins';
 
 import {
   AndroidMetadataName,
-  androidGetNativelyDefinedClassicReleaseChannelAsync,
   androidSetChannelNativelyAsync,
   androidGetNativelyDefinedChannelAsync,
-  androidSetClassicReleaseChannelNativelyAsync,
   androidGetNativelyDefinedRuntimeVersionAsync,
   androidSetRuntimeVersionNativelyAsync,
 } from '../expoUpdates';
@@ -21,45 +19,6 @@ const manifestPath = '/app/android/app/src/main/AndroidManifest.xml';
 
 afterEach(() => {
   vol.reset();
-});
-
-describe(androidSetClassicReleaseChannelNativelyAsync, () => {
-  test('sets the release channel', async () => {
-    vol.fromJSON(
-      {
-        'android/app/src/main/AndroidManifest.xml': originalFs.readFileSync(
-          path.join(__dirname, 'fixtures/NoMetadataAndroidManifest.xml'),
-          'utf-8'
-        ),
-      },
-      '/app'
-    );
-
-    const releaseChannel = 'blah';
-    const ctx = {
-      getReactNativeProjectDirectory: () => '/app',
-      job: { releaseChannel },
-      logger: { info: () => {} },
-    };
-
-    await androidSetClassicReleaseChannelNativelyAsync(ctx as any);
-
-    const newAndroidManifest = await AndroidConfig.Manifest.readAndroidManifestAsync(manifestPath);
-    expect(
-      AndroidConfig.Manifest.getMainApplicationMetaDataValue(
-        newAndroidManifest,
-        AndroidMetadataName.RELEASE_CHANNEL
-      )
-    ).toBe('@string/release_channel');
-
-    const stringResourcePath = await AndroidConfig.Strings.getProjectStringsXMLPathAsync(
-      ctx.getReactNativeProjectDirectory()
-    );
-    const stringResourceObject = await AndroidConfig.Resources.readResourcesXMLAsync({
-      path: stringResourcePath,
-    });
-    expect((stringResourceObject.resources.string as any)[0]['_']).toBe(releaseChannel);
-  });
 });
 
 describe(androidSetChannelNativelyAsync, () => {
@@ -108,30 +67,6 @@ describe(androidGetNativelyDefinedChannelAsync, () => {
     };
 
     await expect(androidGetNativelyDefinedChannelAsync(ctx as any)).resolves.toBe('staging-123');
-  });
-});
-
-describe(androidGetNativelyDefinedClassicReleaseChannelAsync, () => {
-  it('gets the natively defined release channel', async () => {
-    vol.fromJSON(
-      {
-        'android/app/src/main/AndroidManifest.xml': originalFs.readFileSync(
-          path.join(__dirname, 'fixtures/AndroidManifestWithClassicReleaseChannel.xml'),
-          'utf-8'
-        ),
-      },
-      '/app'
-    );
-    const ctx = {
-      getReactNativeProjectDirectory: () => '/app',
-      job: {},
-      logger: { info: () => {} },
-    };
-
-    const nativelyDefinedReleaseChannel = await androidGetNativelyDefinedClassicReleaseChannelAsync(
-      ctx as any
-    );
-    expect(nativelyDefinedReleaseChannel).toBe('example_channel');
   });
 });
 

--- a/packages/build-tools/src/android/expoUpdates.ts
+++ b/packages/build-tools/src/android/expoUpdates.ts
@@ -1,14 +1,13 @@
 import assert from 'assert';
 
 import fs from 'fs-extra';
-import { AndroidConfig, XML } from '@expo/config-plugins';
+import { AndroidConfig } from '@expo/config-plugins';
 import { BuildJob, Job } from '@expo/eas-build-job';
 
 import { BuildContext } from '../context';
 
 export enum AndroidMetadataName {
   UPDATES_CONFIGURATION_REQUEST_HEADERS_KEY = 'expo.modules.updates.UPDATES_CONFIGURATION_REQUEST_HEADERS_KEY',
-  RELEASE_CHANNEL = 'expo.modules.updates.EXPO_RELEASE_CHANNEL',
   RUNTIME_VERSION = 'expo.modules.updates.EXPO_RUNTIME_VERSION',
 }
 
@@ -88,67 +87,6 @@ export async function androidGetNativelyDefinedChannelAsync(
       `Failed to parse ${AndroidMetadataName.UPDATES_CONFIGURATION_REQUEST_HEADERS_KEY} from AndroidManifest.xml: ${err.message}`
     );
   }
-}
-
-export async function androidSetClassicReleaseChannelNativelyAsync(
-  ctx: BuildContext<BuildJob>
-): Promise<void> {
-  const { releaseChannel } = ctx.job;
-  assert(releaseChannel, 'releaseChannel must be defined');
-  const escapedReleaseChannel = XML.escapeAndroidString(releaseChannel);
-
-  const manifestPath = await AndroidConfig.Paths.getAndroidManifestAsync(
-    ctx.getReactNativeProjectDirectory()
-  );
-  if (!(await fs.pathExists(manifestPath))) {
-    throw new Error(`Couldn't find Android manifest at ${manifestPath}`);
-  }
-
-  // Store the release channel in a string resource to ensure it is interpreted as a string
-  const stringResourcePath = await AndroidConfig.Strings.getProjectStringsXMLPathAsync(
-    ctx.getReactNativeProjectDirectory()
-  );
-  const stringResourceObject = await AndroidConfig.Resources.readResourcesXMLAsync({
-    path: stringResourcePath,
-  });
-
-  const resourceName = 'release_channel';
-  const releaseChannelResourceItem = AndroidConfig.Resources.buildResourceItem({
-    name: resourceName,
-    value: escapedReleaseChannel,
-  });
-  const newStringResourceObject = AndroidConfig.Strings.setStringItem(
-    [releaseChannelResourceItem],
-    stringResourceObject
-  );
-  await XML.writeXMLAsync({ path: stringResourcePath, xml: newStringResourceObject });
-
-  const androidManifest = await AndroidConfig.Manifest.readAndroidManifestAsync(manifestPath);
-  const mainApp = AndroidConfig.Manifest.getMainApplicationOrThrow(androidManifest);
-  AndroidConfig.Manifest.addMetaDataItemToMainApplication(
-    mainApp,
-    AndroidMetadataName.RELEASE_CHANNEL,
-    `@string/${resourceName}`,
-    'value'
-  );
-  await AndroidConfig.Manifest.writeAndroidManifestAsync(manifestPath, androidManifest);
-}
-
-export async function androidGetNativelyDefinedClassicReleaseChannelAsync(
-  ctx: BuildContext<Job>
-): Promise<string | null> {
-  const manifestPath = await AndroidConfig.Paths.getAndroidManifestAsync(
-    ctx.getReactNativeProjectDirectory()
-  );
-  if (!(await fs.pathExists(manifestPath))) {
-    return null;
-  }
-
-  const androidManifest = await AndroidConfig.Manifest.readAndroidManifestAsync(manifestPath);
-  return AndroidConfig.Manifest.getMainApplicationMetaDataValue(
-    androidManifest,
-    AndroidMetadataName.RELEASE_CHANNEL
-  );
 }
 
 export async function androidGetNativelyDefinedRuntimeVersionAsync(

--- a/packages/build-tools/src/ios/__tests__/expoUpdates.test.ts
+++ b/packages/build-tools/src/ios/__tests__/expoUpdates.test.ts
@@ -3,11 +3,9 @@ import plist from '@expo/plist';
 import { vol } from 'memfs';
 
 import {
-  iosGetNativelyDefinedClassicReleaseChannelAsync,
   IosMetadataName,
   iosSetChannelNativelyAsync,
   iosGetNativelyDefinedChannelAsync,
-  iosSetClassicReleaseChannelNativelyAsync,
   iosGetNativelyDefinedRuntimeVersionAsync,
   iosSetRuntimeVersionNativelyAsync,
 } from '../../ios/expoUpdates';
@@ -26,30 +24,6 @@ const channel = 'easupdatechannel';
 
 afterEach(() => {
   vol.reset();
-});
-
-describe(iosSetClassicReleaseChannelNativelyAsync, () => {
-  test('sets the release channel', async () => {
-    const releaseChannel = 'examplechannel';
-    vol.fromJSON(
-      {
-        'ios/testapp/Supporting/Expo.plist': noItemsExpoPlist,
-        'ios/testapp.xcodeproj/project.pbxproj': 'placeholder',
-        'ios/testapp/AppDelegate.m': 'placeholder',
-      },
-      '/app'
-    );
-
-    const ctx = {
-      getReactNativeProjectDirectory: () => '/app',
-      job: { releaseChannel },
-      logger: { info: () => {} },
-    };
-    await iosSetClassicReleaseChannelNativelyAsync(ctx as any);
-
-    const newExpoPlist = await fs.readFile(expoPlistPath, 'utf8');
-    expect(plist.parse(newExpoPlist)[IosMetadataName.RELEASE_CHANNEL]).toEqual(releaseChannel);
-  });
 });
 
 describe(iosSetChannelNativelyAsync, () => {
@@ -107,39 +81,6 @@ describe(iosGetNativelyDefinedChannelAsync, () => {
       logger: { info: () => {} },
     };
     await expect(iosGetNativelyDefinedChannelAsync(ctx as any)).resolves.toBe('staging-123');
-  });
-});
-
-describe(iosGetNativelyDefinedClassicReleaseChannelAsync, () => {
-  it('gets the natively defined release channel', async () => {
-    const expoPlist = `
-    <?xml version="1.0" encoding="UTF-8"?>
-    <!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-    <plist version="1.0">
-      <dict>
-        <key>EXUpdatesReleaseChannel</key>
-        <string>examplechannel</string>
-      </dict>
-    </plist>`;
-
-    vol.fromJSON(
-      {
-        'ios/testapp/Supporting/Expo.plist': expoPlist,
-        'ios/testapp.xcodeproj/project.pbxproj': 'placeholder',
-        'ios/testapp/AppDelegate.m': 'placeholder',
-      },
-      '/app'
-    );
-
-    const ctx = {
-      getReactNativeProjectDirectory: () => '/app',
-      logger: { info: () => {} },
-    };
-    const nativelyDefinedReleaseChannel = await iosGetNativelyDefinedClassicReleaseChannelAsync(
-      ctx as any
-    );
-
-    expect(nativelyDefinedReleaseChannel).toBe('examplechannel');
   });
 });
 

--- a/packages/build-tools/src/ios/expoUpdates.ts
+++ b/packages/build-tools/src/ios/expoUpdates.ts
@@ -9,7 +9,6 @@ import { BuildContext } from '../context';
 
 export enum IosMetadataName {
   UPDATES_CONFIGURATION_REQUEST_HEADERS_KEY = 'EXUpdatesRequestHeaders',
-  RELEASE_CHANNEL = 'EXUpdatesReleaseChannel',
   RUNTIME_VERSION = 'EXUpdatesRuntimeVersion',
 }
 
@@ -75,40 +74,6 @@ export async function iosGetNativelyDefinedChannelAsync(
       `Failed to parse ${IosMetadataName.UPDATES_CONFIGURATION_REQUEST_HEADERS_KEY} from Expo.plist: ${err.message}`
     );
   }
-}
-
-export async function iosSetClassicReleaseChannelNativelyAsync(
-  ctx: BuildContext<BuildJob>
-): Promise<void> {
-  assert(ctx.job.releaseChannel, 'releaseChannel must be defined');
-
-  const expoPlistPath = IOSConfig.Paths.getExpoPlistPath(ctx.getReactNativeProjectDirectory());
-
-  if (!(await fs.pathExists(expoPlistPath))) {
-    throw new Error(`${expoPlistPath} does not exist`);
-  }
-
-  const expoPlistContents = await fs.readFile(expoPlistPath, 'utf8');
-  const items: Record<string, string | Record<string, string>> = plist.parse(expoPlistContents);
-  items[IosMetadataName.RELEASE_CHANNEL] = ctx.job.releaseChannel;
-  const updatedExpoPlistContents = plist.build(items);
-
-  await fs.writeFile(expoPlistPath, updatedExpoPlistContents);
-}
-
-export async function iosGetNativelyDefinedClassicReleaseChannelAsync(
-  ctx: BuildContext<Job>
-): Promise<string | null> {
-  const expoPlistPath = IOSConfig.Paths.getExpoPlistPath(ctx.getReactNativeProjectDirectory());
-  if (!(await fs.pathExists(expoPlistPath))) {
-    return null;
-  }
-  const expoPlistContents = await fs.readFile(expoPlistPath, 'utf8');
-  const parsedPlist = plist.parse(expoPlistContents);
-  if (!parsedPlist) {
-    return null;
-  }
-  return parsedPlist[IosMetadataName.RELEASE_CHANNEL] ?? null;
 }
 
 export async function iosGetNativelyDefinedRuntimeVersionAsync(

--- a/packages/build-tools/src/steps/functions/configureEASUpdateIfInstalled.ts
+++ b/packages/build-tools/src/steps/functions/configureEASUpdateIfInstalled.ts
@@ -55,7 +55,7 @@ export function configureEASUpdateIfInstalledFunction(): BuildFunction {
         sdkVersion: metadata?.sdkVersion,
       }).exp;
 
-      const releaseChannelInput = inputs.channel.value as string | undefined;
+      const channelInput = inputs.channel.value as string | undefined;
       const runtimeVersionInput = inputs.runtime_version.value as string | undefined;
       const resolvedRuntimeVersionInput = inputs.resolved_eas_update_runtime_version.value as
         | string
@@ -63,7 +63,7 @@ export function configureEASUpdateIfInstalledFunction(): BuildFunction {
       const throwIfNotConfigured = inputs.throw_if_not_configured.value as boolean;
       if (runtimeVersionInput && !semver.valid(runtimeVersionInput)) {
         throw new Error(
-          `Runtime version provided by the "runtime_version" input is not a valid semver version: ${releaseChannelInput}`
+          `Runtime version provided by the "runtime_version" input is not a valid semver version: ${runtimeVersionInput}`
         );
       }
 
@@ -90,7 +90,7 @@ export function configureEASUpdateIfInstalledFunction(): BuildFunction {
         appConfig,
         inputs: {
           runtimeVersion: runtimeVersionInput,
-          channel: releaseChannelInput,
+          channel: channelInput,
           resolvedRuntimeVersion: resolvedRuntimeVersionInput,
         },
         metadata: stepCtx.global.staticContext.metadata,

--- a/packages/build-tools/src/steps/utils/__tests__/expoUpdates.test.ts
+++ b/packages/build-tools/src/steps/utils/__tests__/expoUpdates.test.ts
@@ -5,8 +5,6 @@ import { ExpoConfig } from '@expo/config';
 import { configureEASUpdateAsync } from '../expoUpdates';
 import { androidSetChannelNativelyAsync } from '../android/expoUpdates';
 import { iosSetChannelNativelyAsync } from '../ios/expoUpdates';
-import { androidSetClassicReleaseChannelNativelyAsync } from '../../../android/expoUpdates';
-import { iosSetClassicReleaseChannelNativelyAsync } from '../../../ios/expoUpdates';
 
 jest.mock('../../../utils/getExpoUpdatesPackageVersionIfInstalledAsync');
 jest.mock('../ios/expoUpdates');
@@ -37,9 +35,7 @@ describe(configureEASUpdateAsync, () => {
     });
 
     expect(androidSetChannelNativelyAsync).not.toBeCalled();
-    expect(androidSetClassicReleaseChannelNativelyAsync).not.toBeCalled();
     expect(iosSetChannelNativelyAsync).not.toBeCalled();
-    expect(iosSetClassicReleaseChannelNativelyAsync).not.toBeCalled();
   });
 
   it('configures for EAS if updates.channel (eas.json) and updates.url (app config) are set', async () => {
@@ -64,16 +60,13 @@ describe(configureEASUpdateAsync, () => {
     });
 
     expect(androidSetChannelNativelyAsync).not.toBeCalled();
-    expect(androidSetClassicReleaseChannelNativelyAsync).not.toBeCalled();
     expect(iosSetChannelNativelyAsync).toBeCalledTimes(1);
-    expect(iosSetClassicReleaseChannelNativelyAsync).not.toBeCalled();
   });
 
-  it('configures for EAS if the updates.channel and releaseChannel are both set', async () => {
+  it('configures for EAS if the updates.channel is set', async () => {
     await configureEASUpdateAsync({
       job: {
         updates: { channel: 'main' },
-        releaseChannel: 'default',
         platform: Platform.IOS,
       } as unknown as BuildJob,
       workingDirectory: '/app',
@@ -90,8 +83,6 @@ describe(configureEASUpdateAsync, () => {
     });
 
     expect(androidSetChannelNativelyAsync).not.toBeCalled();
-    expect(androidSetClassicReleaseChannelNativelyAsync).not.toBeCalled();
     expect(iosSetChannelNativelyAsync).toBeCalledTimes(1);
-    expect(iosSetClassicReleaseChannelNativelyAsync).not.toBeCalled();
   });
 });

--- a/packages/build-tools/src/steps/utils/expoUpdates.ts
+++ b/packages/build-tools/src/steps/utils/expoUpdates.ts
@@ -59,23 +59,17 @@ export async function configureEASUpdateAsync({
       } else if (isDevelopmentClient) {
         // NO-OP: Development clients don't need to have a channel set
       } else {
-        if (job.releaseChannel !== undefined) {
-          logger.warn(
-            `This build is configured with EAS Update however has a Classic Updates releaseChannel set instead of having an EAS Update channel.`
-          );
-        } else {
-          const easUpdateUrl = appConfig.updates?.url ?? null;
-          const jobProfile = job.buildProfile ?? null;
-          logger.warn(
-            `This build has an invalid EAS Update configuration: update.url is set to "${easUpdateUrl}" in app config, but a channel is not specified${
-              jobProfile ? '' : ` for the current build profile "${jobProfile}" in eas.json`
-            }.`
-          );
-          logger.warn(`- No channel will be set and EAS Update will be disabled for the build.`);
-          logger.warn(
-            `- Run \`eas update:configure\` to set your channel in eas.json. For more details, see https://docs.expo.dev/eas-update/getting-started/#configure-your-project`
-          );
-        }
+        const easUpdateUrl = appConfig.updates?.url ?? null;
+        const jobProfile = job.buildProfile ?? null;
+        logger.warn(
+          `This build has an invalid EAS Update configuration: update.url is set to "${easUpdateUrl}" in app config, but a channel is not specified${
+            jobProfile ? '' : ` for the current build profile "${jobProfile}" in eas.json`
+          }.`
+        );
+        logger.warn(`- No channel will be set and EAS Update will be disabled for the build.`);
+        logger.warn(
+          `- Run \`eas update:configure\` to set your channel in eas.json. For more details, see https://docs.expo.dev/eas-update/getting-started/#configure-your-project`
+        );
       }
     }
   } else {

--- a/packages/build-tools/src/utils/__tests__/expoUpdates.test.ts
+++ b/packages/build-tools/src/utils/__tests__/expoUpdates.test.ts
@@ -3,16 +3,8 @@ import { Platform, BuildJob } from '@expo/eas-build-job';
 import { BuildContext } from '../../context';
 import * as expoUpdates from '../expoUpdates';
 import getExpoUpdatesPackageVersionIfInstalledAsync from '../getExpoUpdatesPackageVersionIfInstalledAsync';
-import {
-  iosSetChannelNativelyAsync,
-  iosSetClassicReleaseChannelNativelyAsync,
-  iosGetNativelyDefinedClassicReleaseChannelAsync,
-} from '../../ios/expoUpdates';
-import {
-  androidSetChannelNativelyAsync,
-  androidSetClassicReleaseChannelNativelyAsync,
-  androidGetNativelyDefinedClassicReleaseChannelAsync,
-} from '../../android/expoUpdates';
+import { iosSetChannelNativelyAsync } from '../../ios/expoUpdates';
+import { androidSetChannelNativelyAsync } from '../../android/expoUpdates';
 
 jest.mock('../getExpoUpdatesPackageVersionIfInstalledAsync');
 jest.mock('../../ios/expoUpdates');
@@ -36,9 +28,7 @@ describe(expoUpdates.configureExpoUpdatesIfInstalledAsync, () => {
     );
 
     expect(androidSetChannelNativelyAsync).not.toBeCalled();
-    expect(androidSetClassicReleaseChannelNativelyAsync).not.toBeCalled();
     expect(iosSetChannelNativelyAsync).not.toBeCalled();
-    expect(iosSetClassicReleaseChannelNativelyAsync).not.toBeCalled();
     expect(getExpoUpdatesPackageVersionIfInstalledAsync).toBeCalledTimes(1);
   });
 
@@ -62,9 +52,7 @@ describe(expoUpdates.configureExpoUpdatesIfInstalledAsync, () => {
     });
 
     expect(androidSetChannelNativelyAsync).not.toBeCalled();
-    expect(androidSetClassicReleaseChannelNativelyAsync).not.toBeCalled();
     expect(iosSetChannelNativelyAsync).not.toBeCalled();
-    expect(iosSetClassicReleaseChannelNativelyAsync).not.toBeCalled();
     expect(getExpoUpdatesPackageVersionIfInstalledAsync).toBeCalledTimes(1);
   });
 
@@ -91,13 +79,11 @@ describe(expoUpdates.configureExpoUpdatesIfInstalledAsync, () => {
     });
 
     expect(androidSetChannelNativelyAsync).not.toBeCalled();
-    expect(androidSetClassicReleaseChannelNativelyAsync).not.toBeCalled();
     expect(iosSetChannelNativelyAsync).toBeCalledTimes(1);
-    expect(iosSetClassicReleaseChannelNativelyAsync).not.toBeCalled();
     expect(getExpoUpdatesPackageVersionIfInstalledAsync).toBeCalledTimes(1);
   });
 
-  it('configures for EAS if the updates.channel and releaseChannel are both set', async () => {
+  it('configures for EAS if the updates.channel is set', async () => {
     jest.mocked(getExpoUpdatesPackageVersionIfInstalledAsync).mockResolvedValue('0.18.0');
 
     const managedCtx: BuildContext<BuildJob> = {
@@ -106,7 +92,7 @@ describe(expoUpdates.configureExpoUpdatesIfInstalledAsync, () => {
           url: 'https://u.expo.dev/blahblah',
         },
       },
-      job: { updates: { channel: 'main' }, releaseChannel: 'default', platform: Platform.IOS },
+      job: { updates: { channel: 'main' }, platform: Platform.IOS },
       logger: { info: () => {} },
       getReactNativeProjectDirectory: () => '/app',
     } as any;
@@ -115,158 +101,7 @@ describe(expoUpdates.configureExpoUpdatesIfInstalledAsync, () => {
     });
 
     expect(androidSetChannelNativelyAsync).not.toBeCalled();
-    expect(androidSetClassicReleaseChannelNativelyAsync).not.toBeCalled();
     expect(iosSetChannelNativelyAsync).toBeCalledTimes(1);
-    expect(iosSetClassicReleaseChannelNativelyAsync).not.toBeCalled();
     expect(getExpoUpdatesPackageVersionIfInstalledAsync).toBeCalledTimes(1);
-  });
-
-  it('configures for classic updates if the updates.channel and releaseChannel fields (eas.json) are not set, and updates.url (app config) is not set, and expo-updates version is < 0.19.0', async () => {
-    jest.mocked(getExpoUpdatesPackageVersionIfInstalledAsync).mockResolvedValue('0.18.0');
-
-    const managedCtx: BuildContext<BuildJob> = {
-      appConfig: { updates: {} },
-      job: { platform: Platform.IOS },
-      logger: { info: () => {} },
-      getReactNativeProjectDirectory: () => '/app',
-    } as any;
-    await expoUpdates.configureExpoUpdatesIfInstalledAsync(managedCtx, {
-      resolvedRuntimeVersion: '1',
-    });
-
-    expect(androidSetChannelNativelyAsync).not.toBeCalled();
-    expect(androidSetClassicReleaseChannelNativelyAsync).not.toBeCalled();
-    expect(iosSetChannelNativelyAsync).not.toBeCalled();
-    expect(iosSetClassicReleaseChannelNativelyAsync).not.toBeCalled();
-    expect(iosGetNativelyDefinedClassicReleaseChannelAsync).toBeCalledTimes(1);
-    expect(getExpoUpdatesPackageVersionIfInstalledAsync).toBeCalledTimes(1);
-  });
-
-  it('does not configure for classic updates if the updates.channel and releaseChannel fields (eas.json) are not set, and updates.url (app config) is not set, and expo-updates version is >= 0.19.0', async () => {
-    jest.mocked(getExpoUpdatesPackageVersionIfInstalledAsync).mockResolvedValue('0.19.0');
-
-    const managedCtx: BuildContext<BuildJob> = {
-      appConfig: { updates: {} },
-      job: { platform: Platform.IOS },
-      logger: { info: () => {} },
-      getReactNativeProjectDirectory: () => '/app',
-    } as any;
-    await expoUpdates.configureExpoUpdatesIfInstalledAsync(managedCtx, {
-      resolvedRuntimeVersion: '1',
-    });
-
-    expect(androidSetChannelNativelyAsync).not.toBeCalled();
-    expect(androidSetClassicReleaseChannelNativelyAsync).not.toBeCalled();
-    expect(iosSetChannelNativelyAsync).not.toBeCalled();
-    expect(iosSetClassicReleaseChannelNativelyAsync).not.toBeCalled();
-    expect(iosGetNativelyDefinedClassicReleaseChannelAsync).not.toBeCalled();
-    expect(getExpoUpdatesPackageVersionIfInstalledAsync).toBeCalledTimes(1);
-  });
-
-  it('sets the release channel if it is supplied in ctx.job.releaseChannel, and expo-updates version is < 0.19.0', async () => {
-    jest.mocked(getExpoUpdatesPackageVersionIfInstalledAsync).mockResolvedValue('0.18.0');
-
-    const managedCtx: BuildContext<BuildJob> = {
-      appConfig: {},
-      job: { releaseChannel: 'default', platform: Platform.IOS },
-      logger: { info: () => {} },
-      getReactNativeProjectDirectory: () => '/app',
-    } as any;
-    await expoUpdates.configureExpoUpdatesIfInstalledAsync(managedCtx, {
-      resolvedRuntimeVersion: '1',
-    });
-
-    expect(iosSetClassicReleaseChannelNativelyAsync).toBeCalledTimes(1);
-    expect(androidSetClassicReleaseChannelNativelyAsync).not.toBeCalled();
-    expect(iosGetNativelyDefinedClassicReleaseChannelAsync).not.toBeCalled();
-    expect(androidGetNativelyDefinedClassicReleaseChannelAsync).not.toBeCalled();
-  });
-
-  it('does not set the release channel if it is supplied in ctx.job.releaseChannel, and expo-updates version is >= 0.19.0', async () => {
-    jest.mocked(getExpoUpdatesPackageVersionIfInstalledAsync).mockResolvedValue('0.19.0');
-
-    const managedCtx: BuildContext<BuildJob> = {
-      appConfig: {},
-      job: { releaseChannel: 'default', platform: Platform.IOS },
-      logger: { info: () => {} },
-      getReactNativeProjectDirectory: () => '/app',
-    } as any;
-    await expoUpdates.configureExpoUpdatesIfInstalledAsync(managedCtx, {
-      resolvedRuntimeVersion: '1',
-    });
-
-    expect(iosSetClassicReleaseChannelNativelyAsync).not.toBeCalled();
-    expect(androidSetClassicReleaseChannelNativelyAsync).not.toBeCalled();
-    expect(iosGetNativelyDefinedClassicReleaseChannelAsync).not.toBeCalled();
-    expect(androidGetNativelyDefinedClassicReleaseChannelAsync).not.toBeCalled();
-  });
-
-  it('uses the default release channel if the releaseChannel is not defined in ctx.job.releaseChannel nor natively, and expo-updates version is < 0.19.0', async () => {
-    jest.mocked(getExpoUpdatesPackageVersionIfInstalledAsync).mockResolvedValue('0.18.0');
-
-    const infoLogger = jest.fn();
-    const managedCtx: BuildContext<BuildJob> = {
-      appConfig: {},
-      job: { platform: Platform.IOS },
-      logger: { info: infoLogger, warn: () => {} },
-      getReactNativeProjectDirectory: () => '/app',
-    } as any;
-    await expoUpdates.configureExpoUpdatesIfInstalledAsync(managedCtx, {
-      resolvedRuntimeVersion: '1',
-    });
-
-    expect(infoLogger).toBeCalledWith(`Using default release channel for 'expo-updates' (default)`);
-    expect(iosSetClassicReleaseChannelNativelyAsync).not.toBeCalled();
-    expect(androidSetClassicReleaseChannelNativelyAsync).not.toBeCalled();
-    expect(androidGetNativelyDefinedClassicReleaseChannelAsync).not.toBeCalled();
-    expect(iosGetNativelyDefinedClassicReleaseChannelAsync).toBeCalledTimes(1);
-  });
-
-  it('does not use the default release channel if the releaseChannel is not defined in ctx.job.releaseChannel nor natively, and expo-updates version is >= 0.19.0', async () => {
-    jest.mocked(getExpoUpdatesPackageVersionIfInstalledAsync).mockResolvedValue('0.19.0');
-
-    const infoLogger = jest.fn();
-    const managedCtx: BuildContext<BuildJob> = {
-      appConfig: {},
-      job: { platform: Platform.IOS },
-      logger: { info: infoLogger, warn: () => {} },
-      getReactNativeProjectDirectory: () => '/app',
-    } as any;
-    await expoUpdates.configureExpoUpdatesIfInstalledAsync(managedCtx, {
-      resolvedRuntimeVersion: '1',
-    });
-
-    expect(infoLogger).not.toBeCalledWith(
-      `Using default release channel for 'expo-updates' (default)`
-    );
-    expect(iosSetClassicReleaseChannelNativelyAsync).not.toBeCalled();
-    expect(androidSetClassicReleaseChannelNativelyAsync).not.toBeCalled();
-    expect(androidGetNativelyDefinedClassicReleaseChannelAsync).not.toBeCalled();
-    expect(iosGetNativelyDefinedClassicReleaseChannelAsync).not.toBeCalled();
-  });
-
-  it('does not use the default release channel if the releaseChannel is not defined in ctx.job.releaseChannel nor natively, and expo-updates version is canary', async () => {
-    jest
-      .mocked(getExpoUpdatesPackageVersionIfInstalledAsync)
-      .mockResolvedValue('0.0.1-canary-20240109-93608d8');
-
-    const infoLogger = jest.fn();
-    const managedCtx: BuildContext<BuildJob> = {
-      appConfig: {},
-      job: { platform: Platform.IOS },
-      logger: { info: infoLogger, warn: () => {} },
-      getReactNativeProjectDirectory: () => '/app',
-    } as any;
-    await expoUpdates.configureExpoUpdatesIfInstalledAsync(managedCtx, {
-      resolvedRuntimeVersion: '1',
-    });
-
-    expect(infoLogger).not.toBeCalledWith(
-      `Using default release channel for 'expo-updates' (default)`
-    );
-    expect(iosSetClassicReleaseChannelNativelyAsync).not.toBeCalled();
-    expect(androidSetClassicReleaseChannelNativelyAsync).not.toBeCalled();
-    expect(androidGetNativelyDefinedClassicReleaseChannelAsync).not.toBeCalled();
-    expect(iosGetNativelyDefinedClassicReleaseChannelAsync).not.toBeCalled();
   });
 });

--- a/packages/eas-build-job/src/__tests__/android.test.ts
+++ b/packages/eas-build-job/src/__tests__/android.test.ts
@@ -34,7 +34,6 @@ describe('Android.JobSchema', () => {
       gradleCommand: ':app:bundleRelease',
       applicationArchivePath: 'android/app/build/outputs/bundle/release/app-release.aab',
       projectRootDirectory: '.',
-      releaseChannel: 'default',
       builderEnvironment: {
         image: 'default',
         node: '1.2.3',
@@ -66,7 +65,6 @@ describe('Android.JobSchema', () => {
       gradleCommand: ':app:bundleRelease',
       applicationArchivePath: 'android/app/build/outputs/bundle/release/app-release.aab',
       projectRootDirectory: '.',
-      releaseChannel: 'default',
       builderEnvironment: {
         image: 'default',
         node: '1.2.3',
@@ -117,7 +115,6 @@ describe('Android.JobSchema', () => {
         url: 'http://localhost:3000',
       },
       projectRootDirectory: '.',
-      releaseChannel: 'default',
       builderEnvironment: {
         image: 'default',
         node: '1.2.3',
@@ -177,28 +174,6 @@ describe('Android.JobSchema', () => {
     expect(error).toBeFalsy();
   });
 
-  test('fails when both releaseChannel and updates.channel are defined', () => {
-    const managedJob = {
-      secrets,
-      type: Workflow.MANAGED,
-      platform: Platform.ANDROID,
-      releaseChannel: 'default',
-      updates: {
-        channel: 'main',
-      },
-      projectArchive: {
-        type: ArchiveSourceType.URL,
-        url: 'http://localhost:3000',
-      },
-      projectRootDirectory: '.',
-    };
-
-    const { error } = Android.JobSchema.validate(managedJob, joiOptions);
-    expect(error?.message).toBe(
-      '"value" contains a conflict between optional exclusive peers [releaseChannel, updates.channel]'
-    );
-  });
-
   test('build from git without buildProfile defined', () => {
     const managedJob = {
       secrets,
@@ -213,7 +188,6 @@ describe('Android.JobSchema', () => {
         gitRef: 'master',
       },
       projectRootDirectory: '.',
-      releaseChannel: 'default',
       builderEnvironment: {
         image: 'default',
       },

--- a/packages/eas-build-job/src/__tests__/ios.test.ts
+++ b/packages/eas-build-job/src/__tests__/ios.test.ts
@@ -36,7 +36,6 @@ describe('Ios.JobSchema', () => {
       scheme: 'testapp',
       buildConfiguration: 'Release',
       applicationArchivePath: 'ios/build/*.ipa',
-      releaseChannel: 'default',
       builderEnvironment: {
         image: 'default',
         node: '1.2.3',
@@ -153,7 +152,6 @@ describe('Ios.JobSchema', () => {
       },
       projectRootDirectory: '.',
       username: 'turtle-tutorial',
-      releaseChannel: 'default',
       builderEnvironment: {
         image: 'default',
         node: '1.2.3',
@@ -212,29 +210,6 @@ describe('Ios.JobSchema', () => {
     const { value, error } = Ios.JobSchema.validate(managedJob, joiOptions);
     expect(value).toMatchObject(managedJob);
     expect(error).toBeFalsy();
-  });
-  test('fails when both releaseChannel and updates.channel are defined', () => {
-    const managedJob = {
-      secrets: {
-        buildCredentials,
-      },
-      type: Workflow.MANAGED,
-      platform: Platform.IOS,
-      releaseChannel: 'default',
-      updates: {
-        channel: 'main',
-      },
-      projectArchive: {
-        type: ArchiveSourceType.URL,
-        url: 'http://localhost:3000',
-      },
-      projectRootDirectory: '.',
-    };
-
-    const { error } = Ios.JobSchema.validate(managedJob, joiOptions);
-    expect(error?.message).toBe(
-      '"value" contains a conflict between optional exclusive peers [releaseChannel, updates.channel]'
-    );
   });
 
   test('can set github trigger options', () => {

--- a/packages/eas-build-job/src/android.ts
+++ b/packages/eas-build-job/src/android.ts
@@ -73,7 +73,6 @@ export interface Job {
   platform: Platform.ANDROID;
   projectRootDirectory: string;
   buildProfile?: string;
-  releaseChannel?: string;
   updates?: {
     channel?: string;
   };
@@ -137,7 +136,6 @@ export const JobSchema = Joi.object({
     then: Joi.string().required(),
     otherwise: Joi.string(),
   }),
-  releaseChannel: Joi.string(),
   updates: Joi.object({
     channel: Joi.string(),
   }),
@@ -177,4 +175,4 @@ export const JobSchema = Joi.object({
     submitProfile: Joi.string(),
   }),
   loggerLevel: Joi.string().valid(...Object.values(LoggerLevel)),
-}).oxor('releaseChannel', 'updates.channel');
+});

--- a/packages/eas-build-job/src/ios.ts
+++ b/packages/eas-build-job/src/ios.ts
@@ -86,7 +86,6 @@ export interface Job {
   platform: Platform.IOS;
   projectRootDirectory?: string;
   buildProfile?: string;
-  releaseChannel?: string;
   updates?: {
     channel?: string;
   };
@@ -172,7 +171,6 @@ export const JobSchema = Joi.object({
     }),
     otherwise: Joi.string(),
   }),
-  releaseChannel: Joi.string(),
   updates: Joi.object({
     channel: Joi.string(),
   }),
@@ -213,4 +211,4 @@ export const JobSchema = Joi.object({
     submitProfile: Joi.string(),
   }),
   loggerLevel: Joi.string().valid(...Object.values(LoggerLevel)),
-}).oxor('releaseChannel', 'updates.channel');
+});

--- a/packages/eas-build-job/src/metadata.ts
+++ b/packages/eas-build-job/src/metadata.ts
@@ -55,12 +55,6 @@ export type Metadata = {
   runtimeVersion?: string;
 
   /**
-   * Release channel (for classic expo-updates)
-   * It's undefined if the classic expo-updates package is not installed for the project.
-   */
-  releaseChannel?: string;
-
-  /**
    * Version of the react-native package used in the project.
    */
   reactNativeVersion?: string;
@@ -180,7 +174,6 @@ export const MetadataSchema = Joi.object({
   sdkVersion: Joi.string(),
   runtimeVersion: Joi.string(),
   reactNativeVersion: Joi.string(),
-  releaseChannel: Joi.string(),
   channel: Joi.string(),
   appName: Joi.string(),
   appIdentifier: Joi.string(),


### PR DESCRIPTION
# Why

`eas-build` counterpart to github.com/expo/eas-cli/pull/2357. Classic updates is no longer supported in any SDK version, so this code can be removed.

Closes ENG-12141.

# How

Remove code.

# Test Plan

`yarn tsc`
