### PR TITLE
[build-tools] Fail build upon runtime version mismatch

### DIFF
--- a/packages/build-tools/src/utils/expoUpdates.ts
+++ b/packages/build-tools/src/utils/expoUpdates.ts
@@ -104,12 +104,23 @@ export async function configureExpoUpdatesIfInstalledAsync(
     ctx.job.version?.runtimeVersion ?? resolvedRuntime.resolvedRuntimeVersion;
 
   if (ctx.metadata?.runtimeVersion && ctx.metadata.runtimeVersion !== appConfigRuntimeVersion) {
-    ctx.markBuildPhaseHasWarnings();
-    ctx.logger.warn('Runtime version mismatch');
-    ctx.logger.warn(`Runtime version on your local machine: ${ctx.metadata.runtimeVersion}`);
-    ctx.logger.warn(`Runtime version calculated on EAS: ${appConfigRuntimeVersion}`);
+    ctx.logger.warn(
+      `
+Runtime version mismatch:
+- Runtime version calculated on local machine: ${ctx.metadata.runtimeVersion}
+- Runtime version calculated on EAS: ${appConfigRuntimeVersion}
 
+This may be due to one or more factors:
+- Differing result of conditional app config (app.config.js) evaluation for runtime version resolution.
+- Differing fingerprint when using fingerprint runtime version policy. If applicable, see fingerprint diff below.
+
+This would cause any updates published on the local machine to not be compatible with this build.
+`
+    );
     await logDiffFingerprints({ resolvedRuntime, ctx });
+    throw new Error(
+      'Runtime version calculated on local machine not equal to runtime version calculated during build.'
+    );
   }
 
   if (isEASUpdateConfigured(ctx)) {


### PR DESCRIPTION
# Why

When there's a runtime version mismatch, the build takes the runtime version calculated at build time. But there's a decent chance the runtime version entity will be for the one calculated locally. This has the effect of making updates behave in an undefined manner since it'd have an invalid deployment, and any updates published locally wouldn't reach the build.

# How

The fix is to throw here instead of warn since it breaks our product.

# Test Plan

1. Create canary project
2. Convert app.json to app.config.js
3. Change the line: `"version": process.env.EAS_BUILD ? "1.0.0" : "2.0.0",`
4. `~/expo/run-with-local-eas-build.sh build --local`

See output:
```
...
[CONFIGURE_EXPO_UPDATES]
Runtime version mismatch:
- Runtime version calculated on local machine: 2.0.0
- Runtime version calculated on EAS: 1.0.0

This may be due to one or more factors:
- Differing result of conditional app config (app.config.js) evaluation for runtime version resolution.
- Differing fingerprint when using fingerprint runtime version policy. If applicable, see fingerprint diff below.

This would cause any updates published on the local machine to not be compatible with this build.

[CONFIGURE_EXPO_UPDATES]
Error: Runtime version calculated on local machine not equal to runtime version calculated during build.

...

Build failed
```
