### PR TITLE
[eas-build-job][build-tools] move repack overrides to Turtle and add `BuildMode.REPACK`

### DIFF
--- a/packages/build-tools/src/builders/android.ts
+++ b/packages/build-tools/src/builders/android.ts
@@ -30,7 +30,7 @@ export default async function androidBuilder(ctx: BuildContext<Android.Job>): Pr
     return await runBuilderWithHooksAsync(ctx, buildAsync);
   } else if (ctx.job.mode === BuildMode.RESIGN) {
     throw new Error('Not implemented');
-  } else if (ctx.job.mode === BuildMode.CUSTOM) {
+  } else if (ctx.job.mode === BuildMode.CUSTOM || ctx.job.mode === BuildMode.REPACK) {
     return await runCustomBuildAsync(ctx);
   } else {
     throw new Error('Not implemented');

--- a/packages/build-tools/src/builders/ios.ts
+++ b/packages/build-tools/src/builders/ios.ts
@@ -30,7 +30,7 @@ export default async function iosBuilder(ctx: BuildContext<Ios.Job>): Promise<Ar
     return await runBuilderWithHooksAsync(ctx, buildAsync);
   } else if (ctx.job.mode === BuildMode.RESIGN) {
     return await resignAsync(ctx);
-  } else if (ctx.job.mode === BuildMode.CUSTOM) {
+  } else if (ctx.job.mode === BuildMode.CUSTOM || ctx.job.mode === BuildMode.REPACK) {
     return await runCustomBuildAsync(ctx);
   } else {
     throw new Error('Not implemented');

--- a/packages/build-tools/src/context.ts
+++ b/packages/build-tools/src/context.ts
@@ -98,9 +98,11 @@ export class BuildContext<TJob extends Job = Job> {
     this.cacheManager = options.cacheManager;
     this._uploadArtifact = options.uploadArtifact;
     this.reportError = options.reportError;
+
+    const shouldApplyRepackOverrides = job.platform && job.mode === BuildMode.REPACK;
     this._job = {
       ...job,
-      ...(job.platform && job.mode === BuildMode.REPACK
+      ...(shouldApplyRepackOverrides
         ? {
             customBuildConfig: {
               path: '__eas/repack.yml',

--- a/packages/build-tools/src/context.ts
+++ b/packages/build-tools/src/context.ts
@@ -17,7 +17,7 @@ import {
 } from '@expo/eas-build-job';
 import { ExpoConfig } from '@expo/config';
 import { bunyan } from '@expo/logger';
-import { BuildTrigger } from '@expo/eas-build-job/dist/common';
+import { BuildMode, BuildTrigger } from '@expo/eas-build-job/dist/common';
 
 import { PackageManager, resolvePackageManager } from './utils/packageManager';
 import { resolveBuildPhaseErrorAsync } from './buildErrors/detectError';
@@ -98,7 +98,16 @@ export class BuildContext<TJob extends Job = Job> {
     this.cacheManager = options.cacheManager;
     this._uploadArtifact = options.uploadArtifact;
     this.reportError = options.reportError;
-    this._job = job;
+    this._job = {
+      ...job,
+      ...(job.platform && job.mode === BuildMode.REPACK
+        ? {
+            customBuildConfig: {
+              path: '__eas/repack.yml',
+            },
+          }
+        : null),
+    };
     this._metadata = options.metadata;
     this.skipNativeBuild = options.skipNativeBuild;
     this.reportBuildPhaseStats = options.reportBuildPhaseStats;

--- a/packages/eas-build-job/src/__tests__/android.test.ts
+++ b/packages/eas-build-job/src/__tests__/android.test.ts
@@ -256,4 +256,21 @@ describe('Android.JobSchema', () => {
     expect(value).toMatchObject(job);
     expect(error).toBeFalsy();
   });
+
+  test('can set build mode === repack', () => {
+    const job = {
+      mode: BuildMode.REPACK,
+      type: Workflow.UNKNOWN,
+      platform: Platform.ANDROID,
+      projectArchive: {
+        type: ArchiveSourceType.URL,
+        url: 'https://expo.dev/builds/123',
+      },
+      projectRootDirectory: '.',
+      secrets,
+    };
+    const { value, error } = Android.JobSchema.validate(job, joiOptions);
+    expect(value).toMatchObject(job);
+    expect(error).toBeFalsy();
+  });
 });

--- a/packages/eas-build-job/src/__tests__/ios.test.ts
+++ b/packages/eas-build-job/src/__tests__/ios.test.ts
@@ -254,4 +254,23 @@ describe('Ios.JobSchema', () => {
     expect(value).toMatchObject(job);
     expect(error).toBeFalsy();
   });
+
+  test('can set build mode === repack', () => {
+    const job = {
+      mode: BuildMode.REPACK,
+      type: Workflow.UNKNOWN,
+      platform: Platform.IOS,
+      projectArchive: {
+        type: ArchiveSourceType.URL,
+        url: 'https://expo.dev/builds/123',
+      },
+      projectRootDirectory: '.',
+      secrets: {
+        buildCredentials,
+      },
+    };
+    const { value, error } = Ios.JobSchema.validate(job, joiOptions);
+    expect(value).toMatchObject(job);
+    expect(error).toBeFalsy();
+  });
 });

--- a/packages/eas-build-job/src/android.ts
+++ b/packages/eas-build-job/src/android.ts
@@ -119,7 +119,9 @@ const SecretsSchema = Joi.object({
 });
 
 export const JobSchema = Joi.object({
-  mode: Joi.string().valid(BuildMode.BUILD, BuildMode.CUSTOM).default(BuildMode.BUILD),
+  mode: Joi.string()
+    .valid(BuildMode.BUILD, BuildMode.CUSTOM, BuildMode.REPACK)
+    .default(BuildMode.BUILD),
   type: Joi.string()
     .valid(...Object.values(Workflow))
     .required(),

--- a/packages/eas-build-job/src/common.ts
+++ b/packages/eas-build-job/src/common.ts
@@ -7,6 +7,7 @@ export enum BuildMode {
   BUILD = 'build',
   RESIGN = 'resign',
   CUSTOM = 'custom',
+  REPACK = 'repack',
 }
 
 export enum Workflow {


### PR DESCRIPTION
# Why

Follow up to discussion in https://github.com/expo/universe/pull/15382

Move repack overrides to Turtle and add `BuildMode.REPACK`

# How

Move repack overrides to Turtle and add `BuildMode.REPACK`

# Test Plan

tests
