### PR TITLE
[updates] Update fingerprint diff algorithm

### DIFF
--- a/packages/build-tools/src/utils/fingerprint.ts
+++ b/packages/build-tools/src/utils/fingerprint.ts
@@ -1,6 +1,6 @@
 /**
  * DO NOT EDIT unless the same change is made in `@expo/fingerprint`
- * The diffFingerprints function is a copy/paste from https://github.com/expo/expo/pull/29709
+ * The diffFingerprints function is a copy/paste from that package.
  */
 
 export type FingerprintSource = HashSource & {
@@ -78,20 +78,41 @@ export interface DebugInfoContents {
 
 export type DebugInfo = DebugInfoFile | DebugInfoDir | DebugInfoContents;
 
-export interface FingerprintDiffItem {
-  /**
-   * The operation type of the diff item.
-   */
-  op: 'added' | 'removed' | 'changed';
-
-  /**
-   * The source of the diff item.
-   *   - When type is 'added', the source is the new source.
-   *   - When type is 'removed', the source is the old source.
-   *   - When type is 'changed', the source is the new source.
-   */
-  source: FingerprintSource;
-}
+export type FingerprintDiffItem =
+  | {
+      /**
+       * The operation type of the diff item.
+       */
+      op: 'added';
+      /**
+       * The added source.
+       */
+      addedSource: FingerprintSource;
+    }
+  | {
+      /**
+       * The operation type of the diff item.
+       */
+      op: 'removed';
+      /**
+       * The removed source.
+       */
+      removedSource: FingerprintSource;
+    }
+  | {
+      /**
+       * The operation type of the diff item.
+       */
+      op: 'changed';
+      /**
+       * The source before.
+       */
+      beforeSource: FingerprintSource;
+      /**
+       * The source after.
+       */
+      afterSource: FingerprintSource;
+    };
 
 const typeOrder = {
   file: 0,
@@ -136,25 +157,25 @@ export function diffFingerprints(
     const compareResult = compareSource(source1, source2);
     if (compareResult === 0) {
       if (source1.hash !== source2.hash) {
-        diff.push({ op: 'changed', source: source2 });
+        diff.push({ op: 'changed', beforeSource: source1, afterSource: source2 });
       }
       ++index1;
       ++index2;
     } else if (compareResult < 0) {
-      diff.push({ op: 'removed', source: source1 });
+      diff.push({ op: 'removed', removedSource: source1 });
       ++index1;
     } else {
-      diff.push({ op: 'added', source: source2 });
+      diff.push({ op: 'added', addedSource: source2 });
       ++index2;
     }
   }
 
   while (index1 < fingerprint1.sources.length) {
-    diff.push({ op: 'removed', source: fingerprint1.sources[index1] });
+    diff.push({ op: 'removed', removedSource: fingerprint1.sources[index1] });
     ++index1;
   }
   while (index2 < fingerprint2.sources.length) {
-    diff.push({ op: 'added', source: fingerprint2.sources[index2] });
+    diff.push({ op: 'added', addedSource: fingerprint2.sources[index2] });
     ++index2;
   }
 


### PR DESCRIPTION
# Why

This PR separates out just the backporting portion of https://app.graphite.dev/github/pr/expo/eas-build/460/updates-Change-fingeprint-diff-to-use-versioned-fingerprint-CLI

> Backport the changes from expo/expo#32486 into this local copy of the fingerprint diff mechanism.

This will help debug current fingerprint inconsistencies better before that PR lands (blocked on canary publishes)

# How

[![copypasta](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/WjlTemxb6oA4PgZFmj08/ad1d6316-1e6b-41d1-baa1-4e01688fae82/copypasta.png)](https://app.graphite.dev//settings/meme-library?org=expo) 

# Test Plan

`yarn tsc`
