### PR TITLE
[eas-build-job] import LoggerLevel from @expo/logger/dist/level vs @expo/logger

### DIFF
--- a/packages/eas-build-job/src/__tests__/android.test.ts
+++ b/packages/eas-build-job/src/__tests__/android.test.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from 'crypto';
 
 import Joi from 'joi';
-import { LoggerLevel } from '@expo/logger';
+import LoggerLevel from '@expo/logger/dist/level';
 
 import * as Android from '../android';
 import { ArchiveSourceType, BuildMode, BuildTrigger, Platform, Workflow } from '../common';

--- a/packages/eas-build-job/src/__tests__/ios.test.ts
+++ b/packages/eas-build-job/src/__tests__/ios.test.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from 'crypto';
 
 import Joi from 'joi';
-import { LoggerLevel } from '@expo/logger';
+import LoggerLevel from '@expo/logger/dist/level';
 
 import { ArchiveSourceType, BuildMode, Platform, Workflow } from '../common';
 import * as Ios from '../ios';

--- a/packages/eas-build-job/src/android.ts
+++ b/packages/eas-build-job/src/android.ts
@@ -1,5 +1,5 @@
 import Joi from 'joi';
-import { LoggerLevel } from '@expo/logger';
+import LoggerLevel from '@expo/logger/dist/level';
 
 import {
   ArchiveSource,

--- a/packages/eas-build-job/src/generic.ts
+++ b/packages/eas-build-job/src/generic.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { LoggerLevel } from '@expo/logger';
+import LoggerLevel from '@expo/logger/dist/level';
 
 import {
   ArchiveSourceSchemaZ,

--- a/packages/eas-build-job/src/ios.ts
+++ b/packages/eas-build-job/src/ios.ts
@@ -1,5 +1,5 @@
 import Joi from 'joi';
-import { LoggerLevel } from '@expo/logger';
+import LoggerLevel from '@expo/logger/dist/level';
 
 import {
   ArchiveSource,


### PR DESCRIPTION
# Why

It seems to avoid us trouble with https://app.graphite.dev/github/pr/expo/universe/17278/ENG-13945-website-bump-expo-eas-build-job-to-display-new-EAGER_BUNDLE-build-phase-properly#file-server/website/next.config.mjs

# How

Import from `dist/level` vs `index`

# Test Plan

Run website with it locally
