### PR TITLE
[build-tools] add env var to skip expo doctor check

### DIFF
--- a/packages/build-tools/src/common/setup.ts
+++ b/packages/build-tools/src/common/setup.ts
@@ -89,7 +89,7 @@ export async function setupAsync<TJob extends BuildJob>(ctx: BuildContext<TJob>)
   }
 
   const hasExpoPackage = !!packageJson.dependencies?.expo;
-  if (hasExpoPackage) {
+  if (!ctx.env.EAS_BUILD_DISABLE_EXPO_DOCTOR_STEP && hasExpoPackage) {
     await ctx.runBuildPhase(BuildPhase.RUN_EXPO_DOCTOR, async () => {
       try {
         const { stdout } = await runExpoDoctor(ctx);


### PR DESCRIPTION
# Why

https://exponent-internal.slack.com/archives/C017N0N99RA/p1736458086386249

# How

Add env var which disabled this check if set
