### PR TITLE
Require both `gitCommitHash` and `gitRef`

### DIFF
--- a/packages/build-tools/src/common/projectSources.ts
+++ b/packages/build-tools/src/common/projectSources.ts
@@ -2,7 +2,6 @@ import path from 'path';
 
 import spawn from '@expo/turtle-spawn';
 import fs from 'fs-extra';
-import nullthrows from 'nullthrows';
 import { ArchiveSource, ArchiveSourceType, Job } from '@expo/eas-build-job';
 import { bunyan } from '@expo/logger';
 import downloadFile from '@expo/downloader';
@@ -46,18 +45,7 @@ async function shallowCloneRepositoryAsync({
     await spawn('git', ['init'], { cwd: destinationDirectory });
     await spawn('git', ['remote', 'add', 'origin', repositoryUrl], { cwd: destinationDirectory });
 
-    let gitRef: string | null;
-    let gitCommitHash: string;
-    // If gitRef is provided, but gitCommitHash is not,
-    // we're handling a legacy case - gitRef is the commit hash.
-    // Otherwise we expect gitCommitHash to be present.
-    if (archiveSource.gitRef && !archiveSource.gitCommitHash) {
-      gitCommitHash = archiveSource.gitRef;
-      gitRef = null;
-    } else {
-      gitCommitHash = nullthrows(archiveSource.gitCommitHash);
-      gitRef = archiveSource.gitRef ?? null;
-    }
+    const { gitRef, gitCommitHash } = archiveSource;
 
     await spawn('git', ['fetch', 'origin', '--depth', '1', '--no-tags', gitCommitHash], {
       cwd: destinationDirectory,

--- a/packages/eas-build-job/src/__tests__/android.test.ts
+++ b/packages/eas-build-job/src/__tests__/android.test.ts
@@ -186,6 +186,7 @@ describe('Android.JobSchema', () => {
         type: ArchiveSourceType.GIT,
         repositoryUrl: 'http://localhost:3000',
         gitRef: 'master',
+        gitCommitHash: '1b57db5b1cd12638aba0d12da71a2d691416700d',
       },
       projectRootDirectory: '.',
       builderEnvironment: {

--- a/packages/eas-build-job/src/common.ts
+++ b/packages/eas-build-job/src/common.ts
@@ -45,12 +45,12 @@ export type ArchiveSource =
        * It should contain embedded credentials for private registries.
        */
       repositoryUrl: string;
-      /** A Git ref - points to a branch, tag, or commit. */
-      gitRef?: string;
+      /** A Git ref - points to a branch head, tag head or a branch name. */
+      gitRef: string | null;
       /**
        * Git commit hash.
        */
-      gitCommitHash?: string;
+      gitCommitHash: string;
     };
 
 export const ArchiveSourceSchema = Joi.object<ArchiveSource>({
@@ -75,8 +75,8 @@ export const ArchiveSourceSchema = Joi.object<ArchiveSource>({
     then: Joi.object({
       type: Joi.string().valid(ArchiveSourceType.GIT).required(),
       repositoryUrl: Joi.string().required(),
-      gitCommitHash: Joi.string().optional(),
-      gitRef: Joi.string().optional(),
+      gitCommitHash: Joi.string().required(),
+      gitRef: Joi.string().allow(null).required(),
     }),
   })
   .when(Joi.object({ type: ArchiveSourceType.PATH }).unknown(), {
@@ -90,8 +90,8 @@ export const ArchiveSourceSchemaZ = z.discriminatedUnion('type', [
   z.object({
     type: z.literal(ArchiveSourceType.GIT),
     repositoryUrl: z.string().url(),
-    gitRef: z.string().optional(),
-    gitCommitHash: z.string().optional(),
+    gitRef: z.string().nullable(),
+    gitCommitHash: z.string(),
   }),
   z.object({
     type: z.literal(ArchiveSourceType.PATH),


### PR DESCRIPTION
# Why

Some cleanup after the migration period.

# How

Made both `gitRef` and `gitCommitHash` required (as in non-optional). `gitCommitHash` is expected to always be provided, `gitRef` can be `null` (if we're building not from a branch or a tag, but from a detached commit). We are not going to use the `gitRef = null` case in `www` yet.

# Test Plan

I built this package and linked to `www` in https://github.com/expo/universe/pull/15254. The changes required to make `tsc` ok seemed forward-compatible.