### PR TITLE
[steps] Resolve absolute `working_directory` paths from repository root

### DIFF
--- a/packages/steps/src/BuildStepContext.ts
+++ b/packages/steps/src/BuildStepContext.ts
@@ -233,9 +233,15 @@ export class BuildStepContext {
   }
 
   public get workingDirectory(): string {
-    return this.relativeWorkingDirectory
-      ? path.resolve(this.ctx.defaultWorkingDirectory, this.relativeWorkingDirectory)
-      : this.ctx.defaultWorkingDirectory;
+    if (!this.relativeWorkingDirectory) {
+      return this.ctx.defaultWorkingDirectory;
+    }
+
+    if (path.isAbsolute(this.relativeWorkingDirectory)) {
+      return path.join(this.ctx.projectTargetDirectory, this.relativeWorkingDirectory);
+    }
+
+    return path.join(this.ctx.defaultWorkingDirectory, this.relativeWorkingDirectory);
   }
 
   public serialize(): SerializedBuildStepContext {

--- a/packages/steps/src/__tests__/BuildConfigParser-test.ts
+++ b/packages/steps/src/__tests__/BuildConfigParser-test.ts
@@ -179,7 +179,9 @@ describe(BuildConfigParser, () => {
       expect(step5.id).toMatch(UUID_REGEX);
       expect(step5.name).toBe('List files in another directory');
       expect(step5.command).toBe('ls -la');
-      expect(step5.ctx.workingDirectory).toBe('/home/dsokal');
+      expect(step5.ctx.workingDirectory).toBe(
+        path.join(ctx.projectTargetDirectory, '/home/dsokal')
+      );
       expect(step5.shell).toBe(getDefaultShell());
       expect(step5.stepEnvOverrides).toMatchObject({});
 

--- a/packages/steps/src/__tests__/BuildStepContext-test.ts
+++ b/packages/steps/src/__tests__/BuildStepContext-test.ts
@@ -1,3 +1,4 @@
+import path from 'path';
 import os from 'os';
 
 import { JobInterpolationContext } from '@expo/eas-build-job';
@@ -194,14 +195,28 @@ describe(BuildStepGlobalContext, () => {
       expect(childCtx.logger).toBe(logger2);
     });
     it('can override working directory', () => {
-      const workingDirectoryOverride = '/d/e/f';
-      const ctx = createGlobalContextMock();
-      const childCtx = ctx.stepCtx({
-        relativeWorkingDirectory: workingDirectoryOverride,
+      const ctx = createGlobalContextMock({
+        relativeWorkingDirectory: 'apps/mobile',
+      });
+      ctx.markAsCheckedOut(ctx.baseLogger);
+
+      const relativeChildCtx = ctx.stepCtx({
+        relativeWorkingDirectory: 'scripts',
         logger: ctx.baseLogger,
       });
-      expect(ctx.defaultWorkingDirectory).not.toBe(childCtx.workingDirectory);
-      expect(childCtx.workingDirectory).toBe(workingDirectoryOverride);
+      expect(ctx.defaultWorkingDirectory).not.toBe(relativeChildCtx.workingDirectory);
+      expect(relativeChildCtx.workingDirectory).toBe(
+        path.join(ctx.projectTargetDirectory, 'apps/mobile/scripts')
+      );
+
+      const absoluteChildCtx = ctx.stepCtx({
+        relativeWorkingDirectory: '/apps/web',
+        logger: ctx.baseLogger,
+      });
+      expect(ctx.defaultWorkingDirectory).not.toBe(absoluteChildCtx.workingDirectory);
+      expect(absoluteChildCtx.workingDirectory).toBe(
+        path.join(ctx.projectTargetDirectory, 'apps/web')
+      );
     });
   });
 });


### PR DESCRIPTION
# Why

With Workflows I expect more and more users will want to execute scripts related less to mobile app, in directories other than that of the mobile app.

Currently, `working_directory` works like this:
- relative paths get resolved from the base directory (mobile app directory) — `working_directory: scripts` if base directory is `apps/mobile` ends up being `/home/expo/build/apps/mobile/scripts`
- absolute paths get resolved from VM root — `working_directory: /usr/local/bin` ends up being `/usr/local/bin`.

This makes it cumbersome to execute scripts in directories other than that of mobile app. Say, a user wants to execute scripts in `/apps/web`. If base directory is `apps/mobile`, they'd need to use `../web`. This makes `working_directory` coupled to base directory set in GitHub repository settings.

# How

Here I'm special-casing absolute `working_directory` paths. I expect very few people to need to execute scripts in FS-absolute paths (`/usr/local/bin`). So now it is going to work like this:
- (unchanged) relative paths get resolved from the base directory (mobile app directory) — `working_directory: scripts` if base directory is `apps/mobile` ends up being `/home/expo/build/apps/mobile/scripts`
- absolute paths get resolved from repository root — `working_directory: /usr/local/bin` ends up being `/home/expo/build/usr/local/bin`.

# Test Plan

Adjusted tests.

Also tested manually. A workflow like

```yaml
jobs:
  test:
    steps:
      - run: pwd
      - run: pwd
        working_directory: /
      - run: pwd
        working_directory: ./
      - uses: eas/checkout
      - run: pwd
        working_directory: scripts
      - run: pwd
        working_directory: /apps/web
```

produces output like this
<img width="873" alt="Zrzut ekranu 2025-01-9 o 14 12 39" src="https://github.com/user-attachments/assets/7c477fd9-5bee-4243-8543-ad2368cf74d3" />

