### PR TITLE
[build-tools] call upload app archive before saving cache

### DIFF
--- a/packages/build-tools/src/builders/android.ts
+++ b/packages/build-tools/src/builders/android.ts
@@ -122,15 +122,15 @@ async function buildAsync(ctx: BuildContext<Android.Job>): Promise<void> {
     await runHookIfPresent(ctx, Hook.PRE_UPLOAD_ARTIFACTS);
   });
 
-  await ctx.runBuildPhase(BuildPhase.SAVE_CACHE, async () => {
-    await ctx.cacheManager?.saveCache(ctx);
-  });
-
   await ctx.runBuildPhase(BuildPhase.UPLOAD_APPLICATION_ARCHIVE, async () => {
     await uploadApplicationArchive(ctx, {
       patternOrPath: ctx.job.applicationArchivePath ?? 'android/app/build/outputs/**/*.{apk,aab}',
       rootDir: ctx.getReactNativeProjectDirectory(),
       logger: ctx.logger,
     });
+  });
+
+  await ctx.runBuildPhase(BuildPhase.SAVE_CACHE, async () => {
+    await ctx.cacheManager?.saveCache(ctx);
   });
 }

--- a/packages/build-tools/src/builders/ios.ts
+++ b/packages/build-tools/src/builders/ios.ts
@@ -139,16 +139,16 @@ async function buildAsync(ctx: BuildContext<Ios.Job>): Promise<void> {
     await runHookIfPresent(ctx, Hook.PRE_UPLOAD_ARTIFACTS);
   });
 
-  await ctx.runBuildPhase(BuildPhase.SAVE_CACHE, async () => {
-    await ctx.cacheManager?.saveCache(ctx);
-  });
-
   await ctx.runBuildPhase(BuildPhase.UPLOAD_APPLICATION_ARCHIVE, async () => {
     await uploadApplicationArchive(ctx, {
       patternOrPath: resolveArtifactPath(ctx),
       rootDir: ctx.getReactNativeProjectDirectory(),
       logger: ctx.logger,
     });
+  });
+
+  await ctx.runBuildPhase(BuildPhase.SAVE_CACHE, async () => {
+    await ctx.cacheManager?.saveCache(ctx);
   });
 }
 


### PR DESCRIPTION
# Why

https://exponent-internal.slack.com/archives/C9PRD479V/p1725286240399969

Make sure that even if save cache phase fails we still upload artifacts

# How

Move save cache phase to be run after the upload app archive

# Test Plan

Tests/system tests