### PR TITLE
[build-tools] add new `eas` custom build function for app repacking

### DIFF
--- a/packages/build-tools/package.json
+++ b/packages/build-tools/package.json
@@ -30,6 +30,7 @@
     "@expo/logger": "1.0.57",
     "@expo/package-manager": "1.1.2",
     "@expo/plist": "^0.0.20",
+    "@expo/repack-app": "^0.0.2",
     "@expo/steps": "1.0.108",
     "@expo/template-file": "1.0.57",
     "@expo/turtle-spawn": "1.0.57",

--- a/packages/build-tools/package.json
+++ b/packages/build-tools/package.json
@@ -30,7 +30,7 @@
     "@expo/logger": "1.0.57",
     "@expo/package-manager": "1.1.2",
     "@expo/plist": "^0.0.20",
-    "@expo/repack-app": "^0.0.2",
+    "@expo/repack-app": "0.0.2",
     "@expo/steps": "1.0.108",
     "@expo/template-file": "1.0.57",
     "@expo/turtle-spawn": "1.0.57",

--- a/packages/build-tools/package.json
+++ b/packages/build-tools/package.json
@@ -30,7 +30,7 @@
     "@expo/logger": "1.0.57",
     "@expo/package-manager": "1.1.2",
     "@expo/plist": "^0.0.20",
-    "@expo/repack-app": "0.0.2",
+    "@expo/repack-app": "0.0.5",
     "@expo/steps": "1.0.108",
     "@expo/template-file": "1.0.57",
     "@expo/turtle-spawn": "1.0.57",

--- a/packages/build-tools/resources/__eas/repack.yml
+++ b/packages/build-tools/resources/__eas/repack.yml
@@ -1,0 +1,12 @@
+build:
+  name: Repack golden app
+  steps:
+    - eas/checkout
+    - eas/install_node_modules
+    - eas/__download_and_repack_golden_development_client_archive:
+        id: download_and_repack_golden_development_client_archive
+    - eas/upload_artifact:
+        name: Upload build artifact
+        inputs:
+          type: application-archive
+          path: ${ steps.download_and_repack_golden_development_client_archive.repacked_archive_path }

--- a/packages/build-tools/resources/__eas/repack.yml
+++ b/packages/build-tools/resources/__eas/repack.yml
@@ -10,3 +10,4 @@ build:
         inputs:
           type: application-archive
           path: ${ steps.download_and_repack_golden_development_client_archive.repacked_archive_path }
+          

--- a/packages/build-tools/resources/__eas/repack.yml
+++ b/packages/build-tools/resources/__eas/repack.yml
@@ -1,5 +1,5 @@
 build:
-  name: Repack golden app
+  name: Resign development client
   steps:
     - eas/checkout
     - eas/install_node_modules

--- a/packages/build-tools/src/steps/easFunctions.ts
+++ b/packages/build-tools/src/steps/easFunctions.ts
@@ -25,6 +25,7 @@ import { createInstallPodsBuildFunction } from './functions/installPods';
 import { createSendSlackMessageFunction } from './functions/sendSlackMessage';
 import { createResolveBuildConfigBuildFunction } from './functions/resolveBuildConfig';
 import { calculateEASUpdateRuntimeVersionFunction } from './functions/calculateEASUpdateRuntimeVersion';
+import { createRepackBuildFunction } from './functions/repack';
 
 export function getEasFunctions(ctx: CustomBuildContext): BuildFunction[] {
   const functions = [
@@ -51,6 +52,8 @@ export function getEasFunctions(ctx: CustomBuildContext): BuildFunction[] {
     createSendSlackMessageFunction(),
 
     calculateEASUpdateRuntimeVersionFunction(ctx),
+
+    createRepackBuildFunction(),
   ];
 
   if (ctx.hasBuildJob()) {

--- a/packages/build-tools/src/steps/functions/repack.ts
+++ b/packages/build-tools/src/steps/functions/repack.ts
@@ -116,14 +116,7 @@ export function createRepackBuildFunction(): BuildFunction {
           sourceAppPath: goldenArchivePath,
           outputPath: repackedArchivePath,
           workingDirectory: tmpDir,
-          androidSigningOptions: androidCredentials
-            ? {
-                keyStorePath: androidCredentials?.keyStorePath,
-                keyStorePassword: androidCredentials?.keyStorePassword,
-                keyAlias: androidCredentials?.keyAlias,
-                keyPassword: androidCredentials?.keyPassword,
-              }
-            : undefined,
+          androidSigningOptions: androidCredentials,
           logger: stepsCtx.logger,
           skipWorkingDirCleanup: true,
           verbose: env.__EAS_REPACK_VERBOSE !== undefined,

--- a/packages/build-tools/src/steps/functions/repack.ts
+++ b/packages/build-tools/src/steps/functions/repack.ts
@@ -1,0 +1,118 @@
+import path from 'path';
+import { promisify } from 'util';
+import { Stream } from 'stream';
+import assert from 'node:assert';
+
+import { BuildFunction } from '@expo/steps';
+import fs from 'fs-extra';
+import { Platform } from '@expo/eas-build-job';
+import fetch from 'node-fetch';
+import { repackAppAndroidAsync, repackAppIosAsync } from '@expo/repack-app';
+import { v4 as uuidv4 } from 'uuid';
+
+import IosCredentialsManager from '../utils/ios/credentials/manager';
+
+const pipeline = promisify(Stream.pipeline);
+
+export function createRepackBuildFunction(): BuildFunction {
+  return new BuildFunction({
+    namespace: 'eas',
+    id: '__download_and_repack_golden_development_client_archive',
+    name: 'Download and repack golden development client archive',
+    fn: async (stepsCtx) => {
+      const tmpDir = await fs.mkdtemp('eas-build-golden-dev-client-app');
+      stepsCtx.logger.info(`Created temporary directory: ${tmpDir}`);
+
+      stepsCtx.logger.info('Downloading golden development client archive...');
+      const fileName =
+        stepsCtx.global.staticContext.job.platform === Platform.IOS
+          ? 'golden-dev-client-latest.ipa'
+          : 'golden-dev-client-latest.apk';
+      const goldenArchiveUrl = `https://storage.googleapis.com/turtle-v2/onboarding/${fileName}`;
+      const goldenArchivePath = path.join(tmpDir, fileName);
+      try {
+        const response = await fetch(goldenArchiveUrl, {
+          timeout: 5 * 60 * 1000, // 5 minutes
+        });
+        if (!response.ok) {
+          throw new Error(`[${response.status}] ${response.statusText}`);
+        }
+        await pipeline(response.body, fs.createWriteStream(goldenArchivePath));
+      } catch (error: any) {
+        throw new Error(`Failed to download golden development client archive: ${error.message}`);
+      }
+      stepsCtx.logger.info(`Downloaded golden development client archive to ${goldenArchivePath}`);
+
+      stepsCtx.logger.info('Repacking and resigning the app...');
+      const repackedArchivePath = path.join(tmpDir, fileName);
+      if (stepsCtx.global.staticContext.job.platform === Platform.IOS) {
+        assert(
+          stepsCtx.global.staticContext.job.secrets?.buildCredentials,
+          'iOS credentials are required'
+        );
+        const credentialsManager = new IosCredentialsManager(
+          stepsCtx.global.staticContext.job.secrets.buildCredentials
+        );
+        const credentials = await credentialsManager.prepare(stepsCtx.logger);
+        await repackAppIosAsync({
+          platform: 'ios',
+          projectRoot: stepsCtx.workingDirectory,
+          sourceAppPath: goldenArchivePath,
+          outputPath: repackedArchivePath,
+          workingDirectory: tmpDir,
+          iosSigningOptions: {
+            provisioningProfile: Object.values(credentials.targetProvisioningProfiles)[0].path,
+            keychainPath: credentials.keychainPath,
+            signingIdentity:
+              credentials.applicationTargetProvisioningProfile.data.developerCertificate.toString(),
+          },
+        });
+      } else if (stepsCtx.global.staticContext.job.platform === Platform.ANDROID) {
+        let androidCredentials:
+          | {
+              keyStorePath: string;
+              keyStorePassword: string;
+              keyAlias: string;
+              keyPassword: string | undefined;
+            }
+          | undefined;
+        if (stepsCtx.global.staticContext.job.secrets?.buildCredentials?.keystore.dataBase64) {
+          const keyStorePath = path.join(tmpDir, `keystore-${uuidv4()}`);
+          await fs.writeFile(
+            keyStorePath,
+            Buffer.from(
+              stepsCtx.global.staticContext.job.secrets.buildCredentials.keystore.dataBase64,
+              'base64'
+            )
+          );
+          androidCredentials = {
+            keyStorePath,
+            keyStorePassword:
+              stepsCtx.global.staticContext.job.secrets.buildCredentials.keystore.keystorePassword,
+            keyAlias: stepsCtx.global.staticContext.job.secrets.buildCredentials.keystore.keyAlias,
+            keyPassword:
+              stepsCtx.global.staticContext.job.secrets.buildCredentials.keystore.keyPassword,
+          };
+        }
+
+        await repackAppAndroidAsync({
+          platform: 'android',
+          projectRoot: stepsCtx.workingDirectory,
+          sourceAppPath: goldenArchivePath,
+          outputPath: repackedArchivePath,
+          workingDirectory: tmpDir,
+          androidSigningOptions: androidCredentials
+            ? {
+                keyStorePath: androidCredentials?.keyStorePath,
+                keyStorePassword: androidCredentials?.keyStorePassword,
+                keyAlias: androidCredentials?.keyAlias,
+                keyPassword: androidCredentials?.keyPassword,
+              }
+            : undefined,
+        });
+      } else {
+        throw new Error('Unsupported platform');
+      }
+    },
+  });
+}

--- a/packages/build-tools/src/steps/functions/repack.ts
+++ b/packages/build-tools/src/steps/functions/repack.ts
@@ -3,7 +3,7 @@ import { promisify } from 'util';
 import { Stream } from 'stream';
 import assert from 'node:assert';
 
-import { BuildFunction } from '@expo/steps';
+import { BuildFunction, BuildStepOutput } from '@expo/steps';
 import fs from 'fs-extra';
 import { Platform } from '@expo/eas-build-job';
 import fetch from 'node-fetch';
@@ -19,8 +19,15 @@ export function createRepackBuildFunction(): BuildFunction {
     namespace: 'eas',
     id: '__download_and_repack_golden_development_client_archive',
     name: 'Download and repack golden development client archive',
-    fn: async (stepsCtx) => {
-      const tmpDir = await fs.mkdtemp('eas-build-golden-dev-client-app');
+    outputProviders: [
+      BuildStepOutput.createProvider({
+        id: 'repacked_archive_path',
+        required: true,
+      }),
+    ],
+    fn: async (stepsCtx, { outputs, env }) => {
+      const tmpDir = `/tmp/eas-build-golden-dev-client-app-${uuidv4()}`;
+      await fs.mkdirs(tmpDir);
       stepsCtx.logger.info(`Created temporary directory: ${tmpDir}`);
 
       stepsCtx.logger.info('Downloading golden development client archive...');
@@ -28,7 +35,9 @@ export function createRepackBuildFunction(): BuildFunction {
         stepsCtx.global.staticContext.job.platform === Platform.IOS
           ? 'golden-dev-client-latest.ipa'
           : 'golden-dev-client-latest.apk';
-      const goldenArchiveUrl = `https://storage.googleapis.com/turtle-v2/onboarding/${fileName}`;
+      const goldenArchiveUrl =
+        env.__EAS_GOLDEN_DEV_CLIENT_URL ??
+        `https://storage.googleapis.com/turtle-v2/onboarding/${fileName}`;
       const goldenArchivePath = path.join(tmpDir, fileName);
       try {
         const response = await fetch(goldenArchiveUrl, {
@@ -44,7 +53,10 @@ export function createRepackBuildFunction(): BuildFunction {
       stepsCtx.logger.info(`Downloaded golden development client archive to ${goldenArchivePath}`);
 
       stepsCtx.logger.info('Repacking and resigning the app...');
-      const repackedArchivePath = path.join(tmpDir, fileName);
+      const repackedArchivePath = path.join(
+        tmpDir,
+        stepsCtx.global.staticContext.job.platform === Platform.IOS ? 'target.ipa' : 'target.apk'
+      );
       if (stepsCtx.global.staticContext.job.platform === Platform.IOS) {
         assert(
           stepsCtx.global.staticContext.job.secrets?.buildCredentials,
@@ -64,8 +76,11 @@ export function createRepackBuildFunction(): BuildFunction {
             provisioningProfile: Object.values(credentials.targetProvisioningProfiles)[0].path,
             keychainPath: credentials.keychainPath,
             signingIdentity:
-              credentials.applicationTargetProvisioningProfile.data.developerCertificate.toString(),
+              credentials.applicationTargetProvisioningProfile.data.certificateCommonName,
           },
+          logger: stepsCtx.logger,
+          skipWorkingDirCleanup: true,
+          verbose: env.__EAS_REPACK_VERBOSE !== undefined,
         });
       } else if (stepsCtx.global.staticContext.job.platform === Platform.ANDROID) {
         let androidCredentials:
@@ -109,10 +124,20 @@ export function createRepackBuildFunction(): BuildFunction {
                 keyPassword: androidCredentials?.keyPassword,
               }
             : undefined,
+          logger: stepsCtx.logger,
+          skipWorkingDirCleanup: true,
+          verbose: env.__EAS_REPACK_VERBOSE !== undefined,
         });
       } else {
         throw new Error('Unsupported platform');
       }
+
+      if (!(await fs.exists(repackedArchivePath))) {
+        throw new Error(`Failed to repack the app. ${repackedArchivePath} does not exist`);
+      }
+
+      stepsCtx.logger.info(`Repacked and resigned the app to ${repackedArchivePath}`);
+      outputs.repacked_archive_path.set(repackedArchivePath);
     },
   });
 }

--- a/packages/build-tools/src/steps/functions/repack.ts
+++ b/packages/build-tools/src/steps/functions/repack.ts
@@ -2,6 +2,7 @@ import path from 'path';
 import { promisify } from 'util';
 import { Stream } from 'stream';
 import assert from 'node:assert';
+import os from 'os';
 
 import { BuildFunction, BuildStepOutput } from '@expo/steps';
 import fs from 'fs-extra';
@@ -26,7 +27,7 @@ export function createRepackBuildFunction(): BuildFunction {
       }),
     ],
     fn: async (stepsCtx, { outputs, env }) => {
-      const tmpDir = `/tmp/eas-build-golden-dev-client-app-${uuidv4()}`;
+      const tmpDir = path.join(os.tmpdir(), `eas-build-golden-dev-client-app-${uuidv4()}`);
       await fs.mkdirs(tmpDir);
       stepsCtx.logger.info(`Created temporary directory: ${tmpDir}`);
 
@@ -41,7 +42,7 @@ export function createRepackBuildFunction(): BuildFunction {
       const goldenArchivePath = path.join(tmpDir, fileName);
       try {
         const response = await fetch(goldenArchiveUrl, {
-          timeout: 5 * 60 * 1000, // 5 minutes
+          timeout: 1 * 60 * 1000, // 1 minute
         });
         if (!response.ok) {
           throw new Error(`[${response.status}] ${response.statusText}`);

--- a/packages/build-tools/src/utils/artifacts.ts
+++ b/packages/build-tools/src/utils/artifacts.ts
@@ -19,7 +19,11 @@ export async function findArtifacts({
   /** If provided, will log error suggesting possible files to upload. */
   logger: bunyan | null;
 }): Promise<string[]> {
-  const files = await fg(patternOrPath, { cwd: rootDir, onlyFiles: false });
+  const files = path.isAbsolute(patternOrPath)
+    ? (await fs.pathExists(patternOrPath))
+      ? [patternOrPath]
+      : []
+    : await fg(patternOrPath, { cwd: rootDir, onlyFiles: false });
   if (files.length === 0) {
     if (fg.isDynamicPattern(patternOrPath)) {
       throw new FindArtifactsError(`There are no files matching pattern "${patternOrPath}"`);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2019",
+    "target": "ES2021",
     "module": "commonjs",
     "sourceMap": true,
     "inlineSources": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2021",
+    "target": "ES2019",
     "module": "commonjs",
     "sourceMap": true,
     "inlineSources": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -651,6 +651,29 @@
     xcode "^3.0.1"
     xml2js "0.6.0"
 
+"@expo/config-plugins@~7.9.0":
+  version "7.9.2"
+  resolved "https://registry.yarnpkg.com/@expo/config-plugins/-/config-plugins-7.9.2.tgz#fc18e84761067ce670742d735b888613c06fbea8"
+  integrity sha512-sRU/OAp7kJxrCUiCTUZqvPMKPdiN1oTmNfnbkG4oPdfWQTpid3jyCH7ZxJEN5SI6jrY/ZsK5B/JPgjDUhuWLBQ==
+  dependencies:
+    "@expo/config-types" "^50.0.0-alpha.1"
+    "@expo/fingerprint" "^0.6.0"
+    "@expo/json-file" "~8.3.0"
+    "@expo/plist" "^0.1.0"
+    "@expo/sdk-runtime-versions" "^1.0.0"
+    "@react-native/normalize-color" "^2.0.0"
+    chalk "^4.1.2"
+    debug "^4.3.1"
+    find-up "~5.0.0"
+    getenv "^1.0.0"
+    glob "7.1.6"
+    resolve-from "^5.0.0"
+    semver "^7.5.3"
+    slash "^3.0.0"
+    slugify "^1.6.6"
+    xcode "^3.0.1"
+    xml2js "0.6.0"
+
 "@expo/config-types@^50.0.0", "@expo/config-types@^50.0.0-alpha.1":
   version "50.0.0"
   resolved "https://registry.yarnpkg.com/@expo/config-types/-/config-types-50.0.0.tgz#b534d3ec997ec60f8af24f6ad56244c8afc71a0b"
@@ -663,6 +686,23 @@
   dependencies:
     "@babel/code-frame" "~7.10.4"
     "@expo/config-plugins" "~7.8.2"
+    "@expo/config-types" "^50.0.0"
+    "@expo/json-file" "^8.2.37"
+    getenv "^1.0.0"
+    glob "7.1.6"
+    require-from-string "^2.0.2"
+    resolve-from "^5.0.0"
+    semver "7.5.3"
+    slugify "^1.3.4"
+    sucrase "3.34.0"
+
+"@expo/config@^8.5.6":
+  version "8.5.6"
+  resolved "https://registry.yarnpkg.com/@expo/config/-/config-8.5.6.tgz#e37ba437a1718ed4629e1dd130a7aace25312b89"
+  integrity sha512-wF5awSg6MNn1cb1lIgjnhOn5ov2TEUTnkAVCsOl0QqDwcP+YIerteSFwjn9V52UZvg58L+LKxpCuGbw5IHavbg==
+  dependencies:
+    "@babel/code-frame" "~7.10.4"
+    "@expo/config-plugins" "~7.9.0"
     "@expo/config-types" "^50.0.0"
     "@expo/json-file" "^8.2.37"
     getenv "^1.0.0"
@@ -766,6 +806,20 @@
     "@xmldom/xmldom" "~0.7.7"
     base64-js "^1.2.3"
     xmlbuilder "^14.0.0"
+
+"@expo/repack-app@^0.0.2":
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/@expo/repack-app/-/repack-app-0.0.2.tgz#37a8d7856a6c0fb2d697107bb5be5243c26c6f50"
+  integrity sha512-t8XFHDy0y411df6GrU1TA/Uqe5ndsvLRbznzC3JHOrlQI4m/riHw1j3w/aMMOwIFVWQg72Wd7dCTuhj11S9wnQ==
+  dependencies:
+    "@expo/config" "^8.5.6"
+    "@expo/turtle-spawn" "^1.0.57"
+    commander "^12.0.0"
+    glob "^10.3.12"
+    picocolors "^1.0.0"
+    protobufjs "^7.2.6"
+    resolve-from "^5.0.0"
+    temp-dir "^2.0.0"
 
 "@expo/sdk-runtime-versions@^1.0.0":
   version "1.0.0"
@@ -1536,6 +1590,59 @@
   resolved "https://registry.yarnpkg.com/@pkgr/core/-/core-0.1.0.tgz#7d8dacb7fdef0e4387caf7396cbd77f179867d06"
   integrity sha512-Zwq5OCzuwJC2jwqmpEQt7Ds1DTi6BWSwoGkbb1n9pO3hzb35BoJELx7c0T23iDkBGkh2e7tvOtjF3tr3OaQHDQ==
 
+"@protobufjs/aspromise@^1.1.1", "@protobufjs/aspromise@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@protobufjs/aspromise/-/aspromise-1.1.2.tgz#9b8b0cc663d669a7d8f6f5d0893a14d348f30fbf"
+  integrity sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==
+
+"@protobufjs/base64@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@protobufjs/base64/-/base64-1.1.2.tgz#4c85730e59b9a1f1f349047dbf24296034bb2735"
+  integrity sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==
+
+"@protobufjs/codegen@^2.0.4":
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/@protobufjs/codegen/-/codegen-2.0.4.tgz#7ef37f0d010fb028ad1ad59722e506d9262815cb"
+  integrity sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==
+
+"@protobufjs/eventemitter@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz#355cbc98bafad5978f9ed095f397621f1d066b70"
+  integrity sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==
+
+"@protobufjs/fetch@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@protobufjs/fetch/-/fetch-1.1.0.tgz#ba99fb598614af65700c1619ff06d454b0d84c45"
+  integrity sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==
+  dependencies:
+    "@protobufjs/aspromise" "^1.1.1"
+    "@protobufjs/inquire" "^1.1.0"
+
+"@protobufjs/float@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@protobufjs/float/-/float-1.0.2.tgz#5e9e1abdcb73fc0a7cb8b291df78c8cbd97b87d1"
+  integrity sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==
+
+"@protobufjs/inquire@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@protobufjs/inquire/-/inquire-1.1.0.tgz#ff200e3e7cf2429e2dcafc1140828e8cc638f089"
+  integrity sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==
+
+"@protobufjs/path@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@protobufjs/path/-/path-1.1.2.tgz#6cc2b20c5c9ad6ad0dccfd21ca7673d8d7fbf68d"
+  integrity sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==
+
+"@protobufjs/pool@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@protobufjs/pool/-/pool-1.1.0.tgz#09fd15f2d6d3abfa9b65bc366506d6ad7846ff54"
+  integrity sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==
+
+"@protobufjs/utf8@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
+  integrity sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==
+
 "@react-native/normalize-color@^2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@react-native/normalize-color/-/normalize-color-2.0.0.tgz#da955909432474a9a0fe1cbffc66576a0447f567"
@@ -1848,6 +1955,13 @@
   version "20.11.0"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-20.11.0.tgz#8e0b99e70c0c1ade1a86c4a282f7b7ef87c9552f"
   integrity sha512-o9bjXmDNcF7GbM4CNQpmi+TutCgap/K3w1JyKgxAjqx41zp9qlIAVFi0IhCNsJcXolEqLWhbFbEeL0PvYm4pcQ==
+  dependencies:
+    undici-types "~5.26.4"
+
+"@types/node@>=13.7.0":
+  version "20.12.11"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.12.11.tgz#c4ef00d3507000d17690643278a60dc55a9dc9be"
+  integrity sha512-vDg9PZ/zi+Nqp6boSOT7plNuthRugEKixDv5sFTIpkE89MmNtEArAShI4mxuX2+UrLEe9pxC1vm2cjm9YlWbJw==
   dependencies:
     undici-types "~5.26.4"
 
@@ -3007,6 +3121,11 @@ combined-stream@^1.0.8:
   integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
   dependencies:
     delayed-stream "~1.0.0"
+
+commander@^12.0.0:
+  version "12.0.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-12.0.0.tgz#b929db6df8546080adfd004ab215ed48cf6f2592"
+  integrity sha512-MwVNWlYjDTtOjX5PiD7o5pK0UrFU/OYgcJfjjK4RaHZETNtjJqrZa9Y9ds88+A+f+d5lv+561eZ+yCKoS3gbAA==
 
 commander@^4.0.0:
   version "4.1.1"
@@ -4540,6 +4659,17 @@ glob@^10.2.2:
     minipass "^5.0.0 || ^6.0.2 || ^7.0.0"
     path-scurry "^1.10.1"
 
+glob@^10.3.12:
+  version "10.3.15"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-10.3.15.tgz#e72bc61bc3038c90605f5dd48543dc67aaf3b50d"
+  integrity sha512-0c6RlJt1TICLyvJYIApxb8GsXoai0KUP7AxKKAtsYXdgJR1mGEUa7DgwShbdk1nly0PYoZj01xd4hzbq3fsjpw==
+  dependencies:
+    foreground-child "^3.1.0"
+    jackspeak "^2.3.6"
+    minimatch "^9.0.1"
+    minipass "^7.0.4"
+    path-scurry "^1.11.0"
+
 glob@^6.0.1:
   version "6.0.4"
   resolved "https://registry.yarnpkg.com/glob/-/glob-6.0.4.tgz#0f08860f6a155127b2fadd4f9ce24b1aab6e4d22"
@@ -5448,6 +5578,15 @@ jackspeak@^2.0.3:
   optionalDependencies:
     "@pkgjs/parseargs" "^0.11.0"
 
+jackspeak@^2.3.6:
+  version "2.3.6"
+  resolved "https://registry.yarnpkg.com/jackspeak/-/jackspeak-2.3.6.tgz#647ecc472238aee4b06ac0e461acc21a8c505ca8"
+  integrity sha512-N3yCS/NegsOBokc8GAdM8UcmfsKiSS8cipheD/nivzr700H+nsMOxJjQnvwOcRYVuFkdH0wGUvW2WbXGmrZGbQ==
+  dependencies:
+    "@isaacs/cliui" "^8.0.2"
+  optionalDependencies:
+    "@pkgjs/parseargs" "^0.11.0"
+
 jake@^10.8.5:
   version "10.8.5"
   resolved "https://registry.yarnpkg.com/jake/-/jake-10.8.5.tgz#f2183d2c59382cb274226034543b9c03b8164c46"
@@ -6267,6 +6406,11 @@ log-symbols@^5.1.0:
     chalk "^5.0.0"
     is-unicode-supported "^1.1.0"
 
+long@^5.0.0:
+  version "5.2.3"
+  resolved "https://registry.yarnpkg.com/long/-/long-5.2.3.tgz#a3ba97f3877cf1d778eccbcb048525ebb77499e1"
+  integrity sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q==
+
 loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
@@ -6278,6 +6422,11 @@ lowercase-keys@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-2.0.0.tgz#2603e78b7b4b0006cbca2fbcc8a3202558ac9479"
   integrity sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==
+
+lru-cache@^10.2.0:
+  version "10.2.2"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-10.2.2.tgz#48206bc114c1252940c41b25b41af5b545aca878"
+  integrity sha512-9hp3Vp2/hFQUiIwKo8XCeFVnrg8Pk3TYNPIR7tJADKi5YfcF7vEaK7avFHTlSy3kOKYaJQaalfEo6YuXdceBOQ==
 
 lru-cache@^5.1.1:
   version "5.1.1"
@@ -6615,6 +6764,11 @@ minipass@^5.0.0:
   version "7.0.2"
   resolved "https://registry.yarnpkg.com/minipass/-/minipass-7.0.2.tgz#58a82b7d81c7010da5bd4b2c0c85ac4b4ec5131e"
   integrity sha512-eL79dXrE1q9dBbDCLg7xfn/vl7MS4F1gvJAgjJrQli/jbQWdUttuVawphqpffoIYfRdq78LHx6GP4bU/EQ2ATA==
+
+minipass@^7.0.4:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-7.1.1.tgz#f7f85aff59aa22f110b20e27692465cf3bf89481"
+  integrity sha512-UZ7eQ+h8ywIRAW1hIEl2AqdwzJucU/Kp59+8kkZeSvafXhZjul247BvIJjEVFVeON6d7lM46XX1HXCduKAS8VA==
 
 minizlib@^2.1.1, minizlib@^2.1.2:
   version "2.1.2"
@@ -7430,6 +7584,14 @@ path-scurry@^1.10.1, path-scurry@^1.6.1:
     lru-cache "^9.1.1 || ^10.0.0"
     minipass "^5.0.0 || ^6.0.2 || ^7.0.0"
 
+path-scurry@^1.11.0:
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/path-scurry/-/path-scurry-1.11.1.tgz#7960a668888594a0720b12a911d1a742ab9f11d2"
+  integrity sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==
+  dependencies:
+    lru-cache "^10.2.0"
+    minipass "^5.0.0 || ^6.0.2 || ^7.0.0"
+
 path-type@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-3.0.0.tgz#cef31dc8e0a1a3bb0d105c0cd97cf3bf47f4e36f"
@@ -7603,6 +7765,24 @@ prop-types@^15.8.1:
     loose-envify "^1.4.0"
     object-assign "^4.1.1"
     react-is "^16.13.1"
+
+protobufjs@^7.2.6:
+  version "7.3.0"
+  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-7.3.0.tgz#a32ec0422c039798c41a0700306a6e305b9cb32c"
+  integrity sha512-YWD03n3shzV9ImZRX3ccbjqLxj7NokGN0V/ESiBV5xWqrommYHYiihuIyavq03pWSGqlyvYUFmfoMKd+1rPA/g==
+  dependencies:
+    "@protobufjs/aspromise" "^1.1.2"
+    "@protobufjs/base64" "^1.1.2"
+    "@protobufjs/codegen" "^2.0.4"
+    "@protobufjs/eventemitter" "^1.1.0"
+    "@protobufjs/fetch" "^1.1.0"
+    "@protobufjs/float" "^1.0.2"
+    "@protobufjs/inquire" "^1.1.0"
+    "@protobufjs/path" "^1.1.2"
+    "@protobufjs/pool" "^1.1.0"
+    "@protobufjs/utf8" "^1.1.0"
+    "@types/node" ">=13.7.0"
+    long "^5.0.0"
 
 protocols@^2.0.0, protocols@^2.0.1:
   version "2.0.1"
@@ -8628,6 +8808,11 @@ temp-dir@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/temp-dir/-/temp-dir-1.0.0.tgz#0a7c0ea26d3a39afa7e0ebea9c1fc0bc4daa011d"
   integrity sha512-xZFXEGbG7SNC3itwBzI3RYjq/cEhBkx2hJuKGIUOcEULmkQExXiHat2z/qkISYsuR+IKumhEfKKbV5qXmhICFQ==
+
+temp-dir@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/temp-dir/-/temp-dir-2.0.0.tgz#bde92b05bdfeb1516e804c9c00ad45177f31321e"
+  integrity sha512-aoBAniQmmwtcKp/7BzsH8Cxzv8OL736p7v1ihGb5e9DJ9kTwGWHrQrVB5+lfVDzfGrdRzXch+ig7LHaY1JTOrg==
 
 test-exclude@^6.0.0:
   version "6.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -807,14 +807,15 @@
     base64-js "^1.2.3"
     xmlbuilder "^14.0.0"
 
-"@expo/repack-app@0.0.2":
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/@expo/repack-app/-/repack-app-0.0.2.tgz#37a8d7856a6c0fb2d697107bb5be5243c26c6f50"
-  integrity sha512-t8XFHDy0y411df6GrU1TA/Uqe5ndsvLRbznzC3JHOrlQI4m/riHw1j3w/aMMOwIFVWQg72Wd7dCTuhj11S9wnQ==
+"@expo/repack-app@0.0.5":
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/@expo/repack-app/-/repack-app-0.0.5.tgz#3a22f6c6e4651a8605f0c10e90af9e46918448bf"
+  integrity sha512-AFpgI64odImrt8rUIwUXIwrkHZ5+aI89tFr9nWkxfYNdYPgkoJ34WhQ9p5Fj1kbc81OHIb96/vsmUK+dt+Cy/w==
   dependencies:
     "@expo/config" "^8.5.6"
-    "@expo/turtle-spawn" "^1.0.57"
-    commander "^12.0.0"
+    "@expo/logger" "^1.0.57"
+    "@expo/steps" "^1.0.108"
+    commander "^11.0.0"
     glob "^10.3.12"
     picocolors "^1.0.0"
     protobufjs "^7.2.6"
@@ -3122,10 +3123,10 @@ combined-stream@^1.0.8:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@^12.0.0:
-  version "12.0.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-12.0.0.tgz#b929db6df8546080adfd004ab215ed48cf6f2592"
-  integrity sha512-MwVNWlYjDTtOjX5PiD7o5pK0UrFU/OYgcJfjjK4RaHZETNtjJqrZa9Y9ds88+A+f+d5lv+561eZ+yCKoS3gbAA==
+commander@^11.0.0:
+  version "11.1.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-11.1.0.tgz#62fdce76006a68e5c1ab3314dc92e800eb83d906"
+  integrity sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==
 
 commander@^4.0.0:
   version "4.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -807,7 +807,7 @@
     base64-js "^1.2.3"
     xmlbuilder "^14.0.0"
 
-"@expo/repack-app@^0.0.2":
+"@expo/repack-app@0.0.2":
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/@expo/repack-app/-/repack-app-0.0.2.tgz#37a8d7856a6c0fb2d697107bb5be5243c26c6f50"
   integrity sha512-t8XFHDy0y411df6GrU1TA/Uqe5ndsvLRbznzC3JHOrlQI4m/riHw1j3w/aMMOwIFVWQg72Wd7dCTuhj11S9wnQ==


### PR DESCRIPTION
# Why

Repack onboarding builds

# How

Add new `eas/__download_and_repack_golden_development_client_archive` custom build function to use `@expo/repack-app` to do the repack + resign

# Test Plan

Create a new repo from scratch using the onboarding flow

Add this build profile to your `eas.json`
```json
"repack": {
      "developmentClient": true,
      "distribution": "internal",
      "channel": "development",
      "android": {
        "image": "latest"
      },
      "ios": {
        "image": "latest",
        "config": "repack.yml"
      }
},
```

Add `.eas/build/repack.yml`
```yml
build:
  name: Demo
  steps:
    - eas/checkout
    - eas/install_node_modules
    - eas/__download_and_repack_golden_development_client_archive:
        id: download_and_repack_golden_development_client_archive
    - eas/upload_artifact:
        name: Upload build artifact
        inputs:
          type: application-archive
          path: ${ steps.download_and_repack_golden_development_client_archive.repacked_archive_path }
```

Run `eas build -p ios -e repack`


<img width="605" alt="Screenshot 2024-05-16 at 10 42 29" src="https://github.com/expo/eas-build/assets/55145344/8ddadf2e-4e32-4b10-938d-d205882347c7">

