### PR TITLE
[build-tools] retry installing system image in eas/start_android_emulator function

### DIFF
--- a/packages/build-tools/src/steps/functions/startAndroidEmulator.ts
+++ b/packages/build-tools/src/steps/functions/startAndroidEmulator.ts
@@ -39,10 +39,21 @@ export function createStartAndroidEmulatorBuildFunction(): BuildFunction {
       const deviceName = `${inputs.device_name.value}`;
       const systemImagePackage = `${inputs.system_image_package.value}`;
       logger.info('Making sure system image is installed');
-      await spawn('sdkmanager', [systemImagePackage], {
-        env,
-        logger,
-      });
+      await retryAsync(
+        async () => {
+          await spawn('sdkmanager', [systemImagePackage], {
+            env,
+            logger,
+          });
+        },
+        {
+          logger,
+          retryOptions: {
+            retries: 3, // Retry 3 times
+            retryIntervalMs: 1_000,
+          },
+        }
+      );
 
       logger.info('Creating emulator device');
       const avdManager = spawn(


### PR DESCRIPTION
# Why

https://exponent-internal.slack.com/archives/C02123T524U/p1731088697933349?thread_ts=1731078961.080939&cid=C02123T524U

It seems like installing the correct system image can fail intermittently 

# How

Retry installing it

# Test Plan

System tests