### PR TITLE
[ENG-13945][eas-build-job][build-tools] add new EAGER_BUNDLE build phase for SDK 52+

### DIFF
--- a/packages/build-tools/src/builders/android.ts
+++ b/packages/build-tools/src/builders/android.ts
@@ -106,15 +106,20 @@ async function buildAsync(ctx: BuildContext<Android.Job>): Promise<void> {
 
   if (ctx.metadata?.sdkVersion && semver.satisfies(ctx.metadata?.sdkVersion, '>=52')) {
     await ctx.runBuildPhase(BuildPhase.EAGER_BUNDLE, async () => {
-      await eagerBundleAsync(ctx, {
-        ...(resolvedExpoUpdatesRuntimeVersion?.runtimeVersion
-          ? {
-              extraEnv: {
+      await eagerBundleAsync({
+        platform: ctx.job.platform,
+        workingDir: ctx.getReactNativeProjectDirectory(),
+        logger: ctx.logger,
+        env: {
+          ...ctx.env,
+          ...(resolvedExpoUpdatesRuntimeVersion?.runtimeVersion
+            ? {
                 EXPO_UPDATES_FINGERPRINT_OVERRIDE:
                   resolvedExpoUpdatesRuntimeVersion?.runtimeVersion,
-              },
-            }
-          : null),
+              }
+            : null),
+        },
+        packageManager: ctx.packageManager,
       });
     });
   }

--- a/packages/build-tools/src/builders/android.ts
+++ b/packages/build-tools/src/builders/android.ts
@@ -2,6 +2,7 @@ import path from 'path';
 
 import { Android, BuildMode, BuildPhase, Workflow } from '@expo/eas-build-job';
 import nullthrows from 'nullthrows';
+import semver from 'semver';
 
 import { Artifacts, BuildContext, SkipNativeBuildError } from '../context';
 import {
@@ -20,6 +21,7 @@ import { configureBuildGradle } from '../android/gradleConfig';
 import { setupAsync } from '../common/setup';
 import { prebuildAsync } from '../common/prebuild';
 import { prepareExecutableAsync } from '../utils/prepareBuildExecutable';
+import { eagerBundleAsync } from '../common/eagerBundle';
 
 import { runBuilderWithHooksAsync } from './common';
 import { runCustomBuildAsync } from './custom';
@@ -101,6 +103,22 @@ async function buildAsync(ctx: BuildContext<Android.Job>): Promise<void> {
   if (ctx.skipNativeBuild) {
     throw new SkipNativeBuildError('Skipping Gradle build');
   }
+
+  if (ctx.metadata?.sdkVersion && semver.satisfies(ctx.metadata?.sdkVersion, '>=52')) {
+    await ctx.runBuildPhase(BuildPhase.EAGER_BUNDLE, async () => {
+      await eagerBundleAsync(ctx, {
+        ...(resolvedExpoUpdatesRuntimeVersion?.runtimeVersion
+          ? {
+              extraEnv: {
+                EXPO_UPDATES_FINGERPRINT_OVERRIDE:
+                  resolvedExpoUpdatesRuntimeVersion?.runtimeVersion,
+              },
+            }
+          : null),
+      });
+    });
+  }
+
   await ctx.runBuildPhase(BuildPhase.RUN_GRADLEW, async () => {
     const gradleCommand = resolveGradleCommand(ctx.job);
     await runGradleCommand(ctx, {

--- a/packages/build-tools/src/builders/android.ts
+++ b/packages/build-tools/src/builders/android.ts
@@ -116,6 +116,7 @@ async function buildAsync(ctx: BuildContext<Android.Job>): Promise<void> {
             ? {
                 EXPO_UPDATES_FINGERPRINT_OVERRIDE:
                   resolvedExpoUpdatesRuntimeVersion?.runtimeVersion,
+                EXPO_UPDATES_WORKFLOW_OVERRIDE: ctx.job.type,
               }
             : null),
         },

--- a/packages/build-tools/src/builders/ios.ts
+++ b/packages/build-tools/src/builders/ios.ts
@@ -115,15 +115,20 @@ async function buildAsync(ctx: BuildContext<Ios.Job>): Promise<void> {
 
     if (ctx.metadata?.sdkVersion && semver.satisfies(ctx.metadata?.sdkVersion, '>=52')) {
       await ctx.runBuildPhase(BuildPhase.EAGER_BUNDLE, async () => {
-        await eagerBundleAsync(ctx, {
-          ...(resolvedExpoUpdatesRuntimeVersion?.runtimeVersion
-            ? {
-                extraEnv: {
+        await eagerBundleAsync({
+          platform: ctx.job.platform,
+          workingDir: ctx.getReactNativeProjectDirectory(),
+          logger: ctx.logger,
+          env: {
+            ...ctx.env,
+            ...(resolvedExpoUpdatesRuntimeVersion?.runtimeVersion
+              ? {
                   EXPO_UPDATES_FINGERPRINT_OVERRIDE:
                     resolvedExpoUpdatesRuntimeVersion?.runtimeVersion,
-                },
-              }
-            : null),
+                }
+              : null),
+          },
+          packageManager: ctx.packageManager,
         });
       });
     }

--- a/packages/build-tools/src/builders/ios.ts
+++ b/packages/build-tools/src/builders/ios.ts
@@ -125,6 +125,7 @@ async function buildAsync(ctx: BuildContext<Ios.Job>): Promise<void> {
               ? {
                   EXPO_UPDATES_FINGERPRINT_OVERRIDE:
                     resolvedExpoUpdatesRuntimeVersion?.runtimeVersion,
+                  EXPO_UPDATES_WORKFLOW_OVERRIDE: ctx.job.type,
                 }
               : null),
           },
@@ -146,6 +147,7 @@ async function buildAsync(ctx: BuildContext<Ios.Job>): Promise<void> {
               extraEnv: {
                 EXPO_UPDATES_FINGERPRINT_OVERRIDE:
                   resolvedExpoUpdatesRuntimeVersion?.runtimeVersion,
+                EXPO_UPDATES_WORKFLOW_OVERRIDE: ctx.job.type,
               },
             }
           : null),

--- a/packages/build-tools/src/common/eagerBundle.ts
+++ b/packages/build-tools/src/common/eagerBundle.ts
@@ -1,18 +1,29 @@
-import { BuildJob, Env } from '@expo/eas-build-job';
+import { Env, Platform } from '@expo/eas-build-job';
+import { bunyan } from '@expo/logger';
 
 import { runExpoCliCommand } from '../utils/project';
-import { BuildContext } from '../context';
+import { PackageManager } from '../utils/packageManager';
 
-export async function eagerBundleAsync<TJob extends BuildJob>(
-  ctx: BuildContext<TJob>,
-  options?: { extraEnv?: Env }
-): Promise<void> {
-  await runExpoCliCommand(ctx, ['export:embed', '--eager', '--platform', ctx.job.platform], {
-    cwd: ctx.getReactNativeProjectDirectory(),
-    logger: ctx.logger,
-    env: {
-      ...ctx.env,
-      ...options?.extraEnv,
+export async function eagerBundleAsync({
+  platform,
+  workingDir,
+  logger,
+  env,
+  packageManager,
+}: {
+  platform: Platform;
+  workingDir: string;
+  logger: bunyan;
+  env: Env;
+  packageManager: PackageManager;
+}): Promise<void> {
+  await runExpoCliCommand({
+    args: ['export:embed', '--eager', '--platform', platform],
+    options: {
+      cwd: workingDir,
+      logger,
+      env,
     },
+    packageManager,
   });
 }

--- a/packages/build-tools/src/common/eagerBundle.ts
+++ b/packages/build-tools/src/common/eagerBundle.ts
@@ -1,0 +1,18 @@
+import { BuildJob, Env } from '@expo/eas-build-job';
+
+import { runExpoCliCommand } from '../utils/project';
+import { BuildContext } from '../context';
+
+export async function eagerBundleAsync<TJob extends BuildJob>(
+  ctx: BuildContext<TJob>,
+  options?: { extraEnv?: Env }
+): Promise<void> {
+  await runExpoCliCommand(ctx, ['export:embed', '--eager', '--platform', ctx.job.platform], {
+    cwd: ctx.getReactNativeProjectDirectory(),
+    logger: ctx.logger,
+    env: {
+      ...ctx.env,
+      ...options?.extraEnv,
+    },
+  });
+}

--- a/packages/build-tools/src/common/prebuild.ts
+++ b/packages/build-tools/src/common/prebuild.ts
@@ -26,7 +26,11 @@ export async function prebuildAsync<TJob extends BuildJob>(
   };
 
   const prebuildCommandArgs = getPrebuildCommandArgs(ctx);
-  await runExpoCliCommand(ctx, prebuildCommandArgs, spawnOptions);
+  await runExpoCliCommand({
+    args: prebuildCommandArgs,
+    options: spawnOptions,
+    packageManager: ctx.packageManager,
+  });
   const installDependenciesSpawnPromise = (
     await installDependenciesAsync(ctx, {
       logger,

--- a/packages/build-tools/src/utils/__tests__/project.test.ts
+++ b/packages/build-tools/src/utils/__tests__/project.test.ts
@@ -24,7 +24,7 @@ describe(runExpoCliCommand, () => {
       when(mockCtx.appConfig).thenReturn(expoConfig);
       const ctx = instance(mockCtx);
 
-      void runExpoCliCommand(ctx, ['doctor'], {});
+      void runExpoCliCommand({ args: ['doctor'], options: {}, packageManager: ctx.packageManager });
       expect(spawn).toHaveBeenCalledWith('npx', ['expo', 'doctor'], expect.any(Object));
     });
 
@@ -38,7 +38,7 @@ describe(runExpoCliCommand, () => {
       when(mockCtx.appConfig).thenReturn(expoConfig);
       const ctx = instance(mockCtx);
 
-      void runExpoCliCommand(ctx, ['doctor'], {});
+      void runExpoCliCommand({ args: ['doctor'], options: {}, packageManager: ctx.packageManager });
       expect(spawn).toHaveBeenCalledWith('npx', ['expo', 'doctor'], expect.any(Object));
     });
 
@@ -52,7 +52,7 @@ describe(runExpoCliCommand, () => {
       when(mockCtx.appConfig).thenReturn(expoConfig);
       const ctx = instance(mockCtx);
 
-      void runExpoCliCommand(ctx, ['doctor'], {});
+      void runExpoCliCommand({ args: ['doctor'], options: {}, packageManager: ctx.packageManager });
       expect(spawn).toHaveBeenCalledWith('pnpm', ['expo', 'doctor'], expect.any(Object));
     });
 
@@ -66,7 +66,7 @@ describe(runExpoCliCommand, () => {
       when(mockCtx.appConfig).thenReturn(expoConfig);
       const ctx = instance(mockCtx);
 
-      void runExpoCliCommand(ctx, ['doctor'], {});
+      void runExpoCliCommand({ args: ['doctor'], options: {}, packageManager: ctx.packageManager });
       expect(spawn).toHaveBeenCalledWith('bun', ['expo', 'doctor'], expect.any(Object));
     });
   });

--- a/packages/build-tools/src/utils/project.ts
+++ b/packages/build-tools/src/utils/project.ts
@@ -1,10 +1,8 @@
 import path from 'path';
 
-import { Job } from '@expo/eas-build-job';
 import spawn, { SpawnOptions, SpawnPromise, SpawnResult } from '@expo/turtle-spawn';
 import fs from 'fs-extra';
 
-import { BuildContext } from '../context';
 import { findPackagerRootDir, PackageManager } from '../utils/packageManager';
 
 /**
@@ -16,22 +14,26 @@ export async function isUsingYarn2(projectDir: string): Promise<boolean> {
   return (await fs.pathExists(yarnrcPath)) || (await fs.pathExists(yarnrcRootPath));
 }
 
-export function runExpoCliCommand<TJob extends Job>(
-  ctx: BuildContext<TJob>,
-  args: string[],
-  options: SpawnOptions
-): SpawnPromise<SpawnResult> {
+export function runExpoCliCommand({
+  packageManager,
+  args,
+  options,
+}: {
+  packageManager: PackageManager;
+  args: string[];
+  options: SpawnOptions;
+}): SpawnPromise<SpawnResult> {
   const argsWithExpo = ['expo', ...args];
-  if (ctx.packageManager === PackageManager.NPM) {
+  if (packageManager === PackageManager.NPM) {
     return spawn('npx', argsWithExpo, options);
-  } else if (ctx.packageManager === PackageManager.YARN) {
+  } else if (packageManager === PackageManager.YARN) {
     return spawn('yarn', argsWithExpo, options);
-  } else if (ctx.packageManager === PackageManager.PNPM) {
+  } else if (packageManager === PackageManager.PNPM) {
     return spawn('pnpm', argsWithExpo, options);
-  } else if (ctx.packageManager === PackageManager.BUN) {
+  } else if (packageManager === PackageManager.BUN) {
     return spawn('bun', argsWithExpo, options);
   } else {
-    throw new Error(`Unsupported package manager: ${ctx.packageManager}`);
+    throw new Error(`Unsupported package manager: ${packageManager}`);
   }
 }
 

--- a/packages/eas-build-job/src/logs.ts
+++ b/packages/eas-build-job/src/logs.ts
@@ -17,6 +17,7 @@ export enum BuildPhase {
   PREPARE_CREDENTIALS = 'PREPARE_CREDENTIALS',
   CALCULATE_EXPO_UPDATES_RUNTIME_VERSION = 'CALCULATE_EXPO_UPDATES_RUNTIME_VERSION',
   CONFIGURE_EXPO_UPDATES = 'CONFIGURE_EXPO_UPDATES',
+  EAGER_BUNDLE = 'EAGER_BUNDLE',
   SAVE_CACHE = 'SAVE_CACHE',
   /**
    * @deprecated
@@ -78,6 +79,7 @@ export const buildPhaseDisplayName: Record<BuildPhase, string> = {
   [BuildPhase.PREPARE_CREDENTIALS]: 'Prepare credentials',
   [BuildPhase.CALCULATE_EXPO_UPDATES_RUNTIME_VERSION]: 'Calculate expo-updates runtime version',
   [BuildPhase.CONFIGURE_EXPO_UPDATES]: 'Configure expo-updates',
+  [BuildPhase.EAGER_BUNDLE]: 'Eager bundle',
   [BuildPhase.SAVE_CACHE]: 'Save cache',
   [BuildPhase.UPLOAD_ARTIFACTS]: 'Upload artifacts',
   [BuildPhase.UPLOAD_APPLICATION_ARCHIVE]: 'Upload application archive',
@@ -137,6 +139,7 @@ export const buildPhaseWebsiteId: Record<BuildPhase, string> = {
   [BuildPhase.PREPARE_CREDENTIALS]: 'prepare-credentials',
   [BuildPhase.CALCULATE_EXPO_UPDATES_RUNTIME_VERSION]: 'calculate-expo-updates-runtime-version',
   [BuildPhase.CONFIGURE_EXPO_UPDATES]: 'configure-expo-updates',
+  [BuildPhase.EAGER_BUNDLE]: 'eager-bundle',
   [BuildPhase.SAVE_CACHE]: 'save-cache',
   [BuildPhase.UPLOAD_ARTIFACTS]: 'upload-artifacts',
   [BuildPhase.UPLOAD_APPLICATION_ARCHIVE]: 'upload-application-archive',


### PR DESCRIPTION
# Why

https://linear.app/expo/issue/ENG-13945/add-exportembed-eager

# How

Add a new `EAGER_BUNDLE` build phase which is only run for SDK 52+. In the build phase invoke the `npx expo export:embed --eager --platform platform` command to bundle the JS code eagerly.

Run it for both managed and generic workflow (with native directories or without them).

# Test Plan

Test locally:

## SDK 51 - all builds run without a new build phase:

### Android:

![Screenshot 2024-10-28 at 13.59.29.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/9YRXgAETSTRMfjZ0IP35/a1b21aac-a1a4-40a0-8218-81c01bb76d98.png)

### iOS:

![Screenshot 2024-10-28 at 13.59.46.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/9YRXgAETSTRMfjZ0IP35/20f14192-2ae5-4a60-bb7e-4448a02384d5.png)

## SDK 52 - all builds run with the new build phase:

### Android:

![Screenshot 2024-10-28 at 14.00.08.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/9YRXgAETSTRMfjZ0IP35/f9c73d12-cfdb-451a-bb1f-1f52c52cc734.png)

### iOS:

![Screenshot 2024-10-28 at 14.11.45.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/9YRXgAETSTRMfjZ0IP35/77085420-ef1d-4ebd-b2d6-7ce812f83778.png)

### iOS generic:
![Screenshot 2024-10-28 at 14.23.52.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/9YRXgAETSTRMfjZ0IP35/29067465-c015-4a1e-a7b0-7e97bc334a11.png)

> [!NOTE]
> The way we display the new build phase on the website will change and use the display name of the new build phase once we update `@expo/eas-build-job` there.