### PR TITLE
[build-tools] don't pass logger to `expo-updates` CLI

### DIFF
--- a/packages/build-tools/src/utils/expoUpdatesCli.ts
+++ b/packages/build-tools/src/utils/expoUpdatesCli.ts
@@ -1,6 +1,5 @@
 import resolveFrom, { silent as silentResolveFrom } from 'resolve-from';
 import spawnAsync from '@expo/turtle-spawn';
-import { bunyan } from '@expo/logger';
 import { BuildStepEnv } from '@expo/steps';
 
 export class ExpoUpdatesCLIModuleNotFoundError extends Error {}
@@ -10,7 +9,7 @@ export class ExpoUpdatesCLICommandFailedError extends Error {}
 export async function expoUpdatesCommandAsync(
   projectDir: string,
   args: string[],
-  { logger, env }: { logger: bunyan; env: BuildStepEnv }
+  { env }: { env: BuildStepEnv }
 ): Promise<string> {
   let expoUpdatesCli;
   try {
@@ -30,7 +29,6 @@ export async function expoUpdatesCommandAsync(
     const spawnResult = await spawnAsync(expoUpdatesCli, args, {
       stdio: 'pipe',
       cwd: projectDir,
-      logger,
       env,
     });
     return spawnResult.stdout;

--- a/packages/build-tools/src/utils/resolveRuntimeVersionAsync.ts
+++ b/packages/build-tools/src/utils/resolveRuntimeVersionAsync.ts
@@ -40,7 +40,6 @@ export async function resolveRuntimeVersionAsync({
       projectDir,
       ['runtimeversion:resolve', '--platform', platform, '--workflow', workflow, ...extraArgs],
       {
-        logger,
         env,
       }
     );


### PR DESCRIPTION
# Why

don't pass logger to `expo-updates` CLI

# How

don't pass logger to `expo-updates` CLI so we don't produce noisy logs

# Test Plan

before: 
<img width="784" alt="Screenshot 2024-05-11 at 00 06 55" src="https://github.com/expo/eas-build/assets/55145344/ba2693dc-d1a3-4d68-83fa-c58f7f8c9d70">

after:
<img width="779" alt="Screenshot 2024-05-11 at 00 07 40" src="https://github.com/expo/eas-build/assets/55145344/c558c61b-2126-4d65-98f7-479f672ce4fd">
