### PR TITLE
[build-tools] fix issues with `./gradlew` being executed with inncorrect shell

### DIFF
--- a/packages/build-tools/src/android/gradle.ts
+++ b/packages/build-tools/src/android/gradle.ts
@@ -30,7 +30,7 @@ export async function runGradleCommand(
   }: { logger: bunyan; gradleCommand: string; androidDir: string; extraEnv?: Env }
 ): Promise<void> {
   logger.info(`Running 'gradlew ${gradleCommand}' in ${androidDir}`);
-  await fs.chmod(path.join(androidDir, 'gradlew'), '+x');
+  await fs.chmod(path.join(androidDir, 'gradlew'), 0o755);
   const spawnPromise = spawn('./gradlew', [gradleCommand], {
     cwd: androidDir,
     logger,

--- a/packages/build-tools/src/android/gradle.ts
+++ b/packages/build-tools/src/android/gradle.ts
@@ -30,7 +30,8 @@ export async function runGradleCommand(
   }: { logger: bunyan; gradleCommand: string; androidDir: string; extraEnv?: Env }
 ): Promise<void> {
   logger.info(`Running 'gradlew ${gradleCommand}' in ${androidDir}`);
-  const spawnPromise = spawn('bash', ['-c', `sh gradlew ${gradleCommand}`], {
+  await fs.chmod(path.join(androidDir, 'gradlew'), '+x');
+  const spawnPromise = spawn('./gradlew', [gradleCommand], {
     cwd: androidDir,
     logger,
     lineTransformer: (line?: string) => {

--- a/packages/build-tools/src/android/gradle.ts
+++ b/packages/build-tools/src/android/gradle.ts
@@ -31,7 +31,7 @@ export async function runGradleCommand(
 ): Promise<void> {
   logger.info(`Running 'gradlew ${gradleCommand}' in ${androidDir}`);
   await fs.chmod(path.join(androidDir, 'gradlew'), 0o755);
-  const spawnPromise = spawn('./gradlew', [gradleCommand], {
+  const spawnPromise = spawn('bash', ['-c', `./gradlew ${gradleCommand}`], {
     cwd: androidDir,
     logger,
     lineTransformer: (line?: string) => {

--- a/packages/build-tools/src/steps/utils/android/gradle.ts
+++ b/packages/build-tools/src/steps/utils/android/gradle.ts
@@ -21,7 +21,7 @@ export async function runGradleCommand({
   extraEnv?: BuildStepEnv;
 }): Promise<void> {
   logger.info(`Running 'gradlew ${gradleCommand}' in ${androidDir}`);
-  await fs.chmod(path.join(androidDir, 'gradlew'), '+x');
+  await fs.chmod(path.join(androidDir, 'gradlew'), 0o755);
   const spawnPromise = spawn('./gradlew', [gradleCommand], {
     cwd: androidDir,
     logger,

--- a/packages/build-tools/src/steps/utils/android/gradle.ts
+++ b/packages/build-tools/src/steps/utils/android/gradle.ts
@@ -1,4 +1,5 @@
 import assert from 'assert';
+import path from 'path';
 
 import fs from 'fs-extra';
 import { bunyan } from '@expo/logger';
@@ -20,7 +21,8 @@ export async function runGradleCommand({
   extraEnv?: BuildStepEnv;
 }): Promise<void> {
   logger.info(`Running 'gradlew ${gradleCommand}' in ${androidDir}`);
-  const spawnPromise = spawn('bash', ['-c', `sh gradlew ${gradleCommand}`], {
+  await fs.chmod(path.join(androidDir, 'gradlew'), '+x');
+  const spawnPromise = spawn('./gradlew', [gradleCommand], {
     cwd: androidDir,
     logger,
     lineTransformer: (line?: string) => {

--- a/packages/build-tools/src/steps/utils/android/gradle.ts
+++ b/packages/build-tools/src/steps/utils/android/gradle.ts
@@ -22,7 +22,7 @@ export async function runGradleCommand({
 }): Promise<void> {
   logger.info(`Running 'gradlew ${gradleCommand}' in ${androidDir}`);
   await fs.chmod(path.join(androidDir, 'gradlew'), 0o755);
-  const spawnPromise = spawn('./gradlew', [gradleCommand], {
+  const spawnPromise = spawn('bash', ['-c', `./gradlew ${gradleCommand}`], {
     cwd: androidDir,
     logger,
     lineTransformer: (line?: string) => {


### PR DESCRIPTION
# Why

Using always `bash` or `sh` seems undesired and it looks like it caused some issues for one of our users https://exponent-internal.slack.com/archives/C02123T524U/p1718651239155819

# How

Use `gradlew` as just `./gradlew` instead of `bash -c sh gradlew`.

The `bash -c sh gradlew` hack was introduced to fix permission issues when executing the file. To preserve the fix I added the `chmod +x` before.

# Test Plan

tests
