### PR TITLE
[create-eas-build-function] Add missing ncc dependency

### DIFF
--- a/packages/create-eas-build-function/templates/javascript/package.json
+++ b/packages/create-eas-build-function/templates/javascript/package.json
@@ -4,6 +4,7 @@
   "main": "./build/index.js",
   "type": "commonjs",
   "devDependencies": {
+    "@vercel/ncc": "^0.38.1",
     "@babel/cli": "^7.23.9",
     "@babel/core": "^7.23.9",
     "@babel/preset-env": "^7.23.9"

--- a/packages/create-eas-build-function/templates/typescript/package.json
+++ b/packages/create-eas-build-function/templates/typescript/package.json
@@ -10,6 +10,7 @@
   "keywords": [],
   "author": "",
   "devDependencies": {
+    "@vercel/ncc": "^0.38.1",
     "@types/node": "20.14.2",
     "typescript": "^5.3.3",
     "@expo/steps": "^1.0.75"


### PR DESCRIPTION
# Why

Noticed that when creating a new build function with `create-eas-build-function`, the "build" script in the new function's `package.json` will not work unless `@vercel/ncc` is added to the package.

# How

Added the missing dependency to both templates.

# Test Plan

- CI should pass
- Create a new function, go into the function directory, and call "yarn" and "yarn build". After this change, those steps should work.
