### PR TITLE
[build-tools] Do not let `eas-cli` override `initiatingUserId` or `appId`

### DIFF
--- a/packages/build-tools/src/common/easBuildInternal.ts
+++ b/packages/build-tools/src/common/easBuildInternal.ts
@@ -155,7 +155,12 @@ function validateEasBuildInternalResult<TJob extends BuildJob>({
   if (error) {
     throw error;
   }
-  const newJob = sanitizeBuildJob(value.job) as TJob;
+  const newJob = sanitizeBuildJob({
+    ...value.job,
+    // We want to retain values that we have set on the job.
+    appId: oldJob.appId,
+    initiatingUserId: oldJob.initiatingUserId,
+  }) as TJob;
   assert(newJob.platform === oldJob.platform, 'eas-cli returned a job for a wrong platform');
   const newMetadata = sanitizeMetadata(value.metadata);
   return { newJob, newMetadata };


### PR DESCRIPTION
# Why

Right now `eas-cli` is not returning `initiatingUserId` or `appId` because we haven't finished https://github.com/expo/eas-cli/pull/2652.

Actually, this is good, because we don't need to rely on `eas-cli` on the topic of `initiatingUserId` or `appId`. Whatever `www` has set on the original job should stand even after build config resolution.

# How

Retained `appId` and `initiatingUserId` on the `sanitizeJob` call.

# Test Plan

Turtle should deploy with this change.