### PR TITLE
[build-tools] resolve default values for `eas/calculate_eas_update_runtime_version` function just when executing it

### DIFF
--- a/packages/build-tools/src/steps/easFunctions.ts
+++ b/packages/build-tools/src/steps/easFunctions.ts
@@ -51,7 +51,7 @@ export function getEasFunctions(ctx: CustomBuildContext): BuildFunction[] {
     createInstallPodsBuildFunction(),
     createSendSlackMessageFunction(),
 
-    calculateEASUpdateRuntimeVersionFunction(ctx),
+    calculateEASUpdateRuntimeVersionFunction(),
 
     createRepackBuildFunction(),
   ];

--- a/packages/build-tools/src/steps/functionGroups/build.ts
+++ b/packages/build-tools/src/steps/functionGroups/build.ts
@@ -68,11 +68,10 @@ function createStepsForIosSimulatorBuild({
   globalCtx,
   buildToolsContext,
 }: HelperFunctionsInput): BuildStep[] {
-  const calculateEASUpdateRuntimeVersion = calculateEASUpdateRuntimeVersionFunction(
-    buildToolsContext
-  ).createBuildStepFromFunctionCall(globalCtx, {
-    id: 'calculate_eas_update_runtime_version',
-  });
+  const calculateEASUpdateRuntimeVersion =
+    calculateEASUpdateRuntimeVersionFunction().createBuildStepFromFunctionCall(globalCtx, {
+      id: 'calculate_eas_update_runtime_version',
+    });
   const installPods = createInstallPodsBuildFunction().createBuildStepFromFunctionCall(globalCtx, {
     workingDirectory: './ios',
   });
@@ -118,11 +117,10 @@ function createStepsForIosBuildWithCredentials({
     resolveAppleTeamIdFromCredentialsFunction().createBuildStepFromFunctionCall(globalCtx, {
       id: 'resolve_apple_team_id_from_credentials',
     });
-  const calculateEASUpdateRuntimeVersion = calculateEASUpdateRuntimeVersionFunction(
-    buildToolsContext
-  ).createBuildStepFromFunctionCall(globalCtx, {
-    id: 'calculate_eas_update_runtime_version',
-  });
+  const calculateEASUpdateRuntimeVersion =
+    calculateEASUpdateRuntimeVersionFunction().createBuildStepFromFunctionCall(globalCtx, {
+      id: 'calculate_eas_update_runtime_version',
+    });
   const prebuildStep = createPrebuildBuildFunction().createBuildStepFromFunctionCall(globalCtx, {
     callInputs: {
       apple_team_id: '${ steps.resolve_apple_team_id_from_credentials.apple_team_id }',
@@ -180,11 +178,10 @@ function createStepsForAndroidBuildWithoutCredentials({
   globalCtx,
   buildToolsContext,
 }: HelperFunctionsInput): BuildStep[] {
-  const calculateEASUpdateRuntimeVersion = calculateEASUpdateRuntimeVersionFunction(
-    buildToolsContext
-  ).createBuildStepFromFunctionCall(globalCtx, {
-    id: 'calculate_eas_update_runtime_version',
-  });
+  const calculateEASUpdateRuntimeVersion =
+    calculateEASUpdateRuntimeVersionFunction().createBuildStepFromFunctionCall(globalCtx, {
+      id: 'calculate_eas_update_runtime_version',
+    });
   const configureEASUpdate =
     configureEASUpdateIfInstalledFunction().createBuildStepFromFunctionCall(globalCtx, {
       callInputs: {
@@ -221,11 +218,10 @@ function createStepsForAndroidBuildWithCredentials({
   globalCtx,
   buildToolsContext,
 }: HelperFunctionsInput): BuildStep[] {
-  const calculateEASUpdateRuntimeVersion = calculateEASUpdateRuntimeVersionFunction(
-    buildToolsContext
-  ).createBuildStepFromFunctionCall(globalCtx, {
-    id: 'calculate_eas_update_runtime_version',
-  });
+  const calculateEASUpdateRuntimeVersion =
+    calculateEASUpdateRuntimeVersionFunction().createBuildStepFromFunctionCall(globalCtx, {
+      id: 'calculate_eas_update_runtime_version',
+    });
   const configureEASUpdate =
     configureEASUpdateIfInstalledFunction().createBuildStepFromFunctionCall(globalCtx, {
       callInputs: {

--- a/packages/build-tools/src/steps/functions/calculateEASUpdateRuntimeVersion.ts
+++ b/packages/build-tools/src/steps/functions/calculateEASUpdateRuntimeVersion.ts
@@ -8,9 +8,8 @@ import {
 
 import { resolveRuntimeVersionForExpoUpdatesIfConfiguredAsync } from '../../utils/expoUpdates';
 import { readAppConfig } from '../../utils/appConfig';
-import { CustomBuildContext } from '../../customBuildContext';
 
-export function calculateEASUpdateRuntimeVersionFunction(ctx: CustomBuildContext): BuildFunction {
+export function calculateEASUpdateRuntimeVersionFunction(): BuildFunction {
   return new BuildFunction({
     namespace: 'eas',
     id: 'calculate_eas_update_runtime_version',
@@ -18,15 +17,15 @@ export function calculateEASUpdateRuntimeVersionFunction(ctx: CustomBuildContext
     inputProviders: [
       BuildStepInput.createProvider({
         id: 'platform',
-        defaultValue: ctx.job.platform,
-        required: !ctx.job.platform,
+        required: false,
         allowedValueTypeName: BuildStepInputValueTypeName.STRING,
+        allowedValues: [Platform.ANDROID, Platform.IOS],
       }),
       BuildStepInput.createProvider({
         id: 'workflow',
-        defaultValue: ctx.job.type,
-        required: !ctx.job.type,
+        required: false,
         allowedValueTypeName: BuildStepInputValueTypeName.STRING,
+        allowedValues: [Workflow.GENERIC, Workflow.MANAGED],
       }),
     ],
     outputProviders: [
@@ -52,8 +51,8 @@ export function calculateEASUpdateRuntimeVersionFunction(ctx: CustomBuildContext
         cwd: stepCtx.workingDirectory,
         logger: stepCtx.logger,
         appConfig,
-        platform: inputs.platform.value as Platform,
-        workflow: inputs.workflow.value as Workflow,
+        platform: (inputs.platform.value as Platform) ?? stepCtx.global.staticContext.job.platform,
+        workflow: (inputs.workflow.value as Workflow) ?? stepCtx.global.staticContext.job.type,
         env,
       });
       if (resolvedRuntimeVersion) {


### PR DESCRIPTION
# Why

https://exponent-internal.slack.com/archives/C04PTQN8UTY/p1717496873513409

Default values for build step inputs are provided at the beginning of the build process. At this point in time not all of the `job` data is updated for GH triggered build. It happens in https://github.com/expo/eas-build/blob/d70f544b51913e923803724b9581d830d641186e/packages/build-tools/src/steps/functions/resolveBuildConfig.ts#L33-L42 step. That causes the default value for `workflow` to be invalid.

# How

Make inputs non-required but if the input is not provided fall back to `job` values when executing the step (then `job` values should be correct at this point in time)

Add validation

# Test Plan

Tests
