### PR TITLE
[build-tools] Set up a branch or a tag when cloning repository

### DIFF
--- a/packages/eas-build-job/src/common.ts
+++ b/packages/eas-build-job/src/common.ts
@@ -45,10 +45,12 @@ export type ArchiveSource =
        * It should contain embedded credentials for private registries.
        */
       repositoryUrl: string;
+      /** A Git ref - points to a branch, tag, or commit. */
+      gitRef?: string;
       /**
-       * Git commit hash, branch, or tag
+       * Git commit hash.
        */
-      gitRef: string;
+      gitCommitHash?: string;
     };
 
 export const ArchiveSourceSchema = Joi.object<ArchiveSource>({
@@ -73,7 +75,8 @@ export const ArchiveSourceSchema = Joi.object<ArchiveSource>({
     then: Joi.object({
       type: Joi.string().valid(ArchiveSourceType.GIT).required(),
       repositoryUrl: Joi.string().required(),
-      gitRef: Joi.string().required(),
+      gitCommitHash: Joi.string().optional(),
+      gitRef: Joi.string().optional(),
     }),
   })
   .when(Joi.object({ type: ArchiveSourceType.PATH }).unknown(), {
@@ -87,7 +90,8 @@ export const ArchiveSourceSchemaZ = z.discriminatedUnion('type', [
   z.object({
     type: z.literal(ArchiveSourceType.GIT),
     repositoryUrl: z.string().url(),
-    gitRef: z.string(),
+    gitRef: z.string().optional(),
+    gitCommitHash: z.string().optional(),
   }),
   z.object({
     type: z.literal(ArchiveSourceType.PATH),


### PR DESCRIPTION
# Why

We want project directories to not only contain information of current commit, but also branch or a tag. We need this for `eas-cli update --auto`.

# How

Previously, we were fetching and checking out a `gitRef` which theoretically could be a commit hash, branch name or a tag, but from looking at `www` it is always a commit hash (which I think is good).

From now on, a Git project archive config will contain:
- `gitCommitHash` — THE commit to fetch and checkout
- `gitRef` — an optional spec like `refs/heads/main`, `refs/tags/v1.0` (or `main` even). We will parse this ref and, when fetching, set a destination for the commit via a [refspec](https://www.atlassian.com/git/tutorials/refs-and-the-reflog#refspecs), similarly to [how GitHub does it](https://github.com/actions/checkout/blob/44c2b7a8a4ea60a981eaca3cf939b5f4305c123b/src/ref-helper.ts#L13).

So:
- if `gitRef` is empty, we end up in a detached HEAD state
- if `gitRef` is a (e.g.) `main` branch (`refs/heads/main`):
	- we fetch `commit` telling Git it's expected to be on a remote `main` branch
	- we checkout a new local `main` branch off the remote `main` branch (which points to the `commit`)
- if `gitRef` is a (e.g.) `v1.0` tag:
	- we fetch `commit` telling Git it's a `v1.0` tag
	- we checkout the `v1.0` tag
- if `gitRef` is something we can't parse we assume it's a branch name (`staging`)
	- we fetch `commit`
	- we checkout a new `staging` branch on the commit

Once this is merged and live, I'll submit a pull request to `www` that will add the `gitCommitHash` alongside `gitRef`.

# Test Plan

I have built `eas-build` with these changes, compiled `worker` and triggered 3 manual and 3 automatic GitHub builds, one for each: commit, branch, tag. All resolved ref correctly.

<img width="1160" alt="Zrzut ekranu 2024-05-3 o 23 30 50" src="https://github.com/expo/eas-build/assets/1151041/9495deec-808b-4b22-98ac-faeb4bd41cde">

