### PR TITLE
[ENG-12644][build-tools] calculate artifact size correctly for directories

### DIFF
--- a/packages/build-tools/package.json
+++ b/packages/build-tools/package.json
@@ -43,6 +43,7 @@
     "node-forge": "^1.3.1",
     "nullthrows": "^1.1.1",
     "plist": "^3.1.0",
+    "promise-limit": "^2.7.0",
     "resolve-from": "^5.0.0",
     "semver": "^7.6.2"
   },

--- a/packages/build-tools/src/utils/artifacts.ts
+++ b/packages/build-tools/src/utils/artifacts.ts
@@ -145,11 +145,10 @@ async function getArtifactsSizes(artifacts: string[]): Promise<Record<string, nu
         artifactsSizes[artifact] = stat.size;
       } else {
         const files = await fg('**/*', { cwd: artifact, onlyFiles: true });
-        let size = 0;
-        for (const file of files) {
-          size += (await fs.stat(path.join(artifact, file))).size;
-        }
-        artifactsSizes[artifact] = size;
+        const sizes = await Promise.all(
+          files.map(async (file) => (await fs.stat(path.join(artifact, file))).size)
+        );
+        artifactsSizes[artifact] = sizes.reduce((acc, size) => acc + size, 0);
       }
     })
   );

--- a/packages/build-tools/src/utils/artifacts.ts
+++ b/packages/build-tools/src/utils/artifacts.ts
@@ -2,9 +2,8 @@ import path from 'path';
 
 import fs from 'fs-extra';
 import fg from 'fast-glob';
-import { bunyan, PipeMode } from '@expo/logger';
+import { bunyan } from '@expo/logger';
 import { ManagedArtifactType, Job, BuildJob } from '@expo/eas-build-job';
-import spawnAsync from '@expo/turtle-spawn';
 
 import { BuildContext } from '../context';
 
@@ -93,9 +92,8 @@ export async function maybeFindAndUploadBuildArtifacts(
     ).flat();
     const artifactsSizes = await getArtifactsSizes(buildArtifacts);
     logger.info(`Build artifacts:`);
-    for (const artifactPath of buildArtifacts) {
-      const maybeSize = artifactsSizes[artifactPath];
-      logger.info(`  - ${artifactPath}${maybeSize ? ` (${formatBytes(maybeSize)})` : ''}`);
+    for (const [path, size] of Object.entries(artifactsSizes)) {
+      logger.info(`  - ${path} (${formatBytes(size)})`);
     }
     logger.info('Uploading build artifacts...');
     await ctx.uploadArtifact({
@@ -125,9 +123,8 @@ export async function uploadApplicationArchive(
   const applicationArchives = await findArtifacts({ rootDir, patternOrPath, logger });
   const artifactsSizes = await getArtifactsSizes(applicationArchives);
   logger.info(`Application archives:`);
-  for (const artifactPath of applicationArchives) {
-    const maybeSize = artifactsSizes[artifactPath];
-    logger.info(`  - ${artifactPath}${maybeSize ? ` (${formatBytes(maybeSize)})` : ''}`);
+  for (const [path, size] of Object.entries(artifactsSizes)) {
+    logger.info(`  - ${path} (${formatBytes(size)})`);
   }
   logger.info('Uploading application archive...');
   await ctx.uploadArtifact({
@@ -139,20 +136,20 @@ export async function uploadApplicationArchive(
   });
 }
 
-/**
- * @returns a map of artifact paths to their sizes in bytes
- */
-async function getArtifactsSizes(artifacts: string[]): Promise<Record<string, number | undefined>> {
+async function getArtifactsSizes(artifacts: string[]): Promise<Record<string, number>> {
   const artifactsSizes: Record<string, number> = {};
   await Promise.all(
     artifacts.map(async (artifact) => {
-      try {
-        const { stdout } = await spawnAsync('du', ['-sk', artifact], {
-          mode: PipeMode.COMBINED,
-        });
-        const size = parseInt(stdout.split('\t')[0], 10) * 1024;
-        artifactsSizes[artifact] = size;
-      } catch {}
+      const stat = await fs.stat(artifact);
+      if (!stat.isDirectory()) {
+        artifactsSizes[artifact] = stat.size;
+      } else {
+        const files = await fg('**/*', { cwd: artifact, onlyFiles: true });
+        const sizes = await Promise.all(
+          files.map(async (file) => (await fs.stat(path.join(artifact, file))).size)
+        );
+        artifactsSizes[artifact] = sizes.reduce((acc, size) => acc + size, 0);
+      }
     })
   );
   return artifactsSizes;

--- a/yarn.lock
+++ b/yarn.lock
@@ -7912,6 +7912,11 @@ promise-inflight@^1.0.1:
   resolved "https://registry.yarnpkg.com/promise-inflight/-/promise-inflight-1.0.1.tgz#98472870bf228132fcbdd868129bad12c3c029e3"
   integrity sha1-mEcocL8igTL8vdhoEputEsPAKeM=
 
+promise-limit@^2.7.0:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/promise-limit/-/promise-limit-2.7.0.tgz#eb5737c33342a030eaeaecea9b3d3a93cb592b26"
+  integrity sha512-7nJ6v5lnJsXwGprnGXga4wx6d1POjvi5Qmf1ivTRxTjH4Z/9Czja/UCMLVmB9N93GeWOU93XaFaEt6jbuoagNw==
+
 promise-retry@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/promise-retry/-/promise-retry-2.0.1.tgz#ff747a13620ab57ba688f5fc67855410c370da22"
@@ -8720,16 +8725,7 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -8868,7 +8864,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -8888,13 +8884,6 @@ strip-ansi@^6.0.0:
   integrity sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==
   dependencies:
     ansi-regex "^5.0.0"
-
-strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.1.0"
@@ -9683,7 +9672,7 @@ wordwrap@^1.0.0:
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -9700,15 +9689,6 @@ wrap-ansi@^5.1.0:
     ansi-styles "^3.2.0"
     string-width "^3.0.0"
     strip-ansi "^5.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
 
 wrap-ansi@^8.1.0:
   version "8.1.0"


### PR DESCRIPTION
# Why

https://linear.app/expo/issue/ENG-12644/reported-archive-size-for-simulator-builds-is-incorrect

# How

calculate artifact size correctly for directory artifacts

# Test Plan

Test manually
<img width="934" alt="Screenshot 2024-07-04 at 15 28 05" src="https://github.com/expo/eas-build/assets/55145344/46003cd6-d0ba-41d8-a7da-a0460cbdc95e">

