### PR TITLE
[build-tools] use frozen lockfile for node modules install for SDK 52+ and RN 0.76+

### DIFF
--- a/packages/build-tools/src/common/installDependencies.ts
+++ b/packages/build-tools/src/common/installDependencies.ts
@@ -18,7 +18,7 @@ export async function installDependenciesAsync({
   packageManager: PackageManager;
   env: Record<string, string | undefined>;
   cwd: string;
-  logger?: SpawnOptions['logger'];
+  logger: Exclude<SpawnOptions['logger'], undefined>;
   infoCallbackFn?: SpawnOptions['infoCallbackFn'];
   useFrozenLockfile: boolean;
 }): Promise<{ spawnPromise: SpawnPromise<SpawnResult> }> {
@@ -50,7 +50,7 @@ export async function installDependenciesAsync({
   if (env['EAS_VERBOSE'] === '1') {
     args = [...args, '--verbose'];
   }
-  logger?.info(`Running "${packageManager} ${args.join(' ')}" in ${cwd} directory`);
+  logger.info(`Running "${packageManager} ${args.join(' ')}" in ${cwd} directory`);
   return {
     spawnPromise: spawn(packageManager, args, {
       cwd,

--- a/packages/build-tools/src/common/prebuild.ts
+++ b/packages/build-tools/src/common/prebuild.ts
@@ -32,10 +32,13 @@ export async function prebuildAsync<TJob extends BuildJob>(
     packageManager: ctx.packageManager,
   });
   const installDependenciesSpawnPromise = (
-    await installDependenciesAsync(ctx, {
+    await installDependenciesAsync({
+      packageManager: ctx.packageManager,
+      env: ctx.env,
       logger,
       cwd: resolvePackagerDir(ctx),
-      withoutFrozenLockfile: true, // prebuild should can modify package.json in some cases
+      // prebuild sometimes modifies package.json, so we don't want to use frozen lockfile
+      useFrozenLockfile: false,
     })
   ).spawnPromise;
   await installDependenciesSpawnPromise;

--- a/packages/build-tools/src/common/prebuild.ts
+++ b/packages/build-tools/src/common/prebuild.ts
@@ -35,6 +35,7 @@ export async function prebuildAsync<TJob extends BuildJob>(
     await installDependenciesAsync(ctx, {
       logger,
       cwd: resolvePackagerDir(ctx),
+      withoutFrozenLockfile: true, // prebuild should can modify package.json in some cases
     })
   ).spawnPromise;
   await installDependenciesSpawnPromise;

--- a/packages/build-tools/src/steps/functions/installNodeModules.ts
+++ b/packages/build-tools/src/steps/functions/installNodeModules.ts
@@ -9,7 +9,7 @@ import {
   PackageManager,
   resolvePackageManager,
 } from '../../utils/packageManager';
-import { isUsingYarn2 } from '../../utils/project';
+import { isUsingModernYarnVersion } from '../../utils/project';
 
 export function createInstallNodeModulesBuildFunction(): BuildFunction {
   return new BuildFunction({
@@ -44,7 +44,7 @@ export async function installNodeModules(
   if (packageManager === PackageManager.PNPM) {
     args = ['install', '--no-frozen-lockfile'];
   } else if (packageManager === PackageManager.YARN) {
-    const isYarn2 = await isUsingYarn2(stepCtx.workingDirectory);
+    const isYarn2 = await isUsingModernYarnVersion(stepCtx.workingDirectory);
     if (isYarn2) {
       args = ['install', '--no-immutable', '--inline-builds'];
     }

--- a/packages/build-tools/src/utils/packageManager.ts
+++ b/packages/build-tools/src/utils/packageManager.ts
@@ -59,8 +59,8 @@ export function shouldUseFrozenLockfile({
   const parsedPackageJson = PackageJsonZ.safeParse(packageJson);
   if (!parsedPackageJson.success) {
     // We don't know what the dependencies are,
-    // so we default to NOT using frozen lockfile.
-    return false;
+    // so we default to using frozen lockfile.
+    return true;
   }
 
   const dependencies = parsedPackageJson.data.dependencies;

--- a/packages/build-tools/src/utils/packageManager.ts
+++ b/packages/build-tools/src/utils/packageManager.ts
@@ -1,6 +1,7 @@
 import spawnAsync from '@expo/turtle-spawn';
 import * as PackageManagerUtils from '@expo/package-manager';
 import semver from 'semver';
+import { z } from 'zod';
 
 export enum PackageManager {
   YARN = 'yarn',
@@ -33,4 +34,51 @@ export function findPackagerRootDir(currentDir: string): string {
 export async function isAtLeastNpm7Async(): Promise<boolean> {
   const version = (await spawnAsync('npm', ['--version'], { stdio: 'pipe' })).stdout.trim();
   return semver.gte(version, '7.0.0');
+}
+
+const PackageJsonZ = z.object({
+  dependencies: z
+    .object({
+      expo: z.string().optional(),
+      'react-native': z.string().optional(),
+    })
+    .optional(),
+});
+
+export function shouldUseFrozenLockfile({
+  env,
+  packageJson,
+}: {
+  env: Record<string, string | undefined>;
+  packageJson: unknown;
+}): boolean {
+  if (env.EAS_NO_FROZEN_LOCKFILE) {
+    return false;
+  }
+
+  const parsedPackageJson = PackageJsonZ.safeParse(packageJson);
+  if (!parsedPackageJson.success) {
+    // We don't know what the dependencies are,
+    // so we default to NOT using frozen lockfile.
+    return false;
+  }
+
+  const dependencies = parsedPackageJson.data.dependencies;
+
+  const sdkVersion = semver.coerce(dependencies?.expo)?.version;
+  if (sdkVersion && semver.lt(sdkVersion, '52.0.0')) {
+    // Before SDK 52 we could not have used frozen lockfile.
+    return false;
+  }
+
+  const reactNativeVersion = semver.coerce(dependencies?.['react-native'])?.version;
+  if (reactNativeVersion && semver.lt(reactNativeVersion, '0.76')) {
+    // Before react-native 0.76 we could not have used frozen lockfile.
+    return false;
+  }
+
+  // We either don't know expo and react-native versions,
+  // so we can try to use frozen lockfile, or the versions are
+  // new enough that we do want to use it.
+  return true;
 }

--- a/packages/build-tools/src/utils/project.ts
+++ b/packages/build-tools/src/utils/project.ts
@@ -8,7 +8,7 @@ import { findPackagerRootDir, PackageManager } from '../utils/packageManager';
 /**
  * check if .yarnrc.yml exists in the project dir or in the workspace root dir
  */
-export async function isUsingYarn2(projectDir: string): Promise<boolean> {
+export async function isUsingModernYarnVersion(projectDir: string): Promise<boolean> {
   const yarnrcPath = path.join(projectDir, '.yarnrc.yml');
   const yarnrcRootPath = path.join(findPackagerRootDir(projectDir), '.yarnrc.yml');
   return (await fs.pathExists(yarnrcPath)) || (await fs.pathExists(yarnrcRootPath));


### PR DESCRIPTION
# Why

https://exponent-internal.slack.com/archives/C02123T524U/p1731420965266849?thread_ts=1731420501.834709&cid=C02123T524U
https://exponent-internal.slack.com/archives/C02123T524U/p1731421835879399

We want to use frozen lockfile when installing `node_modules` on our CI.

# How

Enable using frozen lockfile for SDK 52+ and RN 0.76+ in the `install node modules` phase.

Check for `EAS_NO_FROZEN_LOCKFILE` env var to skip using frozen lockfile if set.

Don't use frozen lockfile after prebuild as prebuild can sometimes modify `the package.json`.

# Test Plan

Test locally
