### PR TITLE
[updates] Change fingerprint diff to use versioned fingerprint CLI

### DIFF
--- a/packages/build-tools/src/utils/__tests__/diffFingerprintsAsync.test.ts
+++ b/packages/build-tools/src/utils/__tests__/diffFingerprintsAsync.test.ts
@@ -1,0 +1,80 @@
+import { vol } from 'memfs';
+import fs from 'fs-extra';
+
+import { diffFingerprintsAsync } from '../diffFingerprintsAsync';
+import { isModernExpoFingerprintCLISupportedAsync } from '../expoFingerprintCli';
+
+jest.mock('../expoFingerprintCli', () => ({
+  ...jest.requireActual('../expoFingerprintCli'),
+  expoFingerprintCommandAsync: jest.fn(),
+  isModernExpoFingerprintCLISupportedAsync: jest.fn(),
+}));
+
+jest.mock('fs');
+
+describe(diffFingerprintsAsync, () => {
+  beforeEach(async () => {
+    vol.reset();
+  });
+
+  it('falls back to local when CLI command fails', async () => {
+    await fs.mkdirp('test');
+    await fs.writeFile(
+      'test/fp1',
+      Buffer.from(
+        JSON.stringify({
+          sources: [
+            {
+              type: 'file',
+              filePath: './assets/images/adaptive-icon.png',
+              reasons: ['expoConfigExternalFile'],
+              hash: '19b53640a95efdc2ccc7fc20f3ea4d0d381bb5c4',
+            },
+          ],
+        })
+      )
+    );
+
+    await fs.writeFile(
+      'test/fp2',
+      Buffer.from(
+        JSON.stringify({
+          sources: [
+            {
+              type: 'file',
+              filePath: './assets/images/adaptive-icon.png',
+              reasons: ['expoConfigExternalFile'],
+              hash: '19b53640a95efdc2ccc7fc20f3ea4d0d381bb5c5',
+            },
+          ],
+        })
+      )
+    );
+
+    jest.mocked(isModernExpoFingerprintCLISupportedAsync).mockResolvedValue(false);
+
+    const diff = await diffFingerprintsAsync('test', 'test/fp1', 'test/fp2', {
+      env: {},
+      logger: { debug: jest.fn() } as any,
+    });
+    expect(diff).toEqual(
+      JSON.stringify([
+        {
+          op: 'changed',
+          beforeSource: {
+            type: 'file',
+            filePath: './assets/images/adaptive-icon.png',
+            reasons: ['expoConfigExternalFile'],
+            hash: '19b53640a95efdc2ccc7fc20f3ea4d0d381bb5c4',
+          },
+          afterSource: {
+            type: 'file',
+            filePath: './assets/images/adaptive-icon.png',
+            reasons: ['expoConfigExternalFile'],
+            hash: '19b53640a95efdc2ccc7fc20f3ea4d0d381bb5c5',
+          },
+        },
+      ])
+    );
+  });
+});

--- a/packages/build-tools/src/utils/diffFingerprintsAsync.ts
+++ b/packages/build-tools/src/utils/diffFingerprintsAsync.ts
@@ -1,0 +1,66 @@
+import { BuildStepEnv } from '@expo/steps';
+import fs from 'fs-extra';
+import { bunyan } from '@expo/logger';
+
+import {
+  ExpoFingerprintCLICommandFailedError,
+  ExpoFingerprintCLIInvalidCommandError,
+  ExpoFingerprintCLIModuleNotFoundError,
+  expoFingerprintCommandAsync,
+  isModernExpoFingerprintCLISupportedAsync,
+} from './expoFingerprintCli';
+import { diffFingerprints } from './fingerprint';
+
+export async function diffFingerprintsAsync(
+  projectDir: string,
+  fingerprint1File: string,
+  fingerprint2File: string,
+  { env, logger }: { env: BuildStepEnv; logger: bunyan }
+): Promise<string> {
+  if (!(await isModernExpoFingerprintCLISupportedAsync(projectDir))) {
+    logger.debug('Falling back to local fingerprint diff');
+    return await diffFingerprintsFallbackAsync(fingerprint1File, fingerprint2File);
+  }
+
+  try {
+    return await diffFingerprintsCommandAsync(projectDir, fingerprint1File, fingerprint2File, {
+      env,
+    });
+  } catch (e) {
+    if (
+      e instanceof ExpoFingerprintCLIModuleNotFoundError ||
+      e instanceof ExpoFingerprintCLICommandFailedError ||
+      e instanceof ExpoFingerprintCLIInvalidCommandError
+    ) {
+      logger.debug('Falling back to local fingerprint diff');
+      return await diffFingerprintsFallbackAsync(fingerprint1File, fingerprint2File);
+    }
+    throw e;
+  }
+}
+
+async function diffFingerprintsCommandAsync(
+  projectDir: string,
+  fingerprint1File: string,
+  fingerprint2File: string,
+  { env }: { env: BuildStepEnv }
+): Promise<string> {
+  return await expoFingerprintCommandAsync(
+    projectDir,
+    ['fingerprint:diff', fingerprint1File, fingerprint2File],
+    {
+      env,
+    }
+  );
+}
+
+async function diffFingerprintsFallbackAsync(
+  fingerprint1File: string,
+  fingerprint2File: string
+): Promise<string> {
+  const [fingeprint1, fingerprint2] = await Promise.all([
+    fs.readJSON(fingerprint1File),
+    fs.readJSON(fingerprint2File),
+  ]);
+  return JSON.stringify(diffFingerprints(fingeprint1, fingerprint2));
+}

--- a/packages/build-tools/src/utils/expoFingerprintCli.ts
+++ b/packages/build-tools/src/utils/expoFingerprintCli.ts
@@ -1,0 +1,84 @@
+import resolveFrom from 'resolve-from';
+import spawnAsync from '@expo/turtle-spawn';
+import { BuildStepEnv } from '@expo/steps';
+import fs from 'fs-extra';
+import semver from 'semver';
+
+export class ExpoFingerprintCLIModuleNotFoundError extends Error {}
+export class ExpoFingerprintCLIInvalidCommandError extends Error {}
+export class ExpoFingerprintCLICommandFailedError extends Error {}
+
+function resolveExpoFingerprintCLI(projectRoot: string): string {
+  const expoPackageRoot = resolveFrom.silent(projectRoot, 'expo/package.json');
+  try {
+    return (
+      resolveFrom.silent(expoPackageRoot ?? projectRoot, '@expo/fingerprint/bin/cli') ??
+      resolveFrom(expoPackageRoot ?? projectRoot, '@expo/fingerprint/bin/cli.js')
+    );
+  } catch (e: any) {
+    if (e.code === 'MODULE_NOT_FOUND') {
+      throw new ExpoFingerprintCLIModuleNotFoundError(
+        `The \`@expo/fingerprint\` package was not found.`
+      );
+    }
+    throw e;
+  }
+}
+
+export async function expoFingerprintCommandAsync(
+  projectDir: string,
+  args: string[],
+  { env }: { env: BuildStepEnv }
+): Promise<string> {
+  const expoFingerprintCli = resolveExpoFingerprintCLI(projectDir);
+  try {
+    const spawnResult = await spawnAsync(expoFingerprintCli, args, {
+      stdio: 'pipe',
+      cwd: projectDir,
+      env,
+    });
+    return spawnResult.stdout;
+  } catch (e: any) {
+    if (e.stderr && typeof e.stderr === 'string') {
+      if (e.stderr.includes('Invalid command')) {
+        throw new ExpoFingerprintCLIInvalidCommandError(
+          `The command specified by ${args} was not valid in the \`@expo/fingerprint\` CLI.`
+        );
+      } else {
+        throw new ExpoFingerprintCLICommandFailedError(e.stderr);
+      }
+    }
+    throw e;
+  }
+}
+
+async function getExpoFingerprintPackageVersionIfInstalledAsync(
+  projectDir: string
+): Promise<string | null> {
+  const expoPackageRoot = resolveFrom.silent(projectDir, 'expo/package.json');
+  const maybePackageJson = resolveFrom.silent(
+    expoPackageRoot ?? projectDir,
+    '@expo/fingerprint/package.json'
+  );
+  if (!maybePackageJson) {
+    return null;
+  }
+  const { version } = await fs.readJson(maybePackageJson);
+  return version ?? null;
+}
+
+export async function isModernExpoFingerprintCLISupportedAsync(
+  projectDir: string
+): Promise<boolean> {
+  const expoFingerprintPackageVersion =
+    await getExpoFingerprintPackageVersionIfInstalledAsync(projectDir);
+  if (!expoFingerprintPackageVersion) {
+    return false;
+  }
+
+  if (expoFingerprintPackageVersion.includes('canary')) {
+    return true;
+  }
+
+  return semver.gte(expoFingerprintPackageVersion, '0.11.2');
+}

--- a/packages/build-tools/src/utils/resolveRuntimeVersionAsync.ts
+++ b/packages/build-tools/src/utils/resolveRuntimeVersionAsync.ts
@@ -6,7 +6,6 @@ import { BuildStepEnv } from '@expo/steps';
 
 import { ExpoUpdatesCLIModuleNotFoundError, expoUpdatesCommandAsync } from './expoUpdatesCli';
 import { isModernExpoUpdatesCLIWithRuntimeVersionCommandSupported } from './expoUpdates';
-import { FingerprintSource } from './fingerprint';
 
 export async function resolveRuntimeVersionAsync({
   exp,
@@ -26,7 +25,7 @@ export async function resolveRuntimeVersionAsync({
   env: BuildStepEnv;
 }): Promise<{
   runtimeVersion: string | null;
-  fingerprintSources: FingerprintSource[] | null;
+  fingerprintSources: object[] | null;
 } | null> {
   if (!isModernExpoUpdatesCLIWithRuntimeVersionCommandSupported(expoUpdatesPackageVersion)) {
     logger.debug('Using expo-updates config plugin for runtime version resolution');


### PR DESCRIPTION
# Why

This adds a call into new @expo/fingerprint CLI (https://github.com/expo/expo/pull/32541) to do diffing when possible, falling back to the local diff when unavailable.

This was done to avoid needing to backport changes from the versioned package in the future to test changes in build.

# Test Plan

Test project with versioned fingerprint CLI:

1. Create beta project
2. `eas update:configure`
3. Change app config to app.config.js and add `"version": process.env.EAS_BUILD ? "1.0.0" : "2.0.0",`
3. Add console.log to CLI resolution to verify local CLI is resolved and used.
4. `~/expo/run-with-local-eas-build.sh build --local  --build-logger-level=debug`, see no log indicating that it fell back to local diff indicating that it is using the local copy in the project to do the diffing. See diff looks correct (just config due to process.env modification above).

Test project without (same steps as above but with a SDK 51 project). See it debug logs that it is falling back to local.