### PR TITLE
[build-tools] do not override the `job.expoBuildUrl` after resolving job object using `eas build:internal` for GitHub triggered builds

### DIFF
--- a/packages/build-tools/src/context.ts
+++ b/packages/build-tools/src/context.ts
@@ -247,7 +247,11 @@ export class BuildContext<TJob extends Job = Job> {
         'Updating job information is only allowed when build was triggered by a git-based integration.'
       );
     }
-    this._job = { ...job, triggeredBy: this._job.triggeredBy };
+    this._job = {
+      ...job,
+      triggeredBy: this._job.triggeredBy,
+      ...(this._job.platform ? { expoBuildUrl: this._job.expoBuildUrl } : null),
+    };
     this._metadata = metadata;
   }
 

--- a/packages/build-tools/src/customBuildContext.ts
+++ b/packages/build-tools/src/customBuildContext.ts
@@ -110,7 +110,11 @@ export class CustomBuildContext<TJob extends Job = Job> implements ExternalBuild
         'Updating job information is only allowed when build was triggered by a git-based integration.'
       );
     }
-    this.job = { ...job, triggeredBy: this.job.triggeredBy };
+    this.job = {
+      ...job,
+      triggeredBy: this.job.triggeredBy,
+      ...(this.job.platform ? { expoBuildUrl: this.job.expoBuildUrl } : null),
+    };
     this.metadata = metadata;
   }
 }


### PR DESCRIPTION
# Why

We don't have full knowledge about the project when triggering the GH build in WWW, because we don't clone the repository there + install node modules. We only do this during the build process itself. We use the `eas build:internal` command to obtain an updated job object. The old job object is overridden with a new one, but it seems that overriding `expoBuildUrl` with `undefined` which is set server-side in WWW is not desired.

# How

Do not override `expoBuildUrl`.

# Test Plan

Tests
