### PR TITLE
Update dependabot actions to current versions + have dependabot suggest future updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    allow:
+      - dependency-type: "all"

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -16,9 +16,9 @@ jobs:
     runs-on: ubuntu-latest
     name: '"@expo/steps" code coverage'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: 20
       - name: Setup ncc
@@ -26,4 +26,4 @@ jobs:
       - run: yarn install --frozen-lockfile --check-files
       - run: yarn build
       - run: yarn test:coverage
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v4

--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Update BSL change date
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           token: ${{ secrets.EXPO_BOT_PAT }}
       - name: Check last commit date

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,8 +10,8 @@ jobs:
     name: Publish to npm
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           registry-url: 'https://registry.npmjs.org/'
           scope: 'expo'

--- a/.github/workflows/test-ios.yml
+++ b/.github/workflows/test-ios.yml
@@ -10,9 +10,9 @@ jobs:
     runs-on: macos-latest
     name: Test with Node 20 on macOS
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: 20
       - name: Setup ncc

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,9 +13,9 @@ jobs:
         node: ['18', '20', '22']
     name: Test with Node ${{ matrix.node }} on Linux
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
       - name: Setup ncc


### PR DESCRIPTION
# Why
All of the GitHub actions used were out of date. This produced warnings during builds, and may eventually fail.

Example: https://github.com/expo/eas-build/actions/runs/10742071508
```
The following actions uses node12 which is deprecated and will be forced to run on node16: actions/checkout@v2, actions/setup-node@v1. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/Show less
```

```
The following actions use a deprecated Node.js version and will be forced to run on node20: actions/checkout@v2, actions/setup-node@v1. For more info: https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/
```

# How
I edited the YAML files.

# Test Plan
Run the GitHub actions and confirm them still work.