### PR TITLE
[eas-build-job] Add field to fingerprint metadata indicating whether it is a debug fingerprint

### DIFF
--- a/packages/eas-build-job/src/__tests__/metadata.test.ts
+++ b/packages/eas-build-job/src/__tests__/metadata.test.ts
@@ -75,9 +75,10 @@ describe('MetadataSchema', () => {
     const metadata: Metadata = {
       ...validMetadata,
       fingerprintSource: {
-        type: 'GCS' as any,
+        type: FingerprintSourceType.GCS,
         bucketKey:
           'development/8a9c5554-cfbe-4b4c-814c-c476a1047db9/fd6f8af4-7293-46bd-bec7-3fe639f4fd3e',
+        isDebugFingerprint: true,
       },
     };
     const { value, error } = MetadataSchema.validate(metadata, {

--- a/packages/eas-build-job/src/metadata.ts
+++ b/packages/eas-build-job/src/metadata.ts
@@ -8,10 +8,11 @@ export enum FingerprintSourceType {
   'URL' = 'URL',
 }
 
-export type FingerprintSource =
+export type FingerprintSource = { isDebugFingerprint?: boolean } & (
   | { type: FingerprintSourceType.GCS; bucketKey: string }
   | { type: FingerprintSourceType.PATH; path: string }
-  | { type: FingerprintSourceType.URL; url: string };
+  | { type: FingerprintSourceType.URL; url: string }
+);
 
 export type Metadata = {
   /**
@@ -186,6 +187,7 @@ const FingerprintSourceSchema = Joi.object<FingerprintSource>({
   type: Joi.string()
     .valid(...Object.values(FingerprintSourceType))
     .required(),
+  isDebugFingerprint: Joi.boolean(),
 })
   .when(Joi.object({ type: FingerprintSourceType.GCS }).unknown(), {
     then: Joi.object({


### PR DESCRIPTION
# Why

When uploading fingerprint, we need to know whether it is a debug fingerprint output or a regular fingerprint output so that when we store it we can always overwrite regular with debug when associated with a runtime version (so we always store the most information).

When the user goes to compare, our comparison function will allow comparing debug to non-debug and inform the user when this is the case.

# How

Also store whether the fingerprint is a debug fingerprint.

# Test Plan

tsc, run test