### PR TITLE
[eas-build] Expose generic job's `BuildWorkflow`

### DIFF
--- a/packages/build-tools/package.json
+++ b/packages/build-tools/package.json
@@ -31,6 +31,7 @@
     "@expo/package-manager": "1.5.2",
     "@expo/plist": "^0.1.3",
     "@expo/repack-app": "0.0.6",
+    "@expo/results": "^1.0.0",
     "@expo/steps": "1.0.136",
     "@expo/template-file": "1.0.117",
     "@expo/turtle-spawn": "1.0.117",

--- a/packages/build-tools/src/generic.ts
+++ b/packages/build-tools/src/generic.ts
@@ -2,7 +2,14 @@ import fs from 'fs';
 import path from 'path';
 
 import { BuildPhase, Generic } from '@expo/eas-build-job';
-import { BuildConfigParser, BuildStepGlobalContext, errors, StepsConfigParser } from '@expo/steps';
+import {
+  BuildConfigParser,
+  BuildStepGlobalContext,
+  BuildWorkflow,
+  errors,
+  StepsConfigParser,
+} from '@expo/steps';
+import { Result, asyncResult } from '@expo/results';
 
 import { BuildContext } from './context';
 import { prepareProjectSourcesAsync } from './common/projectSources';
@@ -10,7 +17,9 @@ import { getEasFunctions } from './steps/easFunctions';
 import { CustomBuildContext } from './customBuildContext';
 import { getEasFunctionGroups } from './steps/easFunctionGroups';
 
-export async function runGenericJobAsync(ctx: BuildContext<Generic.Job>): Promise<void> {
+export async function runGenericJobAsync(
+  ctx: BuildContext<Generic.Job>
+): Promise<{ runResult: Result<void>; buildWorkflow: BuildWorkflow }> {
   const customBuildCtx = new CustomBuildContext(ctx);
 
   await prepareProjectSourcesAsync(ctx, customBuildCtx.projectSourceDirectory);
@@ -48,7 +57,9 @@ export async function runGenericJobAsync(ctx: BuildContext<Generic.Job>): Promis
     }
   });
 
-  await workflow.executeAsync();
+  const runResult = await asyncResult(workflow.executeAsync());
+
+  return { runResult, buildWorkflow: workflow };
 }
 
 export async function addEasWorkflows(customBuildCtx: CustomBuildContext): Promise<void> {

--- a/packages/eas-build-job/src/generic.ts
+++ b/packages/eas-build-job/src/generic.ts
@@ -40,11 +40,13 @@ export namespace Generic {
       path: z.string(),
     }),
     steps: z.never().optional(),
+    outputs: z.never().optional(),
   });
 
   const StepsJobZ = CommonJobZ.extend({
     customBuildConfig: z.never().optional(),
     steps: z.array(StepZ).min(1),
+    outputs: z.record(z.string()).optional(),
   });
 
   export type Job = z.infer<typeof JobZ>;

--- a/packages/steps/src/BuildStep.ts
+++ b/packages/steps/src/BuildStep.ts
@@ -120,7 +120,7 @@ export class BuildStep extends BuildStepOutputAccessor {
   public readonly displayName: string;
   public readonly supportedRuntimePlatforms?: BuildRuntimePlatform[];
   public readonly inputs?: BuildStepInput[];
-  public readonly outputs?: BuildStepOutput[];
+  public readonly outputById: BuildStepOutputById;
   public readonly command?: string;
   public readonly fn?: BuildStepFunction;
   public readonly shell: string;
@@ -133,7 +133,6 @@ export class BuildStep extends BuildStepOutputAccessor {
 
   private readonly internalId: string;
   private readonly inputById: BuildStepInputById;
-  protected readonly outputById: BuildStepOutputById;
   protected executed = false;
 
   public static getNewId(userDefinedId?: string): string {
@@ -207,7 +206,6 @@ export class BuildStep extends BuildStepOutputAccessor {
     this.displayName = displayName;
     this.supportedRuntimePlatforms = maybeSupportedRuntimePlatforms;
     this.inputs = inputs;
-    this.outputs = outputs;
     this.inputById = makeBuildStepInputByIdMap(inputs);
     this.outputById = outputById;
     this.fn = fn;
@@ -426,7 +424,7 @@ export class BuildStep extends BuildStepOutputAccessor {
     }
 
     const nonSetRequiredOutputIds: string[] = [];
-    for (const output of this.outputs ?? []) {
+    for (const output of Object.values(this.outputById)) {
       try {
         const value = output.value;
         this.ctx.logger.debug(`Output parameter "${output.id}" is set to "${value}"`);

--- a/packages/steps/src/BuildStep.ts
+++ b/packages/steps/src/BuildStep.ts
@@ -275,6 +275,11 @@ export class BuildStep extends BuildStepOutputAccessor {
         await this.collectAndUpdateEnvsAsync(this.envsDir);
         this.ctx.logger.debug('Finished collecting output parameters');
       } catch (error) {
+        // If the step succeeded, we expect the outputs to be collected successfully.
+        if (this.status === BuildStepStatus.SUCCESS) {
+          throw error;
+        }
+
         this.ctx.logger.debug({ error }, 'Failed to collect output parameters');
       }
 

--- a/packages/steps/src/BuildStep.ts
+++ b/packages/steps/src/BuildStep.ts
@@ -278,7 +278,7 @@ export class BuildStep extends BuildStepOutputAccessor {
           throw error;
         }
 
-        this.ctx.logger.debug({ error }, 'Failed to collect output parameters');
+        this.ctx.logger.debug({ err: error }, 'Failed to collect output parameters');
       }
 
       await cleanUpStepTemporaryDirectoriesAsync(this.ctx.global, this.id);

--- a/packages/steps/src/BuildStep.ts
+++ b/packages/steps/src/BuildStep.ts
@@ -410,6 +410,16 @@ export class BuildStep extends BuildStepOutputAccessor {
     for (const outputId of files) {
       if (!(outputId in this.outputById)) {
         nonDefinedOutputIds.push(outputId);
+        const newOutput = new BuildStepOutput(this.ctx.global, {
+          id: outputId,
+          stepDisplayName: this.displayName,
+          required: false,
+        });
+        const file = path.join(outputsDir, outputId);
+        const rawContents = await fs.readFile(file, 'utf-8');
+        const value = rawContents.trim();
+        newOutput.set(value);
+        this.outputById[outputId] = newOutput;
       } else {
         const file = path.join(outputsDir, outputId);
         const rawContents = await fs.readFile(file, 'utf-8');

--- a/packages/steps/src/BuildTemporaryFiles.ts
+++ b/packages/steps/src/BuildTemporaryFiles.ts
@@ -17,24 +17,6 @@ export async function saveScriptToTemporaryFileAsync(
   return temporaryScriptPath;
 }
 
-export async function createTemporaryOutputsDirectoryAsync(
-  ctx: BuildStepGlobalContext,
-  stepId: string
-): Promise<string> {
-  const directory = getTemporaryOutputsDirPath(ctx, stepId);
-  await fs.mkdir(directory, { recursive: true });
-  return directory;
-}
-
-export async function createTemporaryEnvsDirectoryAsync(
-  ctx: BuildStepGlobalContext,
-  stepId: string
-): Promise<string> {
-  const directory = getTemporaryEnvsDirPath(ctx, stepId);
-  await fs.mkdir(directory, { recursive: true });
-  return directory;
-}
-
 export async function cleanUpStepTemporaryDirectoriesAsync(
   ctx: BuildStepGlobalContext,
   stepId: string
@@ -55,10 +37,10 @@ function getTemporaryScriptsDirPath(ctx: BuildStepGlobalContext, stepId: string)
   return path.join(getTemporaryStepDirPath(ctx, stepId), 'scripts');
 }
 
-function getTemporaryOutputsDirPath(ctx: BuildStepGlobalContext, stepId: string): string {
+export function getTemporaryOutputsDirPath(ctx: BuildStepGlobalContext, stepId: string): string {
   return path.join(getTemporaryStepDirPath(ctx, stepId), 'outputs');
 }
 
-function getTemporaryEnvsDirPath(ctx: BuildStepGlobalContext, stepId: string): string {
+export function getTemporaryEnvsDirPath(ctx: BuildStepGlobalContext, stepId: string): string {
   return path.join(getTemporaryStepDirPath(ctx, stepId), 'envs');
 }

--- a/packages/steps/src/__tests__/AbstractConfigParser-test.ts
+++ b/packages/steps/src/__tests__/AbstractConfigParser-test.ts
@@ -78,8 +78,8 @@ function assertStepsAreMatching(step1: BuildStep, step2: BuildStep): void {
     expect(step1.displayName).toMatch(UUID_REGEX);
     expect(step2.displayName).toMatch(UUID_REGEX);
   }
-  expect(step1.inputs).toEqual(step2.inputs);
-  expect(step1.outputs).toEqual(step2.outputs);
+  expect(step1.inputs).toStrictEqual(step2.inputs);
+  expect(step1.outputById).toStrictEqual(step2.outputById);
   expect(step1.command?.trim()).toEqual(step2.command?.trim());
   expect(step1.fn).toEqual(step2.fn);
 }

--- a/packages/steps/src/__tests__/BuildConfigParser-test.ts
+++ b/packages/steps/src/__tests__/BuildConfigParser-test.ts
@@ -268,11 +268,11 @@ describe(BuildConfigParser, () => {
       expect(step1.command).toMatchSnapshot();
       expect(step1.ctx.workingDirectory).toBe(ctx.defaultWorkingDirectory);
       expect(step1.shell).toBe(getDefaultShell());
-      expect(step1.outputs).toBeDefined();
-      expect(step1.outputs?.[0].id).toBe('first_name');
-      expect(step1.outputs?.[0].required).toBe(true);
-      expect(step1.outputs?.[1].id).toBe('last_name');
-      expect(step1.outputs?.[1].required).toBe(true);
+      const { first_name, last_name } = step1.outputById;
+      expect(first_name.id).toBe('first_name');
+      expect(first_name.required).toBe(true);
+      expect(last_name.id).toBe('last_name');
+      expect(last_name.required).toBe(true);
 
       // - run:
       //     outputs:
@@ -292,15 +292,15 @@ describe(BuildConfigParser, () => {
       expect(step2.command).toMatchSnapshot();
       expect(step2.ctx.workingDirectory).toBe(ctx.defaultWorkingDirectory);
       expect(step2.shell).toBe(getDefaultShell());
-      expect(step2.outputs).toBeDefined();
-      expect(step2.outputs?.[0].id).toBe('first_name');
-      expect(step2.outputs?.[0].required).toBe(true);
-      expect(step2.outputs?.[1].id).toBe('middle_name');
-      expect(step2.outputs?.[1].required).toBe(false);
-      expect(step2.outputs?.[2].id).toBe('last_name');
-      expect(step2.outputs?.[2].required).toBe(true);
-      expect(step2.outputs?.[3].id).toBe('nickname');
-      expect(step2.outputs?.[3].required).toBe(true);
+      const step2Outputs = step2.outputById;
+      expect(step2Outputs.first_name.id).toBe('first_name');
+      expect(step2Outputs.first_name.required).toBe(true);
+      expect(step2Outputs.middle_name.id).toBe('middle_name');
+      expect(step2Outputs.middle_name.required).toBe(false);
+      expect(step2Outputs.last_name.id).toBe('last_name');
+      expect(step2Outputs.last_name.required).toBe(true);
+      expect(step2Outputs.nickname.id).toBe('nickname');
+      expect(step2Outputs.nickname.required).toBe(true);
     });
 
     it('parses functions and function calls', async () => {
@@ -390,8 +390,9 @@ describe(BuildConfigParser, () => {
       expect(step4.command).toBe('set-output value 6');
       expect(step4.ctx.workingDirectory).toBe(ctx.defaultWorkingDirectory);
       expect(step4.shell).toBe(getDefaultShell());
-      expect(step4.outputs?.[0].id).toBe('value');
-      expect(step4.outputs?.[0].required).toBe(true);
+      const { value } = step4.outputById;
+      expect(value.id).toBe('value');
+      expect(value.required).toBe(true);
       expect(step4.stepEnvOverrides).toMatchObject({});
 
       // - print:

--- a/packages/steps/src/__tests__/BuildFunction-test.ts
+++ b/packages/steps/src/__tests__/BuildFunction-test.ts
@@ -201,8 +201,8 @@ describe(BuildFunction, () => {
       expect(step.inputs?.[0].id).toBe('input1');
       expect(step.inputs?.[1].id).toBe('input2');
       expect(step.inputs?.[2].id).toBe('input3');
-      expect(step.outputs?.[0].id).toBe('output1');
-      expect(step.outputs?.[1].id).toBe('output2');
+      expect(step.outputById.output1).toBeDefined();
+      expect(step.outputById.output2).toBeDefined();
     });
     it('passes values to build inputs', () => {
       const ctx = createGlobalContextMock();

--- a/packages/steps/src/__tests__/BuildStep-test.ts
+++ b/packages/steps/src/__tests__/BuildStep-test.ts
@@ -97,6 +97,7 @@ describe(BuildStep, () => {
     it('calls ctx.registerStep with the new object', () => {
       const mockCtx = mock<BuildStepGlobalContext>();
       when(mockCtx.baseLogger).thenReturn(createMockLogger());
+      when(mockCtx.stepsInternalBuildDirectory).thenReturn('temp-dir');
       const ctx = instance(mockCtx);
 
       const id = 'test1';

--- a/packages/steps/src/__tests__/BuildStep-test.ts
+++ b/packages/steps/src/__tests__/BuildStep-test.ts
@@ -398,7 +398,7 @@ describe(BuildStep, () => {
           command,
         });
         await step.executeAsync();
-        const abc = nullthrows(step.outputs).find((output) => output.id === 'abc');
+        const abc = nullthrows(step.outputById.abc);
         expect(abc?.value).toBe('123');
       });
 
@@ -454,7 +454,7 @@ describe(BuildStep, () => {
           fn,
         });
         await step.executeAsync();
-        const abc = nullthrows(step.outputs).find((output) => output.id === 'abc');
+        const abc = nullthrows(step.outputById.abc);
         expect(abc?.value).toBe('123');
       });
 
@@ -476,7 +476,7 @@ describe(BuildStep, () => {
           command,
         });
         await step.executeAsync();
-        const abc = nullthrows(step.outputs).find((output) => output.id === 'abc');
+        const abc = nullthrows(step.outputById.abc);
         expect(abc?.value).toBe('d o m i n i k');
       });
 

--- a/packages/steps/src/__tests__/BuildTemporaryFiles-test.ts
+++ b/packages/steps/src/__tests__/BuildTemporaryFiles-test.ts
@@ -3,7 +3,7 @@ import os from 'os';
 
 import {
   cleanUpStepTemporaryDirectoriesAsync,
-  createTemporaryOutputsDirectoryAsync,
+  getTemporaryOutputsDirPath,
   saveScriptToTemporaryFileAsync,
 } from '../BuildTemporaryFiles.js';
 
@@ -23,24 +23,12 @@ describe(saveScriptToTemporaryFileAsync, () => {
   });
 });
 
-describe(createTemporaryOutputsDirectoryAsync, () => {
-  it('creates a temporary directory for output values', async () => {
-    const ctx = createGlobalContextMock();
-    const outputsPath = await createTemporaryOutputsDirectoryAsync(ctx, 'foo');
-    await expect(fs.stat(outputsPath)).resolves.not.toThrow();
-  });
-  it('creates a temporary directory inside os.tmpdir()', async () => {
-    const ctx = createGlobalContextMock();
-    const outputsPath = await createTemporaryOutputsDirectoryAsync(ctx, 'foo');
-    expect(outputsPath.startsWith(os.tmpdir())).toBe(true);
-  });
-});
-
 describe(cleanUpStepTemporaryDirectoriesAsync, () => {
   it('removes the step temporary directories', async () => {
     const ctx = createGlobalContextMock();
     const scriptPath = await saveScriptToTemporaryFileAsync(ctx, 'foo', 'echo 123');
-    const outputsPath = await createTemporaryOutputsDirectoryAsync(ctx, 'foo');
+    const outputsPath = getTemporaryOutputsDirPath(ctx, 'foo');
+    await fs.mkdir(outputsPath, { recursive: true });
     await expect(fs.stat(scriptPath)).resolves.toBeTruthy();
     await expect(fs.stat(outputsPath)).resolves.toBeTruthy();
     await cleanUpStepTemporaryDirectoriesAsync(ctx, 'foo');

--- a/packages/steps/src/__tests__/StepsConfigParser-test.ts
+++ b/packages/steps/src/__tests__/StepsConfigParser-test.ts
@@ -280,7 +280,7 @@ describe(StepsConfigParser, () => {
       expect(step1.ctx.workingDirectory).toBe(ctx.defaultWorkingDirectory);
       expect(step1.stepEnvOverrides).toEqual({});
       expect(step1.inputs).toBeUndefined();
-      expect(step1.outputs).toBeUndefined();
+      expect(step1.outputById).toStrictEqual({});
       expect(step1.ifCondition).toBeUndefined();
 
       const step2 = result.buildSteps[1];
@@ -293,7 +293,7 @@ describe(StepsConfigParser, () => {
         a: 'b',
       });
       expect(step2.inputs).toBeUndefined();
-      expect(step2.outputs).toBeUndefined();
+      expect(step2.outputById).toStrictEqual({});
       expect(step2.ifCondition).toBeUndefined();
 
       const step3 = result.buildSteps[2];
@@ -307,10 +307,14 @@ describe(StepsConfigParser, () => {
         KEY1: 'value1',
       });
       expect(step3.inputs).toBeUndefined();
-      expect(step3.outputs).toBeDefined();
-      expect(step3.outputs).toHaveLength(3);
-      assert(step3.outputs);
-      const [output1, output2, output3] = step3.outputs;
+      expect(step3.outputById).toBeDefined();
+      expect(Object.keys(step3.outputById)).toHaveLength(3);
+      assert(step3.outputById);
+      const {
+        my_output: output1,
+        my_optional_output: output2,
+        my_optional_output_without_required: output3,
+      } = step3.outputById;
       expect(output1.id).toBe('my_output');
       expect(output1.required).toBe(true);
       expect(output2.id).toBe('my_optional_output');
@@ -364,7 +368,7 @@ describe(StepsConfigParser, () => {
       expect(input4.defaultValue).toBeUndefined();
       expect(input4.rawValue).toBe('${ step3.my_output }');
       expect(input4.required).toBe(true);
-      expect(step4.outputs).toBeUndefined();
+      expect(step4.outputById).toStrictEqual({});
       expect(step4.ifCondition).toBe('${ ctx.job.platform } == "android"');
     });
   });

--- a/packages/steps/src/index.ts
+++ b/packages/steps/src/index.ts
@@ -13,3 +13,4 @@ export { BuildFunctionGroup } from './BuildFunctionGroup.js';
 export { BuildStep } from './BuildStep.js';
 export * as errors from './errors.js';
 export * from './utils/shell/spawn.js';
+export * from './utils/jsepEval.js';

--- a/packages/steps/src/scripts/__tests__/runCustomFunction-test.ts
+++ b/packages/steps/src/scripts/__tests__/runCustomFunction-test.ts
@@ -10,8 +10,8 @@ import { BuildStepOutput } from '../../BuildStepOutput.js';
 import { createStepContextMock } from '../../__tests__/utils/context.js';
 import {
   cleanUpStepTemporaryDirectoriesAsync,
-  createTemporaryEnvsDirectoryAsync,
-  createTemporaryOutputsDirectoryAsync,
+  getTemporaryEnvsDirPath,
+  getTemporaryOutputsDirPath,
 } from '../../BuildTemporaryFiles.js';
 import { BIN_PATH } from '../../utils/shell/bin.js';
 import { createCustomFunctionCall } from '../../utils/customFunction.js';
@@ -67,8 +67,11 @@ describe('runCustomFunction', () => {
     inputs.obj.set({ foo: 'bar' });
 
     try {
-      const outputsDir = await createTemporaryOutputsDirectoryAsync(ctx.global, 'test');
-      const envsDir = await createTemporaryEnvsDirectoryAsync(ctx.global, 'test');
+      const outputsDir = getTemporaryOutputsDirPath(ctx.global, 'test');
+      const envsDir = getTemporaryEnvsDirPath(ctx.global, 'test');
+
+      await fs.mkdir(outputsDir, { recursive: true });
+      await fs.mkdir(envsDir, { recursive: true });
 
       const currentPath = process.env.PATH;
       const newPath = currentPath ? `${BIN_PATH}:${currentPath}` : BIN_PATH;

--- a/yarn.lock
+++ b/yarn.lock
@@ -818,6 +818,11 @@
     resolve-from "^5.0.0"
     temp-dir "^2.0.0"
 
+"@expo/results@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@expo/results/-/results-1.0.0.tgz#fd4b22f936ceafce23b04799f54b87fe2a9e18d1"
+  integrity sha512-qECzzXX5oJot3m2Gu9pfRDz50USdBieQVwYAzeAtQRUTD3PVeTK1tlRUoDcrK8PSruDLuVYdKkLebX4w/o55VA==
+
 "@expo/sdk-runtime-versions@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@expo/sdk-runtime-versions/-/sdk-runtime-versions-1.0.0.tgz#d7ebd21b19f1c6b0395e50d78da4416941c57f7c"
@@ -8728,7 +8733,16 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -8867,7 +8881,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -8887,6 +8901,13 @@ strip-ansi@^6.0.0:
   integrity sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==
   dependencies:
     ansi-regex "^5.0.0"
+
+strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.1.0"
@@ -9675,7 +9696,7 @@ wordwrap@^1.0.0:
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -9692,6 +9713,15 @@ wrap-ansi@^5.1.0:
     ansi-styles "^3.2.0"
     string-width "^3.0.0"
     strip-ansi "^5.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
 
 wrap-ansi@^8.1.0:
   version "8.1.0"


### PR DESCRIPTION
# Why

Exposing `BuildWorkflow` from `runGenericJobAsync` lets us fetch individual steps and their outputs after the job is complete.

# How

- wraps `buildWorkflow.executeAsync()` with `asyncResult` and returns the result from `runGenericJobAsync` alongside `buildWorkflow`,
- adds `outputs` to `Generic.Job` so the user has a way of telling us which steps outputs are to be considered jobs outputs,
- when a generic job finishes, Worker sends a `robotAccessToken`-authenticated request to [a new `www` endpoint](https://github.com/expo/universe/pull/16916/files).

Also changes the way we're handling `outputsDir` and `envsDir` — we want the outputs and environment variables to be collected always, not only if the step succeeded. And exposes `jsepEval` so we can use it in Worker.

Moreover, removes `outputs` from `BuildStep`. We had two: `outputs` and `outputById`, one being updated as we process the workflow and the other not.

# Test Plan

Adjusted tests. I've used this version to run a custom job with `set-output name test` and gotten 

<img width="430" alt="Zrzut ekranu 2024-09-27 o 18 44 42" src="https://github.com/user-attachments/assets/c0b53548-b913-454e-b077-77e071445aa0">
