### PR TITLE
[eas-build-job] make EAGER_BUNDLE step display name "Bundle JavaScript"

### DIFF
--- a/packages/build-tools/src/steps/functions/eagerBundle.ts
+++ b/packages/build-tools/src/steps/functions/eagerBundle.ts
@@ -8,7 +8,7 @@ export function eagerBundleBuildFunction(): BuildFunction {
   return new BuildFunction({
     namespace: 'eas',
     id: 'eager_bundle',
-    name: 'Eager bundle',
+    name: 'Bundle JavaScript',
     inputProviders: [
       BuildStepInput.createProvider({
         id: 'resolved_eas_update_runtime_version',

--- a/packages/eas-build-job/src/logs.ts
+++ b/packages/eas-build-job/src/logs.ts
@@ -79,7 +79,7 @@ export const buildPhaseDisplayName: Record<BuildPhase, string> = {
   [BuildPhase.PREPARE_CREDENTIALS]: 'Prepare credentials',
   [BuildPhase.CALCULATE_EXPO_UPDATES_RUNTIME_VERSION]: 'Calculate expo-updates runtime version',
   [BuildPhase.CONFIGURE_EXPO_UPDATES]: 'Configure expo-updates',
-  [BuildPhase.EAGER_BUNDLE]: 'Eager bundle',
+  [BuildPhase.EAGER_BUNDLE]: 'Bundle JavaScript',
   [BuildPhase.SAVE_CACHE]: 'Save cache',
   [BuildPhase.UPLOAD_ARTIFACTS]: 'Upload artifacts',
   [BuildPhase.UPLOAD_APPLICATION_ARCHIVE]: 'Upload application archive',


### PR DESCRIPTION
# Why

https://exponent-internal.slack.com/archives/C1QMZELP2/p1730225866032479?thread_ts=1730225422.471449&cid=C1QMZELP2

# How

Make the `EAGER_BUNDLE` step display name `Bundle JavaScript`
