### PR TITLE
efficient runtime version resolution

### DIFF
--- a/packages/build-tools/src/utils/resolveRuntimeVersionAsync.ts
+++ b/packages/build-tools/src/utils/resolveRuntimeVersionAsync.ts
@@ -1,3 +1,5 @@
+import { EOL } from 'os';
+
 import { ExpoConfig } from '@expo/config';
 import { Updates } from '@expo/config-plugins';
 import { bunyan } from '@expo/logger';
@@ -50,7 +52,12 @@ export async function resolveRuntimeVersionAsync({
         env,
       }
     );
-    const runtimeVersionResult = JSON.parse(resolvedRuntimeVersionJSONResult);
+
+    const splitRuntimeVersionResult = resolvedRuntimeVersionJSONResult.split(EOL);
+
+    const runtimeVersionResult = JSON.parse(
+      splitRuntimeVersionResult[splitRuntimeVersionResult.length - 1]
+    );
 
     logger.debug('runtimeversion:resolve output:');
     logger.debug(resolvedRuntimeVersionJSONResult);


### PR DESCRIPTION
# Why

My company had a custom `app.config.js` file which helped construct the environment variables based on the profile being used. As a debugging measure, `console.log` was introduced in this file. A stripped down version of this can be found here
```js
const hasProfilePrefix = !!process.env.EAS_BUILD_PROFILE;
if (hasProfilePrefix) {
  const profilePrefix = `${process.env.EAS_BUILD_PROFILE?.toUpperCase()}_`;

  console.log(`Using profile: ${profilePrefix}`); // Notice this line

  Object.entries(process.env)
    .filter(([key]) => key.startsWith(profilePrefix))
    .forEach(([key, value]) => {
      process.env[key.slice(profilePrefix.length)] = value;
    });
}
```

Because of the `std` stream being used in this package, calculating the runtime version in the `[CALCULATE_EXPO_UPDATES_RUNTIME_VERSION]` returned all logs plus what is expected. E.g.
```
Using profile: preview
{"runtimeVersion": "1.0.0"}
``` 
This results in

```
[CALCULATE_EXPO_UPDATES_RUNTIME_VERSION] 
SyntaxError: Unexpected token 'U', "Using prof"... is not valid JSON
    at JSON.parse (<anonymous>)
    at resolveRuntimeVersionAsync (/Users/Comp/.npm/_npx/5e31c5d24a898acf/node_modules/@expo/build-tools/dist/utils/resolveRuntimeVersionAsync.js:24:43)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async resolveRuntimeVersionForExpoUpdatesIfConfiguredAsync (/Users/Comp/.npm/_npx/5e31c5d24a898acf/node_modules/@expo/build-tools/dist/utils/expoUpdates.js:110:36)
    at async /Users/Comp/.npm/_npx/5e31c5d24a898acf/node_modules/@expo/build-tools/dist/builders/android.js:64:16
    at async BuildContext.runBuildPhase (/Users/Comp/.npm/_npx/5e31c5d24a898acf/node_modules/@expo/build-tools/dist/context.js:107:28)
    at async buildAsync (/Users/Comp/.npm/_npx/5e31c5d24a898acf/node_modules/@expo/build-tools/dist/builders/android.js:63:47)
    at async runBuilderWithHooksAsync (/Users/Comp/.npm/_npx/5e31c5d24a898acf/node_modules/@expo/build-tools/dist/builders/common.js:12:13)
    at async Object.androidBuilder (/Users/Comp/.npm/_npx/5e31c5d24a898acf/node_modules/@expo/build-tools/dist/builders/android.js:24:16)
    at async buildAndroidAsync (/Users/Comp/.npm/_npx/5e31c5d24a898acf/node_modules/eas-cli-local-build-plugin/dist/android.js:41:12)
```

# How

By collecting all std data, and splitting by the OS' new line character, we can pick the last string and safely parse this to give the correct runtime version

# Test Plan
- Setup a project with `expo-updates` installed
- Create a custom `app.config.js` and place `console.log` statements in there
- Confirm it accurately calculates the runtime version
