### PR TITLE
[build-tools] automatially parse Xcode logs in search for 'error: ' logs to make debugging build failures easier for user

### DIFF
--- a/packages/build-tools/src/buildErrors/__tests__/detectError.test.ts
+++ b/packages/build-tools/src/buildErrors/__tests__/detectError.test.ts
@@ -1,8 +1,16 @@
 import path from 'path';
 
 import { BuildMode, BuildPhase, errors, Job, Platform } from '@expo/eas-build-job';
+import { vol } from 'memfs';
 
 import { resolveBuildPhaseErrorAsync } from '../detectError';
+
+jest.mock('fs');
+const originalFs = jest.requireActual('fs');
+
+afterEach(() => {
+  vol.reset();
+});
 
 describe(resolveBuildPhaseErrorAsync, () => {
   it('detects log for corrupted npm package', async () => {
@@ -100,6 +108,13 @@ describe(resolveBuildPhaseErrorAsync, () => {
   });
 
   it('detects xcode line error', async () => {
+    vol.fromJSON({
+      '/path/to/xcodelogs.log': originalFs.readFileSync(
+        path.resolve('./src/buildErrors/__tests__/fixtures/xcode.log'),
+        'utf-8'
+      ),
+    });
+
     const fakeError = new Error();
     const err = await resolveBuildPhaseErrorAsync(
       fakeError,
@@ -109,7 +124,7 @@ describe(resolveBuildPhaseErrorAsync, () => {
         phase: BuildPhase.RUN_FASTLANE,
         env: {},
       },
-      path.resolve('./src/buildErrors/__tests__/fixtures')
+      '/path/to/'
     );
     expect(err.errorCode).toBe('XCODE_RESOURCE_BUNDLE_CODE_SIGNING_ERROR');
     expect(err.userFacingErrorCode).toBe('XCODE_RESOURCE_BUNDLE_CODE_SIGNING_ERROR');
@@ -181,5 +196,57 @@ describe(resolveBuildPhaseErrorAsync, () => {
     );
     expect(err.errorCode).toBe('EAS_BUILD_UNKNOWN_FASTLANE_ERROR');
     expect(err.userFacingErrorCode).toBe('EAS_BUILD_UNKNOWN_FASTLANE_ERROR');
+  });
+
+  it('detects provisioning profile mismatch error correctly', async () => {
+    const xcodeLogs = `Intermediates.noindex/Pods.build/Release-iphonesimulator/Yoga.build/Objects-normal/arm64/82b82416624d2658e5098eb0a28c15c5-common-args.resp
+-target arm64-apple-ios15.0-simulator '-std=gnu++14' '-stdlib=libc++' -fmodules '-fmodules-cache-path=/Users/expo/workingdir/build/packages/apps/NFLNetwork/ios/build/ModuleCache.noindex' '-fmodule-name=yoga' -fpascal-strings -Os -fno-common '-DPOD_CONFIGURATION_RELEASE=1' '-DCOCOAPODS=1' -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator18.1.sdk -g -iquote /Users/expo/workingdir/build/packages/apps/NFLNetwork/ios/build/Build/Intermediates.noindex/Pods.build/Release-iphonesimulator/Yoga.build/Yoga-generated-files.hmap -I/Users/expo/workingdir/build/packages/apps/NFLNetwork/ios/build/Build/Intermediates.noindex/Pods.build/Release-iphonesimulator/Yoga.build/Yoga-own-target-headers.hmap -I/Users/expo/workingdir/build/packages/apps/NFLNetwork/ios/build/Build/Intermediates.noindex/Pods.build/Release-iphonesimulator/Yoga.build/Yoga-all-non-framework-target-headers.hmap -ivfsoverlay /Users/expo/workingdir/build/packages/apps/NFLNetwork/ios/build/Build/Intermediates.noindex/Pods.build/Release-iphonesimulator/Pods-8699adb1dd336b26511df848a716bd42-VFS-iphonesimulator/all-product-headers.yaml -iquote /Users/expo/workingdir/build/packages/apps/NFLNetwork/ios/build/Build/Intermediates.noindex/Pods.build/Release-iphonesimulator/Yoga.build/Yoga-project-headers.hmap -I/Users/expo/workingdir/build/packages/apps/NFLNetwork/ios/build/Build/Products/Release-iphonesimulator/Yoga/include -I/Users/expo/workingdir/build/packages/apps/NFLNetwork/ios/Pods/Headers/Private -I/Users/expo/workingdir/build/packages/apps/NFLNetwork/ios/Pods/Headers/Private/Yoga -I/Users/expo/workingdir/build/packages/apps/NFLNetwork/ios/Pods/Headers/Public -I/Users/expo/workingdir/build/packages/apps/NFLNetwork/ios/Pods/Headers/Public/Yoga -I/Users/expo/workingdir/build/packages/apps/NFLNetwork/ios/build/Build/Intermediates.noindex/Pods.build/Release-iphonesimulator/Yoga.build/DerivedSources-normal/arm64 -I/Users/expo/workingdir/build/packages/apps/NFLNetwork/ios/build/Build/Intermediates.noindex/Pods.build/Release-iphonesimulator/Yoga.build/DerivedSources/arm64 -I/Users/expo/workingdir/build/packages/apps/NFLNetwork/ios/build/Build/Intermediates.noindex/Pods.build/Release-iphonesimulator/Yoga.build/DerivedSources -F/Users/expo/workingdir/build/packages/apps/NFLNetwork/ios/build/Build/Products/Release-iphonesimulator/Yoga
+MkDir /Users/expo/workingdir/build/packages/apps/NFLNetwork/ios/build/Build/Products/Release-iphonesimulator/expo-dev-menu/EXDevMenu.bundle (in target 'expo-dev-menu-EXDevMenu' from project 'Pods')
+    cd /Users/expo/workingdir/build/packages/apps/NFLNetwork/ios/Pods
+    /bin/mkdir -p /Users/expo/workingdir/build/packages/apps/NFLNetwork/ios/build/Build/Products/Release-iphonesimulator/expo-dev-menu/EXDevMenu.bundle
+
+MkDir /Users/expo/workingdir/build/packages/apps/NFLNetwork/ios/build/Build/Products/Release-iphonesimulator/expo-dev-launcher/EXDevLauncher.bundle (in target 'expo-dev-launcher-EXDevLauncher' from project 'Pods')
+    cd /Users/expo/workingdir/build/packages/apps/NFLNetwork/ios/Pods
+    /bin/mkdir -p /Users/expo/workingdir/build/packages/apps/NFLNetwork/ios/build/Build/Products/Release-iphonesimulator/expo-dev-launcher/EXDevLauncher.bundle
+
+ProcessXCFramework /Users/expo/workingdir/build/packages/video/ios/Vendor/dependency/ProgrammaticAccessLibrary.xcframework /Users/expo/workingdir/build/packages/apps/NFLNetwork/ios/build/Build/Products/Release-iphonesimulator/ProgrammaticAccessLibrary.framework ios simulator
+    cd /Users/expo/workingdir/build/packages/apps/NFLNetwork/ios
+    builtin-process-xcframework --xcframework /Users/expo/workingdir/build/packages/video/ios/Vendor/dependency/ProgrammaticAccessLibrary.xcframework --platform ios --environment simulator --target-path /Users/expo/workingdir/build/packages/apps/NFLNetwork/ios/build/Build/Products/Release-iphonesimulator
+/Users/expo/workingdir/build/packages/video/ios/Vendor/dependency/ProgrammaticAccessLibrary.xcframework:1:1: error: The signature of “ProgrammaticAccessLibrary.xcframework” cannot be verified.
+    note: A sealed resource is missing or invalid
+    note: /Users/expo/workingdir/build/packages/video/ios/Vendor/dependency/ProgrammaticAccessLibrary.xcframework: a sealed resource is missing or invalid
+file modified: /Users/expo/workingdir/build/packages/video/ios/Vendor/dependency/ProgrammaticAccessLibrary.xcframework/ios-arm64_x86_64-simulator/ProgrammaticAccessLibrary.framework/ProgrammaticAccessLibrary
+file modified: /Users/expo/workingdir/build/packages/video/ios/Vendor/dependency/ProgrammaticAccessLibrary.xcframework/ios-arm64/ProgrammaticAccessLibrary.framework/ProgrammaticAccessLibrary
+error: Some other error
+log
+log
+log
+error: The last one
+log
+note`;
+
+    vol.fromJSON({
+      '/path/to/xcode.log': xcodeLogs,
+    });
+
+    const fakeError = new Error();
+    const err = await resolveBuildPhaseErrorAsync(
+      fakeError,
+      [`some logs`],
+      {
+        job: { platform: Platform.IOS, mode: BuildMode.BUILD } as Job,
+        phase: BuildPhase.RUN_FASTLANE,
+        env: {},
+      },
+      '/path/to'
+    );
+    expect(err.errorCode).toBe('XCODE_BUILD_ERROR');
+    expect(err.userFacingErrorCode).toBe('XCODE_BUILD_ERROR');
+    expect(err.userFacingMessage)
+      .toBe(`The "Run fastlane" step failed because of an error in the Xcode build process. We automatically detected following errors in your Xcode build logs:
+- The signature of “ProgrammaticAccessLibrary.xcframework” cannot be verified.
+- Some other error
+- The last one
+Refer to "Xcode Logs" below for additional, more detailed logs.`);
   });
 });

--- a/packages/build-tools/src/buildErrors/userErrorHandlers.ts
+++ b/packages/build-tools/src/buildErrors/userErrorHandlers.ts
@@ -277,6 +277,29 @@ To resolve this issue, downgrade to an older Xcode version using the "image" fie
   },
   {
     platform: Platform.IOS,
+    phase: XCODE_BUILD_PHASE,
+    // MkDir /Users/expo/workingdir/build/packages/apps/NFLNetwork/ios/build/Build/Products/Release-iphonesimulator/expo-dev-launcher/EXDevLauncher.bundle (in target 'expo-dev-launcher-EXDevLauncher' from project 'Pods')
+    // cd /Users/expo/workingdir/build/packages/apps/NFLNetwork/ios/Pods
+    // /bin/mkdir -p /Users/expo/workingdir/build/packages/apps/NFLNetwork/ios/build/Build/Products/Release-iphonesimulator/expo-dev-launcher/EXDevLauncher.bundle
+    // ProcessXCFramework /Users/expo/workingdir/build/packages/video/ios/Vendor/dependency/ProgrammaticAccessLibrary.xcframework /Users/expo/workingdir/build/packages/apps/NFLNetwork/ios/build/Build/Products/Release-iphonesimulator/ProgrammaticAccessLibrary.framework ios simulator
+    // cd /Users/expo/workingdir/build/packages/apps/NFLNetwork/ios
+    // builtin-process-xcframework --xcframework /Users/expo/workingdir/build/packages/video/ios/Vendor/dependency/ProgrammaticAccessLibrary.xcframework --platform ios --environment simulator --target-path /Users/expo/workingdir/build/packages/apps/NFLNetwork/ios/build/Build/Products/Release-iphonesimulator
+    // /Users/expo/workingdir/build/packages/video/ios/Vendor/dependency/ProgrammaticAccessLibrary.xcframework:1:1: error: The signature of “ProgrammaticAccessLibrary.xcframework” cannot be verified.
+    // note: A sealed resource is missing or invalid
+    // note: /Users/expo/workingdir/build/packages/video/ios/Vendor/dependency/ProgrammaticAccessLibrary.xcframework: a sealed resource is missing or invalid
+    // file modified: /Users/expo/workingdir/build/packages/video/ios/Vendor/dependency/ProgrammaticAccessLibrary.xcframework/ios-arm64_x86_64-simulator/ProgrammaticAccessLibrary.framework/ProgrammaticAccessLibrary
+    // file modified: /Users/expo/workingdir/build/packages/video/ios/Vendor/dependency/ProgrammaticAccessLibrary.xcframework/ios-arm64/ProgrammaticAccessLibrary.framework/ProgrammaticAccessLibrary
+    regexp: /error: .+/g,
+    createError: (matchResult) =>
+      new UserFacingError(
+        'XCODE_BUILD_ERROR',
+        `The "Run fastlane" step failed because of an error in the Xcode build process. We automatically detected following errors in your Xcode build logs:\n${matchResult
+          .map((match) => `- ${match.replace('error: ', '')}`)
+          .join('\n')}\nRefer to "Xcode Logs" below for additional, more detailed logs.`
+      ),
+  },
+  {
+    platform: Platform.IOS,
     phase: BuildPhase.RUN_FASTLANE,
     regexp: /.*/,
     createError: () =>


### PR DESCRIPTION
# Why

Talked about it with @lukmccall today. We want to improve our old generic error message which we display when the build fails during the `RUN_FASTLANE` phase that says `The "Run fastlane" step failed with an unknown error. Refer to "Xcode Logs" below for additional, more detailed logs.` to make it more informative by parsing Xcode logs for the user and displaying found errors in the error message itself so it is easier to find them.

# How

Add a new user error handler for `XCODE_BUILD_PHASE`. If this error handler finds `error: ...` logs in the Xcode build logs file, it displays them nicely in the user-facing error message.

Similar to: https://github.com/expo/eas-build/pull/148

# Test Plan

Added automated tests
