### PR TITLE
[eas-build-job] Add submission full config schemas to share between Turtle and EAS CLI

### DIFF
--- a/packages/eas-build-job/src/index.ts
+++ b/packages/eas-build-job/src/index.ts
@@ -21,3 +21,4 @@ export * from './artifacts';
 export * from './context';
 export * from './generic';
 export * from './step';
+export * from './submission-config';

--- a/packages/eas-build-job/src/submission-config.ts
+++ b/packages/eas-build-job/src/submission-config.ts
@@ -1,0 +1,77 @@
+import { z } from 'zod';
+
+/** Submission config as used by the submission worker. */
+export namespace SubmissionConfig {
+  export type Ios = z.infer<typeof Ios.SchemaZ>;
+  export type Android = z.infer<typeof Android.SchemaZ>;
+
+  export namespace Ios {
+    export const SchemaZ = z
+      .object({
+        /**
+         * App Store Connect unique App ID
+         */
+        ascAppIdentifier: z.string(),
+        isVerboseFastlaneEnabled: z.boolean().optional(),
+      })
+      .and(
+        z.union([
+          z.object({
+            // The `appleIdUsername` & `appleAppSpecificPassword` pair is mutually exclusive with `ascApiJsonKey`
+            appleIdUsername: z.string(),
+            appleAppSpecificPassword: z.string(),
+            ascApiJsonKey: z.never().optional(),
+          }),
+          z.object({
+            /**
+             * ASC API JSON token example:
+             * {
+             *  key_id: "D383SF739",
+             *  issuer_id: "6053b7fe-68a8-4acb-89be-165aa6465141",
+             *  key: "-----BEGIN PRIVATE KEY-----\nMIGTAgEAMBMGByqGSM\n-----END PRIVATE KEY--"
+             * }
+             */
+            ascApiJsonKey: z.string(),
+            appleIdUsername: z.never().optional(),
+            appleAppSpecificPassword: z.never().optional(),
+          }),
+        ])
+      );
+  }
+
+  export namespace Android {
+    export enum ReleaseStatus {
+      COMPLETED = 'completed',
+      DRAFT = 'draft',
+      HALTED = 'halted',
+      IN_PROGRESS = 'inProgress',
+    }
+
+    export enum ReleaseTrack {
+      PRODUCTION = 'production',
+      BETA = 'beta',
+      ALPHA = 'alpha',
+      INTERNAL = 'internal',
+    }
+
+    export const SchemaZ = z
+      .object({
+        track: z.nativeEnum(ReleaseTrack),
+        changesNotSentForReview: z.boolean().default(false),
+        googleServiceAccountKeyJson: z.string(),
+        isVerboseFastlaneEnabled: z.boolean().optional(),
+      })
+      .and(
+        z.union([
+          z.object({
+            releaseStatus: z.literal(ReleaseStatus.IN_PROGRESS),
+            rollout: z.number().gte(0).lte(1).default(1),
+          }),
+          z.object({
+            releaseStatus: z.nativeEnum(ReleaseStatus).optional(),
+            rollout: z.never().optional(),
+          }),
+        ])
+      );
+  }
+}


### PR DESCRIPTION
# Why

I want to be able to expose full submission config from `eas-cli` as expected by `submission-worker`. To keep them in sync I think we may want to use this dependency-shared-everywhere.

# How

Copied submission config schema from `turtle-common` to `eas-build-job`. Renamed a couple of things, flattened structure a bit.

# Test Plan

I've used this locally to ensure `eas-cli` responds with what `submission-worker` expects.