### PR TITLE
[local-build-plugin] import `tar` correctly

### DIFF
--- a/packages/local-build-plugin/package.json
+++ b/packages/local-build-plugin/package.json
@@ -45,7 +45,6 @@
     "@types/hapi__joi": "^17.1.14",
     "@types/lodash": "^4.17.4",
     "@types/semver": "^7.5.8",
-    "@types/tar": "^6.1.13",
     "@types/uuid": "^9.0.7",
     "jest": "^29.7.0",
     "ts-jest": "^29.1.4",

--- a/packages/local-build-plugin/src/artifacts.ts
+++ b/packages/local-build-plugin/src/artifacts.ts
@@ -2,7 +2,7 @@ import path from 'path';
 
 import { bunyan } from '@expo/logger';
 import fs from 'fs-extra';
-import tar from 'tar';
+import * as tar from 'tar';
 
 import config from './config';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1999,14 +1999,6 @@
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.0.tgz#7036640b4e21cc2f259ae826ce843d277dad8cff"
   integrity sha512-RJJrrySY7A8havqpGObOB4W92QXKJo63/jFLLgpvOtsGUqbQZ9Sbgl35KMm1DjC6j7AvmmU2bIno+3IyEaemaw==
 
-"@types/tar@^6.1.13":
-  version "6.1.13"
-  resolved "https://registry.yarnpkg.com/@types/tar/-/tar-6.1.13.tgz#9b5801c02175344101b4b91086ab2bbc8e93a9b6"
-  integrity sha512-IznnlmU5f4WcGTh2ltRu/Ijpmk8wiWXfF0VA4s+HPjHZgvFggk1YaIkbo5krX/zUCzWF8N/l4+W/LNxnvAJ8nw==
-  dependencies:
-    "@types/node" "*"
-    minipass "^4.0.0"
-
 "@types/uuid@^9.0.7":
   version "9.0.7"
   resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-9.0.7.tgz#b14cebc75455eeeb160d5fe23c2fcc0c64f724d8"


### PR DESCRIPTION
# Why

It seems like the `export default` statement was deleted in `tar` 7.x

We imported `tar` like `import tar from 'tar'` and it seems to be the root cause of the https://github.com/expo/eas-cli/issues/2430 issue (`Cannot read properties of undefined (reading 'c')` - we use tar like `tar.c(...)`)

# How

Uninstall not needed `@types/tar` package and import the `tar` correctly

# Test Plan

Test manually
