### PR TITLE
[steps] [ENG-14373] Fix multiline slack messages with env vars

### DIFF
--- a/packages/steps/bin/set-env
+++ b/packages/steps/bin/set-env
@@ -20,4 +20,4 @@ if [[ "$NAME" == *"="* ]]; then
   exit 1
 fi
 
-echo -n $VALUE > $__EXPO_STEPS_ENVS_DIR/$NAME
+echo -n "$VALUE" > $__EXPO_STEPS_ENVS_DIR/$NAME

--- a/packages/steps/src/BuildStep.ts
+++ b/packages/steps/src/BuildStep.ts
@@ -28,6 +28,7 @@ import { BuildStepEnv } from './BuildStepEnv.js';
 import { BuildRuntimePlatform } from './BuildRuntimePlatform.js';
 import { jsepEval } from './utils/jsepEval.js';
 import { interpolateJobContext } from './interpolation.js';
+import { fixEscapeCharactersInRawEnvValue } from './utils/envUtils.js';
 
 export enum BuildStepStatus {
   NEW = 'new',
@@ -484,7 +485,8 @@ export class BuildStep extends BuildStepOutputAccessor {
     const entries = await Promise.all(
       filenames.map(async (basename) => {
         const rawContents = await fs.readFile(path.join(envsDir, basename), 'utf-8');
-        return [basename, rawContents];
+        const updatedContents = fixEscapeCharactersInRawEnvValue(rawContents);
+        return [basename, updatedContents];
       })
     );
     this.ctx.global.updateEnv({

--- a/packages/steps/src/utils/envUtils.ts
+++ b/packages/steps/src/utils/envUtils.ts
@@ -1,0 +1,17 @@
+export function fixEscapeCharactersInRawEnvValue(rawValue: string): string {
+  const escapeCharsMatches = rawValue.match(/\\(\w)/g);
+  let updatedValue = rawValue;
+  for (const match of escapeCharsMatches ?? []) {
+    if (match[1] === 'n') {
+      updatedValue = updatedValue.replace(`${match[0]}${match[1]}`, '\n');
+    }
+    if (match[1] === 't') {
+      updatedValue = updatedValue.replace(`${match[0]}${match[1]}`, '\t');
+    }
+    if (match[1] === 'r') {
+      updatedValue = updatedValue.replace(`${match[0]}${match[1]}`, '\r');
+    }
+  }
+
+  return updatedValue;
+}


### PR DESCRIPTION
# Why

https://github.com/expo/eas-cli/issues/2728
When setting an env var to a multiline string and then passing it as the context of a Slack message to the `eas/send_slack_message` function the new-line characters are not correctly handled. The implicit new-lines are removed, while explicit `\n` characters are used as `\` and `n`.

# How

Updated the `set-env` bash script to preserve the implicit new-lines when saving the var value to the file.
Added a util function that fixes the explicit escape characters when reading the raw env value from the file and updating the context.

# Test Plan

Manual tests

## Config
![Screenshot 2024-12-11 at 13 06 43](https://github.com/user-attachments/assets/50751a0d-f3bf-4251-ac33-12153075dad8)

## Before
<img width="670" alt="Screenshot 2024-12-11 at 13 12 02" src="https://github.com/user-attachments/assets/fc33b602-b267-4cbc-a48f-2691348e59de">

## After
<img width="670" alt="Screenshot 2024-12-11 at 13 07 19" src="https://github.com/user-attachments/assets/9bd616eb-0c8e-4396-ba85-801e65d54be5">
