### PR TITLE
[eas-build-job] Add `appId` and `initiatingUserId` to all job schemas

### DIFF
--- a/packages/eas-build-job/src/android.ts
+++ b/packages/eas-build-job/src/android.ts
@@ -112,6 +112,9 @@ export interface Job {
   loggerLevel?: LoggerLevel;
 
   workflowInterpolationContext?: never;
+
+  initiatingUserId?: string;
+  appId?: string;
 }
 
 const SecretsSchema = Joi.object({
@@ -177,4 +180,7 @@ export const JobSchema = Joi.object({
     submitProfile: Joi.string(),
   }),
   loggerLevel: Joi.string().valid(...Object.values(LoggerLevel)),
+
+  initiatingUserId: Joi.string(),
+  appId: Joi.string(),
 });

--- a/packages/eas-build-job/src/generic.ts
+++ b/packages/eas-build-job/src/generic.ts
@@ -39,6 +39,9 @@ export namespace Generic {
     triggeredBy: z.literal(BuildTrigger.GIT_BASED_INTEGRATION),
     loggerLevel: z.nativeEnum(LoggerLevel).optional(),
     workflowInterpolationContext: StaticWorkflowInterpolationContextZ.optional(),
+
+    initiatingUserId: z.string().optional(),
+    appId: z.string().optional(),
   });
 
   const PathJobZ = CommonJobZ.extend({

--- a/packages/eas-build-job/src/ios.ts
+++ b/packages/eas-build-job/src/ios.ts
@@ -126,6 +126,9 @@ export interface Job {
   loggerLevel?: LoggerLevel;
 
   workflowInterpolationContext?: never;
+
+  initiatingUserId?: string;
+  appId?: string;
 }
 
 const SecretsSchema = Joi.object({
@@ -211,4 +214,7 @@ export const JobSchema = Joi.object({
     submitProfile: Joi.string(),
   }),
   loggerLevel: Joi.string().valid(...Object.values(LoggerLevel)),
+
+  initiatingUserId: Joi.string(),
+  appId: Joi.string(),
 });


### PR DESCRIPTION
We want the new orchestrator to not need to know about initiating user ID or app ID.

https://github.com/expo/workflow-orchestration/blob/a035d7ea5fa0af1bbdaeca86e862ef99e6a54c4d/internal/watcher/watcher.go#L395-L400

After this is merged, going to upgrade and add them in `www` and `turtle-v2`.

Once this is done, going to make them required and remove the properties from `turtle-v2`.