### PR TITLE
[build-tools] don't run `EAGER_BUNDLE` build phase for dev client builds

### DIFF
--- a/packages/build-tools/src/builders/android.ts
+++ b/packages/build-tools/src/builders/android.ts
@@ -106,6 +106,7 @@ async function buildAsync(ctx: BuildContext<Android.Job>): Promise<void> {
 
   if (
     !ctx.env.EAS_BUILD_DISABLE_BUNDLE_JAVASCRIPT_STEP &&
+    !ctx.metadata?.developmentClient &&
     ctx.metadata?.sdkVersion &&
     semver.satisfies(ctx.metadata?.sdkVersion, '>=52')
   ) {

--- a/packages/build-tools/src/builders/ios.ts
+++ b/packages/build-tools/src/builders/ios.ts
@@ -115,6 +115,7 @@ async function buildAsync(ctx: BuildContext<Ios.Job>): Promise<void> {
 
     if (
       !ctx.env.EAS_BUILD_DISABLE_BUNDLE_JAVASCRIPT_STEP &&
+      !ctx.metadata?.developmentClient &&
       ctx.metadata?.sdkVersion &&
       semver.satisfies(ctx.metadata?.sdkVersion, '>=52')
     ) {

--- a/packages/build-tools/src/common/eagerBundle.ts
+++ b/packages/build-tools/src/common/eagerBundle.ts
@@ -1,5 +1,6 @@
-import { Platform } from '@expo/eas-build-job';
+import { Metadata, Platform } from '@expo/eas-build-job';
 import { bunyan } from '@expo/logger';
+import semver from 'semver';
 
 import { runExpoCliCommand } from '../utils/project';
 import { PackageManager } from '../utils/packageManager';
@@ -26,4 +27,12 @@ export async function eagerBundleAsync({
     },
     packageManager,
   });
+}
+
+export function shouldUseEagerBundle(metadata: Metadata | null | undefined): boolean {
+  return Boolean(
+    !metadata?.developmentClient &&
+      metadata?.sdkVersion &&
+      semver.satisfies(metadata?.sdkVersion, '>=52')
+  );
 }

--- a/packages/build-tools/src/steps/functionGroups/build.ts
+++ b/packages/build-tools/src/steps/functionGroups/build.ts
@@ -1,6 +1,5 @@
 import { BuildFunctionGroup, BuildStep, BuildStepGlobalContext } from '@expo/steps';
 import { BuildJob, Platform } from '@expo/eas-build-job';
-import semver from 'semver';
 
 import { createCheckoutBuildFunction } from '../functions/checkout';
 import { createInstallNodeModulesBuildFunction } from '../functions/installNodeModules';
@@ -21,6 +20,7 @@ import { createSetUpNpmrcBuildFunction } from '../functions/useNpmToken';
 import { createResolveBuildConfigBuildFunction } from '../functions/resolveBuildConfig';
 import { calculateEASUpdateRuntimeVersionFunction } from '../functions/calculateEASUpdateRuntimeVersion';
 import { eagerBundleBuildFunction } from '../functions/eagerBundle';
+import { shouldUseEagerBundle } from '../../common/eagerBundle';
 
 interface HelperFunctionsInput {
   globalCtx: BuildStepGlobalContext;
@@ -102,9 +102,7 @@ function createStepsForIosSimulatorBuild({
     calculateEASUpdateRuntimeVersion,
     installPods,
     configureEASUpdate,
-    ...(!globalCtx.staticContext.metadata?.developmentClient &&
-    globalCtx.staticContext.metadata?.sdkVersion &&
-    semver.satisfies(globalCtx.staticContext.metadata?.sdkVersion, '>=52')
+    ...(shouldUseEagerBundle(globalCtx.staticContext.metadata)
       ? [
           eagerBundleBuildFunction().createBuildStepFromFunctionCall(globalCtx, {
             callInputs: {
@@ -179,9 +177,7 @@ function createStepsForIosBuildWithCredentials({
     configureEASUpdate,
     configureIosCredentialsFunction().createBuildStepFromFunctionCall(globalCtx),
     configureIosVersionFunction().createBuildStepFromFunctionCall(globalCtx),
-    ...(!globalCtx.staticContext.metadata?.developmentClient &&
-    globalCtx.staticContext.metadata?.sdkVersion &&
-    semver.satisfies(globalCtx.staticContext.metadata?.sdkVersion, '>=52')
+    ...(shouldUseEagerBundle(globalCtx.staticContext.metadata)
       ? [
           eagerBundleBuildFunction().createBuildStepFromFunctionCall(globalCtx, {
             callInputs: {
@@ -232,9 +228,7 @@ function createStepsForAndroidBuildWithoutCredentials({
     createPrebuildBuildFunction().createBuildStepFromFunctionCall(globalCtx),
     calculateEASUpdateRuntimeVersion,
     configureEASUpdate,
-    ...(!globalCtx.staticContext.metadata?.developmentClient &&
-    globalCtx.staticContext.metadata?.sdkVersion &&
-    semver.satisfies(globalCtx.staticContext.metadata?.sdkVersion, '>=52')
+    ...(shouldUseEagerBundle(globalCtx.staticContext.metadata)
       ? [
           eagerBundleBuildFunction().createBuildStepFromFunctionCall(globalCtx, {
             callInputs: {
@@ -287,9 +281,7 @@ function createStepsForAndroidBuildWithCredentials({
     injectAndroidCredentialsFunction().createBuildStepFromFunctionCall(globalCtx),
     configureAndroidVersionFunction().createBuildStepFromFunctionCall(globalCtx),
     runGradle,
-    ...(!globalCtx.staticContext.metadata?.developmentClient &&
-    globalCtx.staticContext.metadata?.sdkVersion &&
-    semver.satisfies(globalCtx.staticContext.metadata?.sdkVersion, '>=52')
+    ...(shouldUseEagerBundle(globalCtx.staticContext.metadata)
       ? [
           eagerBundleBuildFunction().createBuildStepFromFunctionCall(globalCtx, {
             callInputs: {

--- a/packages/build-tools/src/steps/functionGroups/build.ts
+++ b/packages/build-tools/src/steps/functionGroups/build.ts
@@ -102,7 +102,8 @@ function createStepsForIosSimulatorBuild({
     calculateEASUpdateRuntimeVersion,
     installPods,
     configureEASUpdate,
-    ...(globalCtx.staticContext.metadata?.sdkVersion &&
+    ...(!globalCtx.staticContext.metadata?.developmentClient &&
+    globalCtx.staticContext.metadata?.sdkVersion &&
     semver.satisfies(globalCtx.staticContext.metadata?.sdkVersion, '>=52')
       ? [
           eagerBundleBuildFunction().createBuildStepFromFunctionCall(globalCtx, {
@@ -178,7 +179,8 @@ function createStepsForIosBuildWithCredentials({
     configureEASUpdate,
     configureIosCredentialsFunction().createBuildStepFromFunctionCall(globalCtx),
     configureIosVersionFunction().createBuildStepFromFunctionCall(globalCtx),
-    ...(globalCtx.staticContext.metadata?.sdkVersion &&
+    ...(!globalCtx.staticContext.metadata?.developmentClient &&
+    globalCtx.staticContext.metadata?.sdkVersion &&
     semver.satisfies(globalCtx.staticContext.metadata?.sdkVersion, '>=52')
       ? [
           eagerBundleBuildFunction().createBuildStepFromFunctionCall(globalCtx, {
@@ -230,7 +232,8 @@ function createStepsForAndroidBuildWithoutCredentials({
     createPrebuildBuildFunction().createBuildStepFromFunctionCall(globalCtx),
     calculateEASUpdateRuntimeVersion,
     configureEASUpdate,
-    ...(globalCtx.staticContext.metadata?.sdkVersion &&
+    ...(!globalCtx.staticContext.metadata?.developmentClient &&
+    globalCtx.staticContext.metadata?.sdkVersion &&
     semver.satisfies(globalCtx.staticContext.metadata?.sdkVersion, '>=52')
       ? [
           eagerBundleBuildFunction().createBuildStepFromFunctionCall(globalCtx, {
@@ -284,7 +287,8 @@ function createStepsForAndroidBuildWithCredentials({
     injectAndroidCredentialsFunction().createBuildStepFromFunctionCall(globalCtx),
     configureAndroidVersionFunction().createBuildStepFromFunctionCall(globalCtx),
     runGradle,
-    ...(globalCtx.staticContext.metadata?.sdkVersion &&
+    ...(!globalCtx.staticContext.metadata?.developmentClient &&
+    globalCtx.staticContext.metadata?.sdkVersion &&
     semver.satisfies(globalCtx.staticContext.metadata?.sdkVersion, '>=52')
       ? [
           eagerBundleBuildFunction().createBuildStepFromFunctionCall(globalCtx, {

--- a/packages/build-tools/src/steps/functions/eagerBundle.ts
+++ b/packages/build-tools/src/steps/functions/eagerBundle.ts
@@ -40,7 +40,10 @@ export function eagerBundleBuildFunction(): BuildFunction {
         env: {
           ...env,
           ...(resolvedEASUpdateRuntimeVersion
-            ? { EXPO_UPDATES_FINGERPRINT_OVERRIDE: resolvedEASUpdateRuntimeVersion }
+            ? {
+                EXPO_UPDATES_FINGERPRINT_OVERRIDE: resolvedEASUpdateRuntimeVersion,
+                EXPO_UPDATES_WORKFLOW_OVERRIDE: stepsCtx.global.staticContext.job.type,
+              }
             : null),
         },
         packageManager,


### PR DESCRIPTION
# Why

https://exponent-internal.slack.com/archives/C017N0N99RA/p1736460082340769

# How

If `ctx.metadata?.developmentClient` is true, skip running the phase

# Test Plan

Tests
