### PR TITLE
[eas-build-job] add fingerprint hash to metadata

### DIFF
--- a/packages/eas-build-job/src/__tests__/metadata.test.ts
+++ b/packages/eas-build-job/src/__tests__/metadata.test.ts
@@ -5,6 +5,7 @@ const validMetadata: Metadata = {
   appVersion: '1.0.0',
   appBuildVersion: '123',
   runtimeVersion: '3.2.1',
+  fingerprintHash: '752e99d2b8fde1bf07ebb8af1b4a3c26a6703943',
   cliVersion: '1.2.3',
   buildProfile: 'release',
   credentialsSource: 'remote',

--- a/packages/eas-build-job/src/metadata.ts
+++ b/packages/eas-build-job/src/metadata.ts
@@ -225,6 +225,7 @@ export const MetadataSchema = Joi.object({
   credentialsSource: Joi.string().valid('local', 'remote'),
   sdkVersion: Joi.string(),
   runtimeVersion: Joi.string(),
+  fingerprintHash: Joi.string(),
   fingerprintSource: FingerprintSourceSchema,
   reactNativeVersion: Joi.string(),
   channel: Joi.string(),

--- a/packages/eas-build-job/src/metadata.ts
+++ b/packages/eas-build-job/src/metadata.ts
@@ -67,6 +67,11 @@ export type Metadata = {
   runtimeVersion?: string;
 
   /**
+   * Fingerprint hash of a project's native dependencies
+   */
+  fingerprintHash?: string;
+
+  /**
    * The location of the fingerprint file if one exists
    */
   fingerprintSource?: FingerprintSource;


### PR DESCRIPTION
# Why

In order to support [soft fingerprinting](https://www.notion.so/expo/Soft-fingerprinting-116e5b5735248071951cddcab32ae43d), we need to take a fingerprint on each build. This PR introduces the fingerprintHash field to build metadata to support this feature. 

# Test Plan

- [ ] new tests pass
