### PR TITLE
[eas-cli] allow running eas/build function group with credentials for iOS GH builds

### DIFF
--- a/packages/build-tools/src/steps/functionGroups/build.ts
+++ b/packages/build-tools/src/steps/functionGroups/build.ts
@@ -36,7 +36,7 @@ export function createEasBuildBuildFunctionGroup(
     createBuildStepsFromFunctionGroupCall: (globalCtx) => {
       if (buildToolsContext.job.platform === Platform.IOS) {
         // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-        if (buildToolsContext.job.simulator || !buildToolsContext.job.secrets?.buildCredentials) {
+        if (buildToolsContext.job.simulator) {
           return createStepsForIosSimulatorBuild({
             globalCtx,
             buildToolsContext,

--- a/packages/build-tools/src/steps/functionGroups/build.ts
+++ b/packages/build-tools/src/steps/functionGroups/build.ts
@@ -35,7 +35,6 @@ export function createEasBuildBuildFunctionGroup(
     id: 'build',
     createBuildStepsFromFunctionGroupCall: (globalCtx) => {
       if (buildToolsContext.job.platform === Platform.IOS) {
-        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         if (buildToolsContext.job.simulator) {
           return createStepsForIosSimulatorBuild({
             globalCtx,


### PR DESCRIPTION
# Why

We are making a decision in our system whether to execute the credentials or without the credentials flow for the iOS `eas/build` function group based on the presence of `job.secrets.buildCredentials`. However, at the time of making this discussion (before the build starts), these are always missing for GH builds and are only resolved later.

We should rely on `job.simulator` only instead, which is always correctly set for GH builds https://github.com/expo/universe/blob/9eccb36e30da89e17d1c8b748437da99faebfa7d/server/www/src/data/entities/github/GitHubBuildUtils.ts#L165

# How

Only use `job.simulator` to decide which flow to enter

# Test Plan

Test it manually
