### PR TITLE
[eas-build-job] Make `initiatingUserId` and `appId` required

### DIFF
--- a/packages/eas-build-job/src/android.ts
+++ b/packages/eas-build-job/src/android.ts
@@ -113,8 +113,8 @@ export interface Job {
 
   workflowInterpolationContext?: never;
 
-  initiatingUserId?: string;
-  appId?: string;
+  initiatingUserId: string;
+  appId: string;
 }
 
 const SecretsSchema = Joi.object({
@@ -181,6 +181,6 @@ export const JobSchema = Joi.object({
   }),
   loggerLevel: Joi.string().valid(...Object.values(LoggerLevel)),
 
-  initiatingUserId: Joi.string(),
-  appId: Joi.string(),
+  initiatingUserId: Joi.string().required(),
+  appId: Joi.string().required(),
 });

--- a/packages/eas-build-job/src/generic.ts
+++ b/packages/eas-build-job/src/generic.ts
@@ -40,8 +40,8 @@ export namespace Generic {
     loggerLevel: z.nativeEnum(LoggerLevel).optional(),
     workflowInterpolationContext: StaticWorkflowInterpolationContextZ.optional(),
 
-    initiatingUserId: z.string().optional(),
-    appId: z.string().optional(),
+    initiatingUserId: z.string(),
+    appId: z.string(),
   });
 
   const PathJobZ = CommonJobZ.extend({

--- a/packages/eas-build-job/src/ios.ts
+++ b/packages/eas-build-job/src/ios.ts
@@ -127,8 +127,8 @@ export interface Job {
 
   workflowInterpolationContext?: never;
 
-  initiatingUserId?: string;
-  appId?: string;
+  initiatingUserId: string;
+  appId: string;
 }
 
 const SecretsSchema = Joi.object({
@@ -215,6 +215,6 @@ export const JobSchema = Joi.object({
   }),
   loggerLevel: Joi.string().valid(...Object.values(LoggerLevel)),
 
-  initiatingUserId: Joi.string(),
-  appId: Joi.string(),
+  initiatingUserId: Joi.string().required(),
+  appId: Joi.string().required(),
 });


### PR DESCRIPTION
This is ok if we deploy in the right order:
1. `www` so it starts adding those values
2. `turtle-v2` so it can access those values.