### PR TITLE
[eas-build] [steps] [ENG-13151] Catch errors while evaluating if step should be executed

### DIFF
--- a/packages/steps/src/BuildWorkflow.ts
+++ b/packages/steps/src/BuildWorkflow.ts
@@ -25,7 +25,7 @@ export class BuildWorkflow {
       } catch (err: any) {
         step.ctx.logger.error({ err });
         step.ctx.logger.error(
-          `Runner failed to evaluate if it should execute step "${step.displayName}"`
+          `Runner failed to evaluate if it should execute step "${step.displayName}", using step's if condition "${step.ifCondition}". This can be caused by trying to access non-existing object property. If you think this is a bug report it here: https://github.com/expo/eas-cli/issues.`
         );
         maybeError = maybeError ?? err;
         hasAnyPreviousStepFailed = true;


### PR DESCRIPTION
# Why

https://linear.app/expo/issue/ENG-13151/commented-out-lines-in-message-template-fail-the-send-slack-message
The function `step.shouldExecuteStep(hasAnyPreviousStepFailed)` was throwing an error which was not caught by the `try/catch` wrapping the actual step execution which resulted in a failed build without logs

# How

Wrapped the function determining if the step should be executed in a try/catch block. The caught error is logged, as is a message that the runner failed to evaluate if the step should be executed or not, so the user knows what's going on. The step is then skipped and the build is failed

# Test Plan

Automated tests pass

Manual testing

Before, when interpolated step didn't exist
<img width="1225" alt="Screenshot 2024-08-21 at 14 03 25" src="https://github.com/user-attachments/assets/f59a0ea1-b224-462f-80e9-da55728a49ca">

Now, when interpolated step don't exist
<img width="1225" alt="Screenshot 2024-08-21 at 14 03 55" src="https://github.com/user-attachments/assets/2f47ebb8-79cc-413f-b7ec-5e9620095909">

Now, when interpolated step exists
<img width="1225" alt="Screenshot 2024-08-21 at 14 03 41" src="https://github.com/user-attachments/assets/00c970e4-6989-4be8-8211-ebde93ee477f">

