### PR TITLE
[steps] Move `hasAnyPreviousStepFailed` to `BuildStepGlobalContext`

### DIFF
--- a/packages/steps/src/BuildStep.ts
+++ b/packages/steps/src/BuildStep.ts
@@ -292,9 +292,11 @@ export class BuildStep extends BuildStepOutputAccessor {
     );
   }
 
-  public shouldExecuteStep(hasAnyPreviousStepsFailed: boolean): boolean {
+  public shouldExecuteStep(): boolean {
+    const hasAnyPreviousStepFailed = this.ctx.global.hasAnyPreviousStepFailed;
+
     if (!this.ifCondition) {
-      return !hasAnyPreviousStepsFailed;
+      return !hasAnyPreviousStepFailed;
     }
 
     let ifCondition = this.ifCondition;
@@ -305,8 +307,8 @@ export class BuildStep extends BuildStepOutputAccessor {
 
     return Boolean(
       jsepEval(ifCondition, {
-        success: () => !hasAnyPreviousStepsFailed,
-        failure: () => hasAnyPreviousStepsFailed,
+        success: () => !hasAnyPreviousStepFailed,
+        failure: () => hasAnyPreviousStepFailed,
         always: () => true,
         never: () => false,
         env: this.getScriptEnv(),

--- a/packages/steps/src/BuildStepContext.ts
+++ b/packages/steps/src/BuildStepContext.ts
@@ -55,7 +55,7 @@ export class BuildStepGlobalContext {
   public readonly runtimePlatform: BuildRuntimePlatform;
   public readonly baseLogger: bunyan;
   private didCheckOut = false;
-
+  private _hasAnyPreviousStepFailed = false;
   private stepById: Record<string, BuildStepOutputAccessor> = {};
 
   constructor(
@@ -65,6 +65,7 @@ export class BuildStepGlobalContext {
     this.stepsInternalBuildDirectory = path.join(os.tmpdir(), 'eas-build', uuidv4());
     this.runtimePlatform = provider.runtimePlatform;
     this.baseLogger = provider.logger;
+    this._hasAnyPreviousStepFailed = false;
   }
 
   public get projectSourceDirectory(): string {
@@ -99,6 +100,10 @@ export class BuildStepGlobalContext {
     this.stepById[step.id] = step;
   }
 
+  public get steps(): BuildStepOutputAccessor[] {
+    return Object.values(this.stepById);
+  }
+
   public getStepOutputValue(path: string): string | undefined {
     const { stepId, outputId } = parseOutputPath(path);
     if (!(stepId in this.stepById)) {
@@ -131,6 +136,14 @@ export class BuildStepGlobalContext {
     logger.info(
       `Changing default working directory to ${this.defaultWorkingDirectory} (was ${this.projectTargetDirectory})`
     );
+  }
+
+  public get hasAnyPreviousStepFailed(): boolean {
+    return this._hasAnyPreviousStepFailed;
+  }
+
+  public markAsFailed(): void {
+    this._hasAnyPreviousStepFailed = true;
   }
 
   public wasCheckedOut(): boolean {

--- a/packages/steps/src/BuildWorkflow.ts
+++ b/packages/steps/src/BuildWorkflow.ts
@@ -7,7 +7,6 @@ export class BuildWorkflow {
   public readonly buildFunctions: BuildFunctionById;
 
   constructor(
-    // @ts-expect-error ctx is not used in this class but let's keep it here for consistency
     private readonly ctx: BuildStepGlobalContext,
     { buildSteps, buildFunctions }: { buildSteps: BuildStep[]; buildFunctions: BuildFunctionById }
   ) {
@@ -17,25 +16,24 @@ export class BuildWorkflow {
 
   public async executeAsync(): Promise<void> {
     let maybeError: Error | null = null;
-    let hasAnyPreviousStepFailed = false;
     for (const step of this.buildSteps) {
       let shouldExecuteStep = false;
       try {
-        shouldExecuteStep = step.shouldExecuteStep(hasAnyPreviousStepFailed);
+        shouldExecuteStep = step.shouldExecuteStep();
       } catch (err: any) {
         step.ctx.logger.error({ err });
         step.ctx.logger.error(
           `Runner failed to evaluate if it should execute step "${step.displayName}", using step's if condition "${step.ifCondition}". This can be caused by trying to access non-existing object property. If you think this is a bug report it here: https://github.com/expo/eas-cli/issues.`
         );
         maybeError = maybeError ?? err;
-        hasAnyPreviousStepFailed = true;
+        this.ctx.markAsFailed();
       }
       if (shouldExecuteStep) {
         try {
           await step.executeAsync();
         } catch (err: any) {
           maybeError = maybeError ?? err;
-          hasAnyPreviousStepFailed = true;
+          this.ctx.markAsFailed();
         }
       } else {
         step.skip();

--- a/packages/steps/src/__tests__/BuildStep-test.ts
+++ b/packages/steps/src/__tests__/BuildStep-test.ts
@@ -1017,14 +1017,14 @@ describe(BuildStep.deserialize, () => {
 describe(BuildStep.prototype.shouldExecuteStep, () => {
   it('returns true when if condition is always and previous steps failed', () => {
     const ctx = createGlobalContextMock();
+    ctx.markAsFailed();
     const step = new BuildStep(ctx, {
       id: 'test1',
       displayName: 'Test 1',
       command: 'echo 123',
       ifCondition: '${ always() }',
     });
-    const hasAnyPreviousStepsFailed = true;
-    expect(step.shouldExecuteStep(hasAnyPreviousStepsFailed)).toBe(true);
+    expect(step.shouldExecuteStep()).toBe(true);
   });
 
   it('returns true when if condition is always and previous steps have not failed', () => {
@@ -1035,20 +1035,19 @@ describe(BuildStep.prototype.shouldExecuteStep, () => {
       command: 'echo 123',
       ifCondition: '${ always() }',
     });
-    const hasAnyPreviousStepsFailed = false;
-    expect(step.shouldExecuteStep(hasAnyPreviousStepsFailed)).toBe(true);
+    expect(step.shouldExecuteStep()).toBe(true);
   });
 
   it('returns false when if condition is success and previous steps failed', () => {
     const ctx = createGlobalContextMock();
+    ctx.markAsFailed();
     const step = new BuildStep(ctx, {
       id: 'test1',
       displayName: 'Test 1',
       command: 'echo 123',
       ifCondition: '${ success() }',
     });
-    const hasAnyPreviousStepsFailed = true;
-    expect(step.shouldExecuteStep(hasAnyPreviousStepsFailed)).toBe(false);
+    expect(step.shouldExecuteStep()).toBe(false);
   });
 
   it('returns true when a dynamic expression matches', () => {
@@ -1065,7 +1064,7 @@ describe(BuildStep.prototype.shouldExecuteStep, () => {
       },
       ifCondition: '${ env.NODE_ENV === "production" && env.LOCAL_ENV === "true" }',
     });
-    expect(step.shouldExecuteStep(false)).toBe(true);
+    expect(step.shouldExecuteStep()).toBe(true);
   });
 
   it('returns true when a simplified dynamic expression matches', () => {
@@ -1079,7 +1078,7 @@ describe(BuildStep.prototype.shouldExecuteStep, () => {
       },
       ifCondition: "env.NODE_ENV === 'production'",
     });
-    expect(step.shouldExecuteStep(false)).toBe(true);
+    expect(step.shouldExecuteStep()).toBe(true);
   });
 
   it('returns true when an input matches', () => {
@@ -1102,7 +1101,7 @@ describe(BuildStep.prototype.shouldExecuteStep, () => {
       ],
       ifCondition: 'inputs.foo1 === "bar"',
     });
-    expect(step.shouldExecuteStep(false)).toBe(true);
+    expect(step.shouldExecuteStep()).toBe(true);
   });
 
   it('returns true when an eas value matches', () => {
@@ -1113,7 +1112,7 @@ describe(BuildStep.prototype.shouldExecuteStep, () => {
       command: 'echo 123',
       ifCondition: 'eas.runtimePlatform === "linux"',
     });
-    expect(step.shouldExecuteStep(false)).toBe(true);
+    expect(step.shouldExecuteStep()).toBe(true);
   });
 
   it('returns true when if condition is success and previous steps have not failed', () => {
@@ -1124,20 +1123,19 @@ describe(BuildStep.prototype.shouldExecuteStep, () => {
       command: 'echo 123',
       ifCondition: '${ success() }',
     });
-    const hasAnyPreviousStepsFailed = false;
-    expect(step.shouldExecuteStep(hasAnyPreviousStepsFailed)).toBe(true);
+    expect(step.shouldExecuteStep()).toBe(true);
   });
 
   it('returns true when if condition is failure and previous steps failed', () => {
     const ctx = createGlobalContextMock();
+    ctx.markAsFailed();
     const step = new BuildStep(ctx, {
       id: 'test1',
       displayName: 'Test 1',
       command: 'echo 123',
       ifCondition: '${ failure() }',
     });
-    const hasAnyPreviousStepsFailed = true;
-    expect(step.shouldExecuteStep(hasAnyPreviousStepsFailed)).toBe(true);
+    expect(step.shouldExecuteStep()).toBe(true);
   });
 
   it('returns false when if condition is failure and previous steps have not failed', () => {
@@ -1148,7 +1146,6 @@ describe(BuildStep.prototype.shouldExecuteStep, () => {
       command: 'echo 123',
       ifCondition: '${ failure() }',
     });
-    const hasAnyPreviousStepsFailed = false;
-    expect(step.shouldExecuteStep(hasAnyPreviousStepsFailed)).toBe(false);
+    expect(step.shouldExecuteStep()).toBe(false);
   });
 });

--- a/packages/steps/src/__tests__/BuildWorkflow-test.ts
+++ b/packages/steps/src/__tests__/BuildWorkflow-test.ts
@@ -1,4 +1,4 @@
-import { instance, mock, verify, when, anything } from 'ts-mockito';
+import { instance, mock, verify, when } from 'ts-mockito';
 
 import { BuildStep } from '../BuildStep.js';
 import { BuildWorkflow } from '../BuildWorkflow.js';
@@ -12,10 +12,10 @@ describe(BuildWorkflow, () => {
       const mockBuildStep2 = mock<BuildStep>();
       const mockBuildStep3 = mock<BuildStep>();
       const mockBuildStep4 = mock<BuildStep>();
-      when(mockBuildStep4.shouldExecuteStep(anything())).thenReturn(true);
-      when(mockBuildStep3.shouldExecuteStep(anything())).thenReturn(true);
-      when(mockBuildStep2.shouldExecuteStep(anything())).thenReturn(true);
-      when(mockBuildStep1.shouldExecuteStep(anything())).thenReturn(true);
+      when(mockBuildStep4.shouldExecuteStep()).thenReturn(true);
+      when(mockBuildStep3.shouldExecuteStep()).thenReturn(true);
+      when(mockBuildStep2.shouldExecuteStep()).thenReturn(true);
+      when(mockBuildStep1.shouldExecuteStep()).thenReturn(true);
 
       const buildSteps: BuildStep[] = [
         instance(mockBuildStep1),
@@ -37,9 +37,9 @@ describe(BuildWorkflow, () => {
       const mockBuildStep1 = mock<BuildStep>();
       const mockBuildStep2 = mock<BuildStep>();
       const mockBuildStep3 = mock<BuildStep>();
-      when(mockBuildStep3.shouldExecuteStep(anything())).thenReturn(true);
-      when(mockBuildStep2.shouldExecuteStep(anything())).thenReturn(true);
-      when(mockBuildStep1.shouldExecuteStep(anything())).thenReturn(true);
+      when(mockBuildStep3.shouldExecuteStep()).thenReturn(true);
+      when(mockBuildStep2.shouldExecuteStep()).thenReturn(true);
+      when(mockBuildStep1.shouldExecuteStep()).thenReturn(true);
 
       const buildSteps: BuildStep[] = [
         instance(mockBuildStep1),
@@ -61,10 +61,10 @@ describe(BuildWorkflow, () => {
       const mockBuildStep2 = mock<BuildStep>();
       const mockBuildStep3 = mock<BuildStep>();
       const mockBuildStep4 = mock<BuildStep>();
-      when(mockBuildStep4.shouldExecuteStep(anything())).thenReturn(true);
-      when(mockBuildStep3.shouldExecuteStep(anything())).thenReturn(false);
-      when(mockBuildStep2.shouldExecuteStep(anything())).thenReturn(false);
-      when(mockBuildStep1.shouldExecuteStep(anything())).thenReturn(true);
+      when(mockBuildStep4.shouldExecuteStep()).thenReturn(true);
+      when(mockBuildStep3.shouldExecuteStep()).thenReturn(false);
+      when(mockBuildStep2.shouldExecuteStep()).thenReturn(false);
+      when(mockBuildStep1.shouldExecuteStep()).thenReturn(true);
 
       const buildSteps: BuildStep[] = [
         instance(mockBuildStep1),
@@ -87,9 +87,9 @@ describe(BuildWorkflow, () => {
       const mockBuildStep1 = mock<BuildStep>();
       const mockBuildStep2 = mock<BuildStep>();
       const mockBuildStep3 = mock<BuildStep>();
-      when(mockBuildStep3.shouldExecuteStep(anything())).thenReturn(false);
-      when(mockBuildStep2.shouldExecuteStep(anything())).thenReturn(false);
-      when(mockBuildStep1.shouldExecuteStep(anything())).thenReturn(true);
+      when(mockBuildStep3.shouldExecuteStep()).thenReturn(false);
+      when(mockBuildStep2.shouldExecuteStep()).thenReturn(false);
+      when(mockBuildStep1.shouldExecuteStep()).thenReturn(true);
       when(mockBuildStep1.executeAsync()).thenReject(new Error('Step 1 failed'));
 
       const buildSteps: BuildStep[] = [
@@ -111,9 +111,9 @@ describe(BuildWorkflow, () => {
       const mockBuildStep1 = mock<BuildStep>();
       const mockBuildStep2 = mock<BuildStep>();
       const mockBuildStep3 = mock<BuildStep>();
-      when(mockBuildStep3.shouldExecuteStep(anything())).thenReturn(true);
-      when(mockBuildStep2.shouldExecuteStep(anything())).thenReturn(true);
-      when(mockBuildStep1.shouldExecuteStep(anything())).thenReturn(true);
+      when(mockBuildStep3.shouldExecuteStep()).thenReturn(true);
+      when(mockBuildStep2.shouldExecuteStep()).thenReturn(true);
+      when(mockBuildStep1.shouldExecuteStep()).thenReturn(true);
       when(mockBuildStep1.executeAsync()).thenReject(new Error('Step 1 failed'));
 
       const buildSteps: BuildStep[] = [
@@ -135,9 +135,9 @@ describe(BuildWorkflow, () => {
       const mockBuildStep1 = mock<BuildStep>();
       const mockBuildStep2 = mock<BuildStep>();
       const mockBuildStep3 = mock<BuildStep>();
-      when(mockBuildStep3.shouldExecuteStep(anything())).thenReturn(true);
-      when(mockBuildStep2.shouldExecuteStep(anything())).thenReturn(true);
-      when(mockBuildStep1.shouldExecuteStep(anything())).thenReturn(true);
+      when(mockBuildStep3.shouldExecuteStep()).thenReturn(true);
+      when(mockBuildStep2.shouldExecuteStep()).thenReturn(true);
+      when(mockBuildStep1.shouldExecuteStep()).thenReturn(true);
       when(mockBuildStep1.executeAsync()).thenReject(new Error('Step 1 failed'));
       when(mockBuildStep2.executeAsync()).thenReject(new Error('Step 2 failed'));
       when(mockBuildStep3.executeAsync()).thenReject(new Error('Step 3 failed'));


### PR DESCRIPTION
# Why

Moving `hasAnyPreviousStepFailed` from being passed to `shouldExecuteStep` to global context so we can expose `success()` and `failure()` in places other than just the `if` condition.

# How

Added a private property to `BuildStepGlobalContext` with public getter and `markAsFailed`.

# Test Plan

Adjusted tests.