### PR TITLE
[build-tools] Use `__EXPO_RELATIVE_BASE_DIRECTORY` to update default working directory for generic jobs

### DIFF
--- a/packages/build-tools/src/context.ts
+++ b/packages/build-tools/src/context.ts
@@ -276,8 +276,11 @@ export class BuildContext<TJob extends Job = Job> {
 
   public getReactNativeProjectDirectory(baseDirectory = this.buildDirectory): string {
     if (!this.job.platform) {
-      // Generic jobs start from base directory.
-      return baseDirectory;
+      return path.join(
+        baseDirectory,
+        // NOTE: We may want to add projectRootDirectory to generic jobs in the future.
+        this.job.builderEnvironment.env.__EXPO_RELATIVE_BASE_DIRECTORY || '.'
+      );
     }
 
     return path.join(baseDirectory, this.job.projectRootDirectory ?? '.');

--- a/packages/build-tools/src/utils/__tests__/hooks.test.ts
+++ b/packages/build-tools/src/utils/__tests__/hooks.test.ts
@@ -26,7 +26,7 @@ describe(runHookIfPresent, () => {
     vol.reset();
     (spawn as jest.Mock).mockReset();
 
-    ctx = new BuildContext({ projectRootDirectory: '.' } as BuildJob, {
+    ctx = new BuildContext({ projectRootDirectory: '.', platform: 'android' } as BuildJob, {
       workingdir: '/workingdir',
       logBuffer: { getLogs: () => [], getPhaseLogs: () => [] },
       logger: loggerMock as any,


### PR DESCRIPTION
# Why

Adds support for monorepos to EAS Update GitHub integration.

# How

Used the environment variable passed from `www` to change `workingDirectory`

# Test Plan

Tested with microfoam fork. (Don't mind failure to upload assets.)

<img width="1271" alt="Zrzut ekranu 2024-07-10 o 13 40 49" src="https://github.com/expo/eas-build/assets/1151041/17505640-e647-40f4-87ea-b78099ef7169">
