### PR TITLE
[build-tools] [ENG-11415] Add timeout for install pods

### DIFF
--- a/packages/build-tools/src/builders/ios.ts
+++ b/packages/build-tools/src/builders/ios.ts
@@ -221,7 +221,7 @@ async function resignAsync(ctx: BuildContext<Ios.Job>): Promise<Artifacts> {
 async function runInstallPodsAsync(ctx: BuildContext<Ios.Job>): Promise<void> {
   let warnTimeout: NodeJS.Timeout | undefined;
   let killTimeout: NodeJS.Timeout | undefined;
-  let killTimedOut: boolean = false;
+  let timedOutToKill: boolean = false;
   try {
     const installPodsSpawnPromise = (
       await installPods(ctx, {
@@ -238,7 +238,7 @@ async function runInstallPodsAsync(ctx: BuildContext<Ios.Job>): Promise<void> {
     }, INSTALL_PODS_WARN_TIMEOUT_MS);
 
     killTimeout = setTimeout(async () => {
-      killTimedOut = true;
+      timedOutToKill = true;
       ctx.logger.error(
         '"Install pods" phase takes a very long time and it did not produce any logs in the past 30 minutes. Most likely an unexpected error happened which caused the process to hang and it will be terminated'
       );
@@ -254,7 +254,7 @@ async function runInstallPodsAsync(ctx: BuildContext<Ios.Job>): Promise<void> {
 
     await installPodsSpawnPromise;
   } catch (err: any) {
-    if (killTimedOut) {
+    if (timedOutToKill) {
       throw new InstallPodsTimeoutError('"Install pods" phase was inactive for over 30 minutes');
     }
     throw err;

--- a/packages/build-tools/src/builders/ios.ts
+++ b/packages/build-tools/src/builders/ios.ts
@@ -25,8 +25,8 @@ import { getParentAndDescendantProcessPidsAsync } from '../utils/processes';
 import { runBuilderWithHooksAsync } from './common';
 import { runCustomBuildAsync } from './custom';
 
-const INSTALL_PODS_WARN_TIMEOUT_MS = 15 * 60 * 1000;
-const INSTALL_PODS_KILL_TIMEOUT_MS = 30 * 60 * 1000;
+const INSTALL_PODS_WARN_TIMEOUT_MS = 15 * 60 * 1000; // 15 minutes
+const INSTALL_PODS_KILL_TIMEOUT_MS = 30 * 60 * 1000; // 30 minutes
 
 class InstallPodsTimeoutError extends Error {}
 

--- a/packages/build-tools/src/builders/ios.ts
+++ b/packages/build-tools/src/builders/ios.ts
@@ -20,9 +20,15 @@ import { resolveArtifactPath, resolveBuildConfiguration, resolveScheme } from '.
 import { setupAsync } from '../common/setup';
 import { prebuildAsync } from '../common/prebuild';
 import { prepareExecutableAsync } from '../utils/prepareBuildExecutable';
+import { getParentAndDescendantProcessPidsAsync } from '../utils/processes';
 
 import { runBuilderWithHooksAsync } from './common';
 import { runCustomBuildAsync } from './custom';
+
+const INSTALL_PODS_WARN_TIMEOUT_MS = 15 * 60 * 1000;
+const INSTALL_PODS_KILL_TIMEOUT_MS = 30 * 60 * 1000;
+
+class InstallPodsTimeoutError extends Error {}
 
 export default async function iosBuilder(ctx: BuildContext<Ios.Job>): Promise<Artifacts> {
   if (ctx.job.mode === BuildMode.BUILD) {
@@ -70,7 +76,7 @@ async function buildAsync(ctx: BuildContext<Ios.Job>): Promise<void> {
     });
 
     await ctx.runBuildPhase(BuildPhase.INSTALL_PODS, async () => {
-      await installPods(ctx);
+      await runInstallPodsAsync(ctx);
     });
 
     await ctx.runBuildPhase(BuildPhase.POST_INSTALL_HOOK, async () => {
@@ -210,4 +216,58 @@ async function resignAsync(ctx: BuildContext<Ios.Job>): Promise<Artifacts> {
     throw new Error('Builder must upload application archive');
   }
   return ctx.artifacts;
+}
+
+async function runInstallPodsAsync(ctx: BuildContext<Ios.Job>): Promise<void> {
+  let warnTimeout: NodeJS.Timeout | undefined;
+  let killTimeout: NodeJS.Timeout | undefined;
+  let killTimedOut: boolean = false;
+  try {
+    const installPodsSpawnPromise = (
+      await installPods(ctx, {
+        infoCallbackFn: () => {
+          if (warnTimeout) {
+            warnTimeout.refresh();
+          }
+          if (killTimeout) {
+            killTimeout.refresh();
+          }
+        },
+      })
+    ).spawnPromise;
+    warnTimeout = setTimeout(() => {
+      ctx.logger.warn(
+        '"Install pods" phase takes longer then expected and it did not produce any logs in the past 15 minutes'
+      );
+    }, INSTALL_PODS_WARN_TIMEOUT_MS);
+
+    killTimeout = setTimeout(async () => {
+      killTimedOut = true;
+      ctx.logger.error(
+        '"Install pods" phase takes a very long time and it did not produce any logs in the past 30 minutes. Most likely an unexpected error happened which caused the process to hang and it will be terminated'
+      );
+      const ppid = nullthrows(installPodsSpawnPromise.child.pid);
+      const pids = await getParentAndDescendantProcessPidsAsync(ppid);
+      pids.forEach((pid) => {
+        process.kill(pid);
+      });
+      ctx.reportError?.('"Install pods" phase takes a very long time', undefined, {
+        extras: { buildId: ctx.env.EAS_BUILD_ID },
+      });
+    }, INSTALL_PODS_KILL_TIMEOUT_MS);
+
+    await installPodsSpawnPromise;
+  } catch (err: any) {
+    if (killTimedOut) {
+      throw new InstallPodsTimeoutError('"Install pods" phase was inactive for over 30 minutes');
+    }
+    throw err;
+  } finally {
+    if (warnTimeout) {
+      clearTimeout(warnTimeout);
+    }
+    if (killTimeout) {
+      clearTimeout(killTimeout);
+    }
+  }
 }

--- a/packages/build-tools/src/builders/ios.ts
+++ b/packages/build-tools/src/builders/ios.ts
@@ -226,12 +226,8 @@ async function runInstallPodsAsync(ctx: BuildContext<Ios.Job>): Promise<void> {
     const installPodsSpawnPromise = (
       await installPods(ctx, {
         infoCallbackFn: () => {
-          if (warnTimeout) {
-            warnTimeout.refresh();
-          }
-          if (killTimeout) {
-            killTimeout.refresh();
-          }
+          warnTimeout?.refresh();
+          killTimeout?.refresh();
         },
       })
     ).spawnPromise;

--- a/packages/build-tools/src/ios/pod.ts
+++ b/packages/build-tools/src/ios/pod.ts
@@ -1,32 +1,38 @@
 import path from 'path';
 
 import { Ios } from '@expo/eas-build-job';
-import spawn from '@expo/turtle-spawn';
+import spawn, { SpawnOptions, SpawnPromise, SpawnResult } from '@expo/turtle-spawn';
 
 import { BuildContext } from '../context';
 
-export async function installPods<TJob extends Ios.Job>(ctx: BuildContext<TJob>): Promise<void> {
+export async function installPods<TJob extends Ios.Job>(
+  ctx: BuildContext<TJob>,
+  { infoCallbackFn }: SpawnOptions
+): Promise<{ spawnPromise: SpawnPromise<SpawnResult> }> {
   const iosDir = path.join(ctx.getReactNativeProjectDirectory(), 'ios');
 
-  await spawn('pod', ['install'], {
-    cwd: iosDir,
-    logger: ctx.logger,
-    env: {
-      ...ctx.env,
-      LANG: 'en_US.UTF-8',
-      ...(ctx.env.EAS_BUILD_COCOAPODS_CACHE_URL
-        ? { NEXUS_COCOAPODS_REPO_URL: ctx.env.EAS_BUILD_COCOAPODS_CACHE_URL }
-        : {}),
-    },
-    lineTransformer: (line?: string) => {
-      if (
-        !line ||
-        /\[!\] '[\w-]+' uses the unencrypted 'http' protocol to transfer the Pod\./.exec(line)
-      ) {
-        return null;
-      } else {
-        return line;
-      }
-    },
-  });
+  return {
+    spawnPromise: spawn('pod', ['install'], {
+      cwd: iosDir,
+      logger: ctx.logger,
+      env: {
+        ...ctx.env,
+        LANG: 'en_US.UTF-8',
+        ...(ctx.env.EAS_BUILD_COCOAPODS_CACHE_URL
+          ? { NEXUS_COCOAPODS_REPO_URL: ctx.env.EAS_BUILD_COCOAPODS_CACHE_URL }
+          : {}),
+      },
+      lineTransformer: (line?: string) => {
+        if (
+          !line ||
+          /\[!\] '[\w-]+' uses the unencrypted 'http' protocol to transfer the Pod\./.exec(line)
+        ) {
+          return null;
+        } else {
+          return line;
+        }
+      },
+      infoCallbackFn,
+    }),
+  };
 }


### PR DESCRIPTION
# Why

https://linear.app/expo/issue/ENG-11415/add-timeouts-for-the-install-pods-build-phase

# How

Added a warn and kill timeout for install pods phase, similar to what has been done for install dependencies phase here - https://github.com/expo/eas-build/pull/297

# Test Plan

Automated tests
