### PR TITLE
[build-tools] use `--dev false` when doing `npx expo export:embed --eager`

### DIFF
--- a/packages/build-tools/src/common/eagerBundle.ts
+++ b/packages/build-tools/src/common/eagerBundle.ts
@@ -18,7 +18,7 @@ export async function eagerBundleAsync({
   packageManager: PackageManager;
 }): Promise<void> {
   await runExpoCliCommand({
-    args: ['export:embed', '--eager', '--platform', platform],
+    args: ['export:embed', '--eager', '--platform', platform, '--dev', 'false'],
     options: {
       cwd: workingDir,
       logger,


### PR DESCRIPTION
# Why

This should resolve the issue with `npx expo export:embed --eager` getting stuck

# How

https://exponent-internal.slack.com/archives/C5ERY0TAR/p1730760976830759?thread_ts=1730716531.023659&cid=C5ERY0TAR

Use `--dev false` when doing `npx expo export:embed --eager`

# Test Plan

Run command with `--dev false` on repro project and it wasn't stuck.
