### PR TITLE
Add `environment` to Metadata

### DIFF
--- a/packages/eas-build-job/src/metadata.ts
+++ b/packages/eas-build-job/src/metadata.ts
@@ -175,6 +175,11 @@ export type Metadata = {
    * Custom node version selected by user for the build. If user didn't select any node version and wants to use default it will be undefined.
    */
   customNodeVersion?: string;
+
+  /**
+   * Environment variables that should be set for the build.
+   */
+  environment?: string;
 };
 
 const FingerprintSourceSchema = Joi.object<FingerprintSource>({
@@ -233,6 +238,7 @@ export const MetadataSchema = Joi.object({
   simulator: Joi.boolean(),
   selectedImage: Joi.string(),
   customNodeVersion: Joi.string(),
+  environment: Joi.string().valid('production', 'preview', 'development'),
 });
 
 export function sanitizeMetadata(metadata: object): Metadata {

--- a/packages/eas-build-job/src/metadata.ts
+++ b/packages/eas-build-job/src/metadata.ts
@@ -177,9 +177,9 @@ export type Metadata = {
   customNodeVersion?: string;
 
   /**
-   * Environment variables that should be set for the build.
+   * EAS env vars environment chosen for the job
    */
-  environment?: 'production' | 'preview' |'development';
+  environment?: 'production' | 'preview' | 'development';
 };
 
 const FingerprintSourceSchema = Joi.object<FingerprintSource>({

--- a/packages/eas-build-job/src/metadata.ts
+++ b/packages/eas-build-job/src/metadata.ts
@@ -179,7 +179,7 @@ export type Metadata = {
   /**
    * Environment variables that should be set for the build.
    */
-  environment?: string;
+  environment?: 'production' | 'preview' |'development';
 };
 
 const FingerprintSourceSchema = Joi.object<FingerprintSource>({


### PR DESCRIPTION
# Why

User should be able to choose environment variables set that will be used during build process.

# How

Added `environment` to build `metadata`.

# Test Plan

Tested manually with similar changes to `eas-cli`
