### PR TITLE
[build-tools] Do not override secrets with empty values

### DIFF
--- a/packages/build-tools/src/__tests__/context.test.ts
+++ b/packages/build-tools/src/__tests__/context.test.ts
@@ -1,0 +1,81 @@
+import { randomUUID } from 'crypto';
+
+import { BuildTrigger, Job, Metadata } from '@expo/eas-build-job';
+import { vol } from 'memfs';
+
+import { BuildContext } from '../context';
+
+import { createMockLogger } from './utils/logger';
+
+jest.mock('fs');
+jest.mock('fs-extra');
+
+describe('BuildContext', () => {
+  it('should merge secrets', async () => {
+    const robotAccessToken = randomUUID();
+    await vol.promises.mkdir('/workingdir/environment-secrets/', { recursive: true });
+
+    const ctx = new BuildContext(
+      {
+        triggeredBy: BuildTrigger.GIT_BASED_INTEGRATION,
+        secrets: {
+          robotAccessToken,
+          environmentSecrets: [
+            {
+              name: 'TEST_SECRET',
+              value: 'test-secret-value',
+            },
+          ],
+        },
+      } as Job,
+      {
+        env: {},
+        workingdir: '/workingdir',
+        logger: createMockLogger(),
+        logBuffer: { getLogs: () => [], getPhaseLogs: () => [] },
+        uploadArtifact: jest.fn(),
+      }
+    );
+
+    ctx.updateJobInformation({} as Job, {} as Metadata);
+
+    expect(ctx.job.secrets).toEqual({
+      robotAccessToken,
+      environmentSecrets: [
+        {
+          name: 'TEST_SECRET',
+          value: 'test-secret-value',
+        },
+      ],
+    });
+
+    const newRobotAccessToken = randomUUID();
+    ctx.updateJobInformation(
+      {
+        secrets: {
+          robotAccessToken: newRobotAccessToken,
+          environmentSecrets: [
+            {
+              name: 'TEST_SECRET',
+              value: 'new-test-secret-value',
+            },
+            {
+              name: 'TEST_SECRET_2',
+              value: 'test-secret-value-2',
+            },
+          ],
+        },
+      } as Job,
+      {} as Metadata
+    );
+
+    expect(ctx.job.secrets).toEqual({
+      robotAccessToken: newRobotAccessToken,
+      environmentSecrets: [
+        { name: 'TEST_SECRET', value: 'test-secret-value' },
+        { name: 'TEST_SECRET', value: 'new-test-secret-value' },
+        { name: 'TEST_SECRET_2', value: 'test-secret-value-2' },
+      ],
+    });
+  });
+});

--- a/packages/build-tools/src/context.ts
+++ b/packages/build-tools/src/context.ts
@@ -250,6 +250,16 @@ export class BuildContext<TJob extends Job = Job> {
     this._job = {
       ...job,
       triggeredBy: this._job.triggeredBy,
+      secrets: {
+        ...this.job.secrets,
+        ...job.secrets,
+        robotAccessToken: job.secrets?.robotAccessToken ?? this.job.secrets?.robotAccessToken,
+        environmentSecrets: [
+          // Latter secrets override former ones.
+          ...(this.job.secrets?.environmentSecrets ?? []),
+          ...(job.secrets?.environmentSecrets ?? []),
+        ],
+      },
       ...(this._job.platform ? { expoBuildUrl: this._job.expoBuildUrl } : null),
     };
     this._metadata = metadata;

--- a/packages/build-tools/src/customBuildContext.ts
+++ b/packages/build-tools/src/customBuildContext.ts
@@ -116,6 +116,16 @@ export class CustomBuildContext<TJob extends Job = Job> implements ExternalBuild
     this.job = {
       ...job,
       triggeredBy: this.job.triggeredBy,
+      secrets: {
+        ...this.job.secrets,
+        ...job.secrets,
+        robotAccessToken: job.secrets?.robotAccessToken ?? this.job.secrets?.robotAccessToken,
+        environmentSecrets: [
+          // Latter secrets override former ones.
+          ...(this.job.secrets?.environmentSecrets ?? []),
+          ...(job.secrets?.environmentSecrets ?? []),
+        ],
+      },
       ...(this.job.platform ? { expoBuildUrl: this.job.expoBuildUrl } : null),
     };
     this.metadata = metadata;


### PR DESCRIPTION
# Why

It seems when build configuration is resolved, `robotAccessToken` gets removed from the job.

# How

Made it so we merge secrets instead of overriding them.

# Test Plan

Added test.