### PR TITLE
[build-tools] run `resolvePackageManager` function in correct directory for custom builds

### DIFF
--- a/packages/build-tools/src/steps/functions/installNodeModules.ts
+++ b/packages/build-tools/src/steps/functions/installNodeModules.ts
@@ -1,3 +1,5 @@
+import path from 'path';
+
 import { BuildFunction, BuildStepEnv } from '@expo/steps';
 import { BuildStepContext } from '@expo/steps/dist_esm/BuildStepContext';
 import spawn from '@expo/turtle-spawn';
@@ -27,6 +29,17 @@ export async function installNodeModules(
   const { logger } = stepCtx;
   const packageManager = resolvePackageManager(stepCtx.workingDirectory);
   const packagerRunDir = findPackagerRootDir(stepCtx.workingDirectory);
+
+  if (packagerRunDir !== stepCtx.workingDirectory) {
+    const relativeReactNativeProjectDirectory = path.relative(
+      stepCtx.global.projectTargetDirectory,
+      stepCtx.workingDirectory
+    );
+    logger.info(
+      `We detected that '${relativeReactNativeProjectDirectory}' is a ${packageManager} workspace`
+    );
+  }
+
   let args = ['install'];
   if (packageManager === PackageManager.PNPM) {
     args = ['install', '--no-frozen-lockfile'];

--- a/packages/build-tools/src/steps/functions/installNodeModules.ts
+++ b/packages/build-tools/src/steps/functions/installNodeModules.ts
@@ -25,7 +25,7 @@ export async function installNodeModules(
   env: BuildStepEnv
 ): Promise<void> {
   const { logger } = stepCtx;
-  const packageManager = resolvePackageManager(stepCtx.global.projectTargetDirectory);
+  const packageManager = resolvePackageManager(stepCtx.workingDirectory);
   const packagerRunDir = findPackagerRootDir(stepCtx.workingDirectory);
   let args = ['install'];
   if (packageManager === PackageManager.PNPM) {

--- a/packages/build-tools/src/steps/functions/prebuild.ts
+++ b/packages/build-tools/src/steps/functions/prebuild.ts
@@ -34,7 +34,7 @@ export function createPrebuildBuildFunction(): BuildFunction {
     fn: async (stepCtx, { inputs, env }) => {
       const { logger } = stepCtx;
       const appleTeamId = inputs.apple_team_id.value as string | undefined;
-      const packageManager = resolvePackageManager(stepCtx.global.projectTargetDirectory);
+      const packageManager = resolvePackageManager(stepCtx.workingDirectory);
 
       assert(stepCtx.global.staticContext.job, 'Job is not defined');
       const job = stepCtx.global.staticContext.job;


### PR DESCRIPTION
# Why

https://github.com/expo/eas-cli/issues/2401#issuecomment-2242242004

It seems like we are running `resolvePackageManager` in the wrong directory for custom builds (`stepsCtx.global.projectTargetDirectory` vs `stepsCtx.workingDir`).

For standard builds, we run `resolvePackageManager` in the `ctx.getReactNativeProjectDirectory()` directory
https://github.com/expo/eas-build/blob/b89f2dc256e611efe5627adfdae94e805cb392e3/packages/build-tools/src/context.ts#L160-L162
that is the default `stepsCtx.workingDir` for custom builds.

# How

Run  `resolvePackageManager` in `stepsCtx.workingDir`

# Test Plan

Tests
