### PR TITLE
[steps] Allow all values to `steps.with`

### DIFF
--- a/packages/eas-build-job/src/__tests__/step.test.ts
+++ b/packages/eas-build-job/src/__tests__/step.test.ts
@@ -33,6 +33,8 @@ describe('StepZ', () => {
           key2: ['value1'],
         },
         arg4: '${{ steps.step1.outputs.test }}',
+        arg5: true,
+        arg6: [1, 2, 3],
       },
     };
     expect(StepZ.parse(step)).toEqual(step);

--- a/packages/eas-build-job/src/step.ts
+++ b/packages/eas-build-job/src/step.ts
@@ -70,7 +70,7 @@ export const FunctionStepZ = CommonStepZ.extend({
    *      - value1
    *   arg4: ${{ steps.step1.outputs.test }}
    */
-  with: z.record(z.union([z.string(), z.number(), z.record(z.any())], z.boolean())).optional(),
+  with: z.record(z.unknown()).optional(),
 
   run: z.never().optional(),
   shell: z.never().optional(),

--- a/packages/steps/src/BuildConfig.ts
+++ b/packages/steps/src/BuildConfig.ts
@@ -7,11 +7,7 @@ import YAML from 'yaml';
 
 import { BuildConfigError, BuildWorkflowError } from './errors.js';
 import { BuildRuntimePlatform } from './BuildRuntimePlatform.js';
-import {
-  BuildStepInputValueTypeWithRequired,
-  BuildStepInputValueTypeName,
-  BuildStepInputValueType,
-} from './BuildStepInput.js';
+import { BuildStepInputValueTypeName, BuildStepInputValueType } from './BuildStepInput.js';
 import { BuildStepEnv } from './BuildStepEnv.js';
 import { BUILD_STEP_OR_BUILD_GLOBAL_CONTEXT_REFERENCE_REGEX } from './utils/template.js';
 
@@ -57,7 +53,7 @@ export type BuildFunctionCallConfig = {
   if?: string;
 };
 
-export type BuildStepInputs = Record<string, BuildStepInputValueTypeWithRequired>;
+export type BuildStepInputs = Record<string, unknown>;
 export type BuildStepOutputs = (
   | string
   | {

--- a/packages/steps/src/BuildFunction.ts
+++ b/packages/steps/src/BuildFunction.ts
@@ -3,13 +3,13 @@ import assert from 'assert';
 import { BuildRuntimePlatform } from './BuildRuntimePlatform.js';
 import { BuildStep, BuildStepFunction } from './BuildStep.js';
 import { BuildStepGlobalContext } from './BuildStepContext.js';
-import { BuildStepInputProvider, BuildStepInputValueTypeWithRequired } from './BuildStepInput.js';
+import { BuildStepInputProvider } from './BuildStepInput.js';
 import { BuildStepOutputProvider } from './BuildStepOutput.js';
 import { BuildStepEnv } from './BuildStepEnv.js';
 import { createCustomFunctionCall } from './utils/customFunction.js';
 
 export type BuildFunctionById = Record<string, BuildFunction>;
-export type BuildFunctionCallInputs = Record<string, BuildStepInputValueTypeWithRequired>;
+export type BuildFunctionCallInputs = Record<string, unknown>;
 
 export class BuildFunction {
   public readonly namespace?: string;

--- a/packages/steps/src/BuildStepInput.ts
+++ b/packages/steps/src/BuildStepInput.ts
@@ -246,7 +246,7 @@ export class BuildStepInput<
     }
   }
 
-  private parseInputValueToObject(value: string): Record<string, any> {
+  private parseInputValueToObject(value: string): unknown {
     try {
       return JSON.parse(value);
     } catch (e: any) {

--- a/packages/steps/src/BuildStepInput.ts
+++ b/packages/steps/src/BuildStepInput.ts
@@ -246,7 +246,7 @@ export class BuildStepInput<
     }
   }
 
-  private parseInputValueToObject(value: string): unknown {
+  private parseInputValueToObject(value: string): Record<string, any> {
     try {
       return JSON.parse(value);
     } catch (e: any) {


### PR DESCRIPTION
# Why

Currently, it seems the union fails to accept booleans, because `z.boolean()` is outside of the array literal.

# How

Replaced explicit schema with `z.unknown()`, thus letting the build step input parser validate the params (which afaik can be `json`, so anything `JSON.parse` can output).

After this is merged, going to update `eas-build-job` in `www` and change `with` definition in `WorkflowCustomJob`.

---

I also decided to replace some more "type assumptions" to `unknown`. So far our types were often very optimistic, e.g. that a build step input (the one we get from the user) will only ever be of the right type. I've changed that to `unknown` and more type changes needed to follow. Fortunately, those are only type changes (there is [_one_ code change](https://github.com/expo/eas-build/pull/490/files#diff-5dce43c6bc6a8d5435521a29218e8a4d3f70c68c8c73bd88083857a6e5d334e9R110)).


# Test Plan

Adjusted tests.