### PR TITLE
[eas-build-job] Add properties to `WorkflowInterpolationContext`

### DIFF
--- a/packages/eas-build-job/src/common.ts
+++ b/packages/eas-build-job/src/common.ts
@@ -167,6 +167,13 @@ export interface BuildPhaseStats {
 }
 
 export const StaticWorkflowInterpolationContextZ = z.object({
+  after: z.record(
+    z.string(),
+    z.object({
+      status: z.string(),
+      outputs: z.record(z.string(), z.string().nullable()),
+    })
+  ),
   needs: z.record(
     z.string(),
     z.object({
@@ -179,6 +186,9 @@ export const StaticWorkflowInterpolationContextZ = z.object({
       event_name: z.enum(['push', 'pull_request', 'workflow_dispatch']),
       sha: z.string(),
       ref: z.string(),
+      ref_name: z.string(),
+      ref_type: z.string(),
+      commit_message: z.string(),
     })
     // We need to .optional() to support jobs that are not triggered by a GitHub event.
     .optional(),

--- a/packages/eas-build-job/src/common.ts
+++ b/packages/eas-build-job/src/common.ts
@@ -188,7 +188,6 @@ export const StaticWorkflowInterpolationContextZ = z.object({
       ref: z.string(),
       ref_name: z.string(),
       ref_type: z.string(),
-      commit_message: z.string(),
     })
     // We need to .optional() to support jobs that are not triggered by a GitHub event.
     .optional(),


### PR DESCRIPTION
`after` makes a lot of sense, `ref_name`, `ref_type` and `commit_message` will be used for `main`, `branch` and `test commit`.