### PR TITLE
[build-tools] pass `keyPassword` to `@expo/repack` only if it is defined

### DIFF
--- a/packages/build-tools/src/steps/functions/repack.ts
+++ b/packages/build-tools/src/steps/functions/repack.ts
@@ -114,7 +114,10 @@ export function createRepackBuildFunction(): BuildFunction {
             keyStorePath,
             keyStorePassword: `pass:${stepsCtx.global.staticContext.job.secrets.buildCredentials.keystore.keystorePassword}`,
             keyAlias: stepsCtx.global.staticContext.job.secrets.buildCredentials.keystore.keyAlias,
-            keyPassword: `pass:${stepsCtx.global.staticContext.job.secrets.buildCredentials.keystore.keyPassword}`,
+            keyPassword: stepsCtx.global.staticContext.job.secrets.buildCredentials.keystore
+              .keyPassword
+              ? `pass:${stepsCtx.global.staticContext.job.secrets.buildCredentials.keystore.keyPassword}`
+              : undefined,
           };
         }
 


### PR DESCRIPTION
# Why

https://exponent-internal.slack.com/archives/CLQ58M23X/p1719753567896349?thread_ts=1716632008.211259&cid=CLQ58M23X

# How

Pass `keyPassword` only if it is defined to avoid passing `pass:undefined`.

# Test Plan

tests
