### PR TITLE
[build-tools] [ENG-13708] Upload outputs in public step

### DIFF
--- a/packages/build-tools/src/utils/__tests__/outputs.test.ts
+++ b/packages/build-tools/src/utils/__tests__/outputs.test.ts
@@ -11,7 +11,7 @@ import { createLogger } from '@expo/logger';
 import fetch, { Response } from 'node-fetch';
 
 import {
-  getDynamicValuesFromStep,
+  getStepOutputsAsObject,
   getJobOutputsFromSteps,
   uploadJobOutputsToWwwAsync,
 } from '../outputs';
@@ -40,10 +40,10 @@ const context = new BuildStepGlobalContext(
   false
 );
 
-describe(getDynamicValuesFromStep, () => {
+describe(getStepOutputsAsObject, () => {
   it('returns empty object for outputs of a step with no outputs', () => {
     expect(
-      getDynamicValuesFromStep(
+      getStepOutputsAsObject(
         new BuildStep(context, {
           id: 'test',
           displayName: 'test',
@@ -55,7 +55,7 @@ describe(getDynamicValuesFromStep, () => {
 
   it(`returns outputs from a step when they're defined`, () => {
     expect(
-      getDynamicValuesFromStep(
+      getStepOutputsAsObject(
         new BuildStep(context, {
           id: 'test',
           displayName: 'test',
@@ -89,7 +89,7 @@ describe(getDynamicValuesFromStep, () => {
     output1.set('abc');
     output2.set('true');
     expect(
-      getDynamicValuesFromStep(
+      getStepOutputsAsObject(
         new BuildStep(context, {
           id: 'test',
           displayName: 'test',

--- a/packages/build-tools/src/utils/__tests__/outputs.test.ts
+++ b/packages/build-tools/src/utils/__tests__/outputs.test.ts
@@ -8,7 +8,7 @@ import {
   BuildStepOutput,
 } from '@expo/steps';
 import { createLogger } from '@expo/logger';
-import fetch from 'node-fetch';
+import fetch, { Response } from 'node-fetch';
 
 import {
   getDynamicValuesFromStep,
@@ -213,6 +213,97 @@ describe(uploadJobOutputsToWwwAsync, () => {
           outputs: { fingerprintHash: 'mock-fingerprint-hash', nodeVersion: '' },
         }),
       })
+    );
+  });
+  it('outputs upload fails', async () => {
+    const workflowJobId = randomUUID();
+    const robotAccessToken = randomUUID();
+
+    const logger = createLogger({ name: 'test' }).child('test');
+    const buildContext = {
+      job: {
+        outputs: {
+          fingerprintHash: '${{ steps.setup.outputs.fingerprint_hash }}',
+          nodeVersion: '${{ steps.node_setup.outputs.node_version }}',
+        },
+        builderEnvironment: {
+          env: {
+            __WORKFLOW_JOB_ID: workflowJobId,
+          },
+        },
+        secrets: {
+          robotAccessToken,
+        },
+      } as unknown as Generic.Job,
+      logBuffer: {
+        getLogs: () => [],
+        getPhaseLogs: () => [],
+      },
+      _metadata: {} as any,
+      logger,
+      reportBuildPhaseStats: () => {},
+    } as unknown as BuildContext<Generic.Job>;
+
+    const fingerprintHashStepOutput = new BuildStepOutput(context, {
+      id: 'fingerprint_hash',
+      stepDisplayName: 'test',
+      required: true,
+    });
+    const nodeVersionStepOutput = new BuildStepOutput(context, {
+      id: 'node_version',
+      stepDisplayName: 'test2',
+      required: false,
+    });
+    const unusedStepOutput = new BuildStepOutput(context, {
+      id: 'test3',
+      stepDisplayName: 'test3',
+      required: false,
+    });
+    fingerprintHashStepOutput.set('mock-fingerprint-hash');
+    unusedStepOutput.set('true');
+
+    const loggerErrorSpy = jest.spyOn(logger, 'error');
+    const fetchMock = jest.mocked(fetch);
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 400,
+      statusText: 'Request failed',
+    } as unknown as Response);
+    await uploadJobOutputsToWwwAsync(buildContext, {
+      steps: [
+        new BuildStep(context, {
+          id: 'setup',
+          displayName: 'test',
+          command: 'test',
+          outputs: [fingerprintHashStepOutput, unusedStepOutput],
+        }),
+        new BuildStep(context, {
+          id: 'node_setup',
+          displayName: 'test2',
+          command: 'test2',
+          outputs: [nodeVersionStepOutput],
+        }),
+      ],
+      logger,
+      expoApiV2BaseUrl: 'http://exp.test/--/api/v2/',
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      `http://exp.test/--/api/v2/workflows/${workflowJobId}`, // URL
+      expect.objectContaining({
+        method: 'PATCH',
+        headers: {
+          Authorization: `Bearer ${robotAccessToken}`,
+          'Content-Type': 'application/json',
+        },
+        timeout: 20000,
+        body: JSON.stringify({
+          outputs: { fingerprintHash: 'mock-fingerprint-hash', nodeVersion: '' },
+        }),
+      })
+    );
+    expect(loggerErrorSpy).toHaveBeenCalledWith(
+      { err: new Error('[400] Request failed') },
+      'Failed to upload outputs'
     );
   });
 });

--- a/packages/build-tools/src/utils/__tests__/outputs.test.ts
+++ b/packages/build-tools/src/utils/__tests__/outputs.test.ts
@@ -106,7 +106,7 @@ describe(getJobOutputsFromSteps, () => {
     expect(
       getJobOutputsFromSteps({
         jobOutputDefinitions: {},
-        interpolationContext: {},
+        interpolationContext: { steps: {} },
       })
     ).toEqual({});
   });
@@ -117,7 +117,7 @@ describe(getJobOutputsFromSteps, () => {
         jobOutputDefinitions: {
           test: '${{ 1 + 1 }}',
         },
-        interpolationContext: {},
+        interpolationContext: { steps: {} },
       })
     ).toEqual({ test: '2' });
 

--- a/packages/build-tools/src/utils/__tests__/outputs.test.ts
+++ b/packages/build-tools/src/utils/__tests__/outputs.test.ts
@@ -1,0 +1,244 @@
+import { randomUUID } from 'crypto';
+
+import { Generic } from '@expo/eas-build-job';
+import {
+  BuildRuntimePlatform,
+  BuildStep,
+  BuildStepGlobalContext,
+  BuildStepOutput,
+} from '@expo/steps';
+import { createLogger } from '@expo/logger';
+import fetch from 'node-fetch';
+
+import {
+  getDynamicValuesFromStep,
+  getJobOutputsFromSteps,
+  uploadJobOutputsToWwwAsync,
+} from '../outputs';
+import { BuildContext } from '../../context';
+
+jest.mock('node-fetch');
+
+const context = new BuildStepGlobalContext(
+  {
+    buildLogsDirectory: 'test',
+    projectSourceDirectory: 'test',
+    projectTargetDirectory: 'test',
+    defaultWorkingDirectory: 'test',
+    runtimePlatform: BuildRuntimePlatform.DARWIN,
+    staticContext: () => ({
+      job: {} as any,
+      metadata: {} as any,
+      env: {} as any,
+      expoApiServerURL: 'https://api.expo.test',
+    }),
+    env: {},
+    logger: createLogger({ name: 'test' }),
+    updateEnv: () => {},
+  },
+  false
+);
+
+describe(getDynamicValuesFromStep, () => {
+  it('returns empty object for outputs of a step with no outputs', () => {
+    expect(
+      getDynamicValuesFromStep(
+        new BuildStep(context, {
+          id: 'test',
+          displayName: 'test',
+          command: 'test',
+        })
+      )
+    ).toEqual({ outputs: {} });
+  });
+
+  it(`returns outputs from a step when they're defined`, () => {
+    expect(
+      getDynamicValuesFromStep(
+        new BuildStep(context, {
+          id: 'test',
+          displayName: 'test',
+          command: 'test',
+          outputs: [
+            new BuildStepOutput(context, {
+              id: 'test',
+              stepDisplayName: 'test',
+              required: false,
+            }),
+          ],
+        })
+      )
+    ).toEqual({ outputs: { test: '' } });
+
+    const output1 = new BuildStepOutput(context, {
+      id: 'test',
+      stepDisplayName: 'test',
+      required: false,
+    });
+    const output2 = new BuildStepOutput(context, {
+      id: 'test2',
+      stepDisplayName: 'test2',
+      required: true,
+    });
+    const output3 = new BuildStepOutput(context, {
+      id: 'test3',
+      stepDisplayName: 'test3',
+      required: false,
+    });
+    output1.set('abc');
+    output2.set('true');
+    expect(
+      getDynamicValuesFromStep(
+        new BuildStep(context, {
+          id: 'test',
+          displayName: 'test',
+          command: 'test',
+          outputs: [output1, output2, output3],
+        })
+      )
+    ).toEqual({ outputs: { test: 'abc', test2: 'true', test3: '' } });
+  });
+});
+
+describe(getJobOutputsFromSteps, () => {
+  it('returns empty object for outputs of a step with no outputs', () => {
+    expect(
+      getJobOutputsFromSteps({
+        jobOutputDefinitions: {},
+        interpolationContext: {},
+      })
+    ).toEqual({});
+  });
+
+  it('interpolates outputs', () => {
+    expect(
+      getJobOutputsFromSteps({
+        jobOutputDefinitions: {
+          test: '${{ 1 + 1 }}',
+        },
+        interpolationContext: {},
+      })
+    ).toEqual({ test: '2' });
+
+    expect(
+      getJobOutputsFromSteps({
+        jobOutputDefinitions: {
+          fingerprint_hash: '${{ steps.setup.outputs.fingerprint_hash }}',
+        },
+        interpolationContext: {
+          steps: { setup: { outputs: { fingerprint_hash: 'abc' } } },
+        },
+      })
+    ).toEqual({ fingerprint_hash: 'abc' });
+  });
+});
+
+describe(uploadJobOutputsToWwwAsync, () => {
+  it('uploads outputs', async () => {
+    const workflowJobId = randomUUID();
+    const robotAccessToken = randomUUID();
+
+    const logger = createLogger({ name: 'test' }).child('test');
+    const buildContext = {
+      job: {
+        outputs: {
+          fingerprintHash: '${{ steps.setup.outputs.fingerprint_hash }}',
+          nodeVersion: '${{ steps.node_setup.outputs.node_version }}',
+        },
+        builderEnvironment: {
+          env: {
+            __WORKFLOW_JOB_ID: workflowJobId,
+          },
+        },
+        secrets: {
+          robotAccessToken,
+        },
+      } as unknown as Generic.Job,
+      logBuffer: {
+        getLogs: () => [],
+        getPhaseLogs: () => [],
+      },
+      _metadata: {} as any,
+      logger,
+      reportBuildPhaseStats: () => {},
+    } as unknown as BuildContext<Generic.Job>;
+    // const buildContext = createBuildContext({
+    //   job: {
+    //     outputs: {
+    //       fingerprintHash: '${{ steps.setup.outputs.fingerprint_hash }}',
+    //       nodeVersion: '${{ steps.node_setup.outputs.node_version }}',
+    //     },
+    //     builderEnvironment: {
+    //       env: {
+    //         __WORKFLOW_JOB_ID: workflowJobId,
+    //       },
+    //     },
+    //     secrets: {
+    //       robotAccessToken,
+    //     },
+    //   } as unknown as Generic.Job,
+    //   logBuffer: {
+    //     getLogs: () => [],
+    //     getPhaseLogs: () => [],
+    //   },
+    //   analytics: {} as any,
+    //   metadata: {} as any,
+    //   projectId: 'test',
+    //   buildId: 'test',
+    //   buildLogger: createLogger({ name: 'test' }),
+    //   reportBuildPhaseStatsFn: () => {},
+    // });
+
+    const fingerprintHashStepOutput = new BuildStepOutput(context, {
+      id: 'fingerprint_hash',
+      stepDisplayName: 'test',
+      required: true,
+    });
+    const nodeVersionStepOutput = new BuildStepOutput(context, {
+      id: 'node_version',
+      stepDisplayName: 'test2',
+      required: false,
+    });
+    const unusedStepOutput = new BuildStepOutput(context, {
+      id: 'test3',
+      stepDisplayName: 'test3',
+      required: false,
+    });
+    fingerprintHashStepOutput.set('mock-fingerprint-hash');
+    unusedStepOutput.set('true');
+
+    const fetchMock = jest.mocked(fetch);
+    await uploadJobOutputsToWwwAsync(buildContext, {
+      steps: [
+        new BuildStep(context, {
+          id: 'setup',
+          displayName: 'test',
+          command: 'test',
+          outputs: [fingerprintHashStepOutput, unusedStepOutput],
+        }),
+        new BuildStep(context, {
+          id: 'node_setup',
+          displayName: 'test2',
+          command: 'test2',
+          outputs: [nodeVersionStepOutput],
+        }),
+      ],
+      logger,
+      expoApiV2BaseUrl: 'http://exp.test/--/api/v2/',
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      `http://exp.test/--/api/v2/workflows/${workflowJobId}`, // URL
+      expect.objectContaining({
+        method: 'PATCH',
+        headers: {
+          Authorization: `Bearer ${robotAccessToken}`,
+          'Content-Type': 'application/json',
+        },
+        timeout: 20000,
+        body: JSON.stringify({
+          outputs: { fingerprintHash: 'mock-fingerprint-hash', nodeVersion: '' },
+        }),
+      })
+    );
+  });
+});

--- a/packages/build-tools/src/utils/__tests__/outputs.test.ts
+++ b/packages/build-tools/src/utils/__tests__/outputs.test.ts
@@ -162,32 +162,6 @@ describe(uploadJobOutputsToWwwAsync, () => {
       logger,
       reportBuildPhaseStats: () => {},
     } as unknown as BuildContext<Generic.Job>;
-    // const buildContext = createBuildContext({
-    //   job: {
-    //     outputs: {
-    //       fingerprintHash: '${{ steps.setup.outputs.fingerprint_hash }}',
-    //       nodeVersion: '${{ steps.node_setup.outputs.node_version }}',
-    //     },
-    //     builderEnvironment: {
-    //       env: {
-    //         __WORKFLOW_JOB_ID: workflowJobId,
-    //       },
-    //     },
-    //     secrets: {
-    //       robotAccessToken,
-    //     },
-    //   } as unknown as Generic.Job,
-    //   logBuffer: {
-    //     getLogs: () => [],
-    //     getPhaseLogs: () => [],
-    //   },
-    //   analytics: {} as any,
-    //   metadata: {} as any,
-    //   projectId: 'test',
-    //   buildId: 'test',
-    //   buildLogger: createLogger({ name: 'test' }),
-    //   reportBuildPhaseStatsFn: () => {},
-    // });
 
     const fingerprintHashStepOutput = new BuildStepOutput(context, {
       id: 'fingerprint_hash',

--- a/packages/build-tools/src/utils/outputs.ts
+++ b/packages/build-tools/src/utils/outputs.ts
@@ -56,7 +56,7 @@ export function getJobOutputsFromSteps({
 }: {
   jobOutputDefinitions: Record<string, string>;
   interpolationContext: {
-    steps: Record<string, { outputs: Record<string, string | undefined> } | string>;
+    steps: Record<string, { outputs: Record<string, string | undefined> }>;
   };
 }): Record<string, string | undefined> {
   const jobOutputs: Record<string, string | undefined> = {};

--- a/packages/build-tools/src/utils/outputs.ts
+++ b/packages/build-tools/src/utils/outputs.ts
@@ -51,6 +51,7 @@ export async function uploadJobOutputsToWwwAsync(
     }
   } catch (err) {
     logger.error({ err }, 'Failed to upload outputs');
+    throw err;
   }
 }
 

--- a/packages/build-tools/src/utils/outputs.ts
+++ b/packages/build-tools/src/utils/outputs.ts
@@ -25,9 +25,9 @@ export async function uploadJobOutputsToWwwAsync(
     const robotAccessToken = nullthrows(ctx.job.secrets?.robotAccessToken);
 
     const interpolationContext = {
-      steps: Object.fromEntries(steps.map((step) => [step.id, getDynamicValuesFromStep(step)])),
+      steps: Object.fromEntries(steps.map((step) => [step.id, getStepOutputsAsObject(step)])),
     };
-    logger.info({ dynamicValues: interpolationContext }, 'Using dynamic values');
+    logger.debug({ dynamicValues: interpolationContext }, 'Using dynamic values');
 
     const outputs = getJobOutputsFromSteps({
       jobOutputDefinitions: ctx.job.outputs,
@@ -55,7 +55,9 @@ export function getJobOutputsFromSteps({
   interpolationContext,
 }: {
   jobOutputDefinitions: Record<string, string>;
-  interpolationContext: Record<string, any>;
+  interpolationContext: {
+    steps: Record<string, { outputs: Record<string, string | undefined> } | string>;
+  };
 }): Record<string, string | undefined> {
   const jobOutputs: Record<string, string | undefined> = {};
   for (const [outputKey, outputDefinition] of Object.entries(jobOutputDefinitions)) {
@@ -70,7 +72,7 @@ export function getJobOutputsFromSteps({
 }
 
 /** This is what we'll use to generate an object representing a step. */
-export function getDynamicValuesFromStep(step: BuildStep): {
+export function getStepOutputsAsObject(step: BuildStep): {
   outputs: Record<string, string | undefined>;
 } {
   const outputs = Object.fromEntries(

--- a/packages/build-tools/src/utils/outputs.ts
+++ b/packages/build-tools/src/utils/outputs.ts
@@ -2,9 +2,10 @@ import { Generic } from '@expo/eas-build-job';
 import { BuildStep, jsepEval } from '@expo/steps';
 import { bunyan } from '@expo/logger';
 import nullthrows from 'nullthrows';
-import fetch from 'node-fetch';
 
 import { BuildContext } from '../context';
+
+import { turtleFetch } from './turtleFetch';
 
 export async function uploadJobOutputsToWwwAsync(
   ctx: BuildContext<Generic.Job>,
@@ -34,21 +35,14 @@ export async function uploadJobOutputsToWwwAsync(
     });
     logger.info('Uploading outputs');
 
-    const response = await fetch(
-      new URL(`workflows/${workflowJobId}`, expoApiV2BaseUrl).toString(),
-      {
-        method: 'PATCH',
-        body: JSON.stringify({ outputs }),
-        headers: {
-          Authorization: `Bearer ${robotAccessToken}`,
-          'Content-Type': 'application/json',
-        },
-        timeout: 20000,
-      }
-    );
-    if (!response.ok) {
-      throw new Error(`[${response.status}] ${response.statusText}`);
-    }
+    await turtleFetch(new URL(`workflows/${workflowJobId}`, expoApiV2BaseUrl).toString(), 'PATCH', {
+      json: { outputs },
+      headers: {
+        Authorization: `Bearer ${robotAccessToken}`,
+      },
+      timeout: 20000,
+      logger,
+    });
   } catch (err) {
     logger.error({ err }, 'Failed to upload outputs');
     throw err;

--- a/packages/build-tools/src/utils/outputs.ts
+++ b/packages/build-tools/src/utils/outputs.ts
@@ -34,15 +34,21 @@ export async function uploadJobOutputsToWwwAsync(
     });
     logger.info('Uploading outputs');
 
-    await fetch(new URL(`workflows/${workflowJobId}`, expoApiV2BaseUrl).toString(), {
-      method: 'PATCH',
-      body: JSON.stringify({ outputs }),
-      headers: {
-        Authorization: `Bearer ${robotAccessToken}`,
-        'Content-Type': 'application/json',
-      },
-      timeout: 20000,
-    });
+    const response = await fetch(
+      new URL(`workflows/${workflowJobId}`, expoApiV2BaseUrl).toString(),
+      {
+        method: 'PATCH',
+        body: JSON.stringify({ outputs }),
+        headers: {
+          Authorization: `Bearer ${robotAccessToken}`,
+          'Content-Type': 'application/json',
+        },
+        timeout: 20000,
+      }
+    );
+    if (!response.ok) {
+      throw new Error(`[${response.status}] ${response.statusText}`);
+    }
   } catch (err) {
     logger.error({ err }, 'Failed to upload outputs');
   }

--- a/packages/build-tools/src/utils/outputs.ts
+++ b/packages/build-tools/src/utils/outputs.ts
@@ -1,0 +1,80 @@
+import { Generic } from '@expo/eas-build-job';
+import { BuildStep, jsepEval } from '@expo/steps';
+import { bunyan } from '@expo/logger';
+import nullthrows from 'nullthrows';
+import fetch from 'node-fetch';
+
+import { BuildContext } from '../context';
+
+export async function uploadJobOutputsToWwwAsync(
+  ctx: BuildContext<Generic.Job>,
+  {
+    steps,
+    logger,
+    expoApiV2BaseUrl,
+  }: { steps: BuildStep[]; logger: bunyan; expoApiV2BaseUrl: string }
+): Promise<void> {
+  if (!ctx.job.outputs) {
+    logger.info('Job defines no outputs, skipping upload');
+    return;
+  }
+
+  try {
+    const workflowJobId = nullthrows(ctx.job.builderEnvironment?.env?.__WORKFLOW_JOB_ID);
+    const robotAccessToken = nullthrows(ctx.job.secrets?.robotAccessToken);
+
+    const interpolationContext = {
+      steps: Object.fromEntries(steps.map((step) => [step.id, getDynamicValuesFromStep(step)])),
+    };
+    logger.info({ dynamicValues: interpolationContext }, 'Using dynamic values');
+
+    const outputs = getJobOutputsFromSteps({
+      jobOutputDefinitions: ctx.job.outputs,
+      interpolationContext,
+    });
+    logger.info('Uploading outputs');
+
+    await fetch(new URL(`workflows/${workflowJobId}`, expoApiV2BaseUrl).toString(), {
+      method: 'PATCH',
+      body: JSON.stringify({ outputs }),
+      headers: {
+        Authorization: `Bearer ${robotAccessToken}`,
+        'Content-Type': 'application/json',
+      },
+      timeout: 20000,
+    });
+  } catch (err) {
+    logger.error({ err }, 'Failed to upload outputs');
+  }
+}
+
+/** Function we use to get outputs of the whole job from steps. */
+export function getJobOutputsFromSteps({
+  jobOutputDefinitions,
+  interpolationContext,
+}: {
+  jobOutputDefinitions: Record<string, string>;
+  interpolationContext: Record<string, any>;
+}): Record<string, string | undefined> {
+  const jobOutputs: Record<string, string | undefined> = {};
+  for (const [outputKey, outputDefinition] of Object.entries(jobOutputDefinitions)) {
+    const outputValue = outputDefinition.replace(/\$\{\{(.+?)\}\}/g, (_match, expression) => {
+      return `${jsepEval(expression, interpolationContext)}`;
+    });
+
+    jobOutputs[outputKey] = outputValue;
+  }
+
+  return jobOutputs;
+}
+
+/** This is what we'll use to generate an object representing a step. */
+export function getDynamicValuesFromStep(step: BuildStep): {
+  outputs: Record<string, string | undefined>;
+} {
+  const outputs = Object.fromEntries(
+    Object.entries(step.outputById).map(([id, output]) => [id, output.value ?? '']) ?? []
+  );
+
+  return { outputs };
+}

--- a/packages/build-tools/src/utils/turtleFetch.ts
+++ b/packages/build-tools/src/utils/turtleFetch.ts
@@ -1,0 +1,74 @@
+import fetch, { Response, RequestInit, HeaderInit } from 'node-fetch';
+import { bunyan } from '@expo/logger';
+
+import { retryAsync } from './retry';
+
+type TurtleFetchMethod = 'GET' | 'POST' | 'PUT' | 'DELETE' | 'HEAD' | 'OPTIONS' | 'TRACE' | 'PATCH';
+
+export class TurtleFetchError extends Error {
+  readonly response: Response;
+  constructor(message: string, response: Response) {
+    super(message);
+    this.response = response;
+  }
+}
+
+/**
+ * Wrapper around node-fetch adding some useful features:
+ * - retries
+ * - json body - if you specify json in options, it will be stringified and content-type will be set to application/json
+ * - automatic error throwing - if response is not ok, it will throw an error
+ *
+ * @param url URL to fetch
+ * @param method HTTP method
+ * @param options.retries number of retries
+ * @param options.json json body
+ * @param options.headers headers
+ * @param options.shouldThrowOnNotOk if false, it will not throw an error if response is not ok (default: true)
+ * @param options other options passed to node-fetch
+ * @returns {Promise<Response>}
+ */
+export async function turtleFetch(
+  url: string,
+  method: TurtleFetchMethod,
+  options: Omit<RequestInit, 'body' | 'method'> & {
+    retries?: number;
+    json?: Record<string, any>;
+    headers?: Exclude<HeaderInit, string[][]>;
+    shouldThrowOnNotOk?: boolean;
+    retryIntervalMs?: number;
+    logger?: bunyan;
+  }
+): Promise<Response> {
+  const {
+    json,
+    headers: rawHeaders,
+    retries: rawRetries,
+    logger,
+    retryIntervalMs = 1000,
+    shouldThrowOnNotOk = true,
+    ...otherOptions
+  } = options;
+
+  const retries = rawRetries ?? (method === 'POST' ? 0 : 2);
+
+  const body = JSON.stringify(json);
+  const headers = json ? { ...rawHeaders, 'Content-Type': 'application/json' } : rawHeaders;
+
+  return await retryAsync(
+    async (attemptCount) => {
+      const response = await fetch(url, {
+        method,
+        body,
+        headers,
+        ...otherOptions,
+      });
+      const shouldThrow = shouldThrowOnNotOk || attemptCount < retries;
+      if (!response.ok && shouldThrow) {
+        throw new TurtleFetchError(`Request failed with status ${response.status}`, response);
+      }
+      return response;
+    },
+    { retryOptions: { retries, retryIntervalMs }, logger }
+  );
+}

--- a/packages/eas-build-job/src/logs.ts
+++ b/packages/eas-build-job/src/logs.ts
@@ -54,6 +54,7 @@ export enum BuildPhase {
   // CUSTOM BUILDS
   PARSE_CUSTOM_WORKFLOW_CONFIG = 'PARSE_CUSTOM_WORKFLOW_CONFIG',
   CUSTOM = 'CUSTOM',
+  COMPLETE_JOB = 'COMPLETE_JOB',
 }
 
 export enum SubmissionPhase {
@@ -114,6 +115,7 @@ export const buildPhaseDisplayName: Record<BuildPhase, string> = {
   // CUSTOM
   [BuildPhase.CUSTOM]: 'Unknown build phase',
   [BuildPhase.PARSE_CUSTOM_WORKFLOW_CONFIG]: 'Parse custom build config',
+  [BuildPhase.COMPLETE_JOB]: 'Complete job',
 };
 
 export const submissionPhaseDisplayName: Record<SubmissionPhase, string> = {
@@ -174,6 +176,7 @@ export const buildPhaseWebsiteId: Record<BuildPhase, string> = {
   // CUSTOM
   [BuildPhase.CUSTOM]: 'custom',
   [BuildPhase.PARSE_CUSTOM_WORKFLOW_CONFIG]: 'parse-custom-workflow-config',
+  [BuildPhase.COMPLETE_JOB]: 'complete-job',
 };
 
 export const submissionPhaseWebsiteId: Record<SubmissionPhase, string> = {


### PR DESCRIPTION
# Why

https://linear.app/expo/issue/ENG-13708/move-uploading-outputs-to-eas-build-and-public-step

# How

Created outputs upload function based on the one existing in turtle, but accepting the `logger` and `expoApiV2BaseUrl` params.
Calling that function at the end of generic job in a new dedicated `Complete job` step, with the logger for that step.
Added mappings for that new step.

# Test Plan

Automated tests mostly based on those from Turtle

# Deployment plan
1) Merge this PR
2) Release new version of `build-tools` and `eas-build-job`
3) Update `eas-build-job` in `website`, merge and deploy
4) Update `build-tools` and `eas-build-job` in Turtle, merge and deploy