### PR TITLE
[build-tools] add logger to `pod install` spawn call in `eas/install_pods` custom build function

### DIFF
--- a/packages/build-tools/src/steps/functions/installPods.ts
+++ b/packages/build-tools/src/steps/functions/installPods.ts
@@ -9,9 +9,22 @@ export function createInstallPodsBuildFunction(): BuildFunction {
     fn: async (stepsCtx, { env }) => {
       stepsCtx.logger.info('Installing pods');
       await spawn('pod', ['install'], {
-        stdio: 'pipe',
-        env,
+        logger: stepsCtx.logger,
+        env: {
+          ...env,
+          LANG: 'en_US.UTF-8',
+        },
         cwd: stepsCtx.workingDirectory,
+        lineTransformer: (line?: string) => {
+          if (
+            !line ||
+            /\[!\] '[\w-]+' uses the unencrypted 'http' protocol to transfer the Pod\./.exec(line)
+          ) {
+            return null;
+          } else {
+            return line;
+          }
+        },
       });
     },
   });


### PR DESCRIPTION
# Why

https://exponent-internal.slack.com/archives/C02123T524U/p1736176457964409

# How

It seems like we indeed forgot to pass the logger to this function. I sync this spawn call to be the same as https://github.com/expo/eas-build/blob/2f806e10cfd0ccf6078475633aa09fca4312e9ba/packages/build-tools/src/ios/pod.ts#L15-L36

# Test Plan

System tests - see if logs appear
