### PR TITLE
[eas-build-job] Allow `steps` in build jobs

### DIFF
--- a/packages/build-tools/src/builders/custom.ts
+++ b/packages/build-tools/src/builders/custom.ts
@@ -1,5 +1,7 @@
+import assert from 'assert';
 import path from 'path';
 
+import nullthrows from 'nullthrows';
 import { BuildJob, BuildPhase, BuildTrigger, Ios, Platform } from '@expo/eas-build-job';
 import { BuildConfigParser, BuildStepGlobalContext, StepsConfigParser, errors } from '@expo/steps';
 
@@ -25,6 +27,11 @@ export async function runCustomBuildAsync(ctx: BuildContext<BuildJob>): Promise<
     customBuildCtx.updateEnv(ctx.env);
   }
 
+  assert(
+    'steps' in ctx.job || 'customBuildConfig' in ctx.job,
+    'Steps or custom build config path are required in custom jobs'
+  );
+
   const globalContext = new BuildStepGlobalContext(customBuildCtx, false);
   const easFunctions = getEasFunctions(customBuildCtx);
   const easFunctionGroups = getEasFunctionGroups(customBuildCtx);
@@ -39,7 +46,10 @@ export async function runCustomBuildAsync(ctx: BuildContext<BuildJob>): Promise<
         externalFunctionGroups: easFunctionGroups,
         configPath: path.join(
           ctx.getReactNativeProjectDirectory(customBuildCtx.projectSourceDirectory),
-          ctx.job.customBuildConfig.path
+          nullthrows(
+            ctx.job.customBuildConfig?.path,
+            'Steps or custom build config path are required in custom jobs'
+          )
         ),
       });
   const workflow = await ctx.runBuildPhase(BuildPhase.PARSE_CUSTOM_WORKFLOW_CONFIG, async () => {

--- a/packages/build-tools/src/builders/custom.ts
+++ b/packages/build-tools/src/builders/custom.ts
@@ -2,7 +2,6 @@ import path from 'path';
 
 import { BuildJob, BuildPhase, BuildTrigger, Ios, Platform } from '@expo/eas-build-job';
 import { BuildConfigParser, BuildStepGlobalContext, StepsConfigParser, errors } from '@expo/steps';
-import nullthrows from 'nullthrows';
 
 import { Artifacts, BuildContext } from '../context';
 import { prepareProjectSourcesAsync } from '../common/projectSources';
@@ -26,26 +25,21 @@ export async function runCustomBuildAsync(ctx: BuildContext<BuildJob>): Promise<
     customBuildCtx.updateEnv(ctx.env);
   }
 
-  const customBuildConfig = nullthrows(
-    ctx.job.customBuildConfig,
-    'Custom build config must be defined for custom builds'
-  );
-
   const globalContext = new BuildStepGlobalContext(customBuildCtx, false);
   const easFunctions = getEasFunctions(customBuildCtx);
   const easFunctionGroups = getEasFunctionGroups(customBuildCtx);
-  const parser = customBuildConfig.steps
+  const parser = ctx.job.steps
     ? new StepsConfigParser(globalContext, {
         externalFunctions: easFunctions,
         externalFunctionGroups: easFunctionGroups,
-        steps: customBuildConfig.steps,
+        steps: ctx.job.steps,
       })
     : new BuildConfigParser(globalContext, {
         externalFunctions: easFunctions,
         externalFunctionGroups: easFunctionGroups,
         configPath: path.join(
           ctx.getReactNativeProjectDirectory(customBuildCtx.projectSourceDirectory),
-          customBuildConfig.path
+          ctx.job.customBuildConfig.path
         ),
       });
   const workflow = await ctx.runBuildPhase(BuildPhase.PARSE_CUSTOM_WORKFLOW_CONFIG, async () => {

--- a/packages/build-tools/src/generic.ts
+++ b/packages/build-tools/src/generic.ts
@@ -2,13 +2,7 @@ import fs from 'fs';
 import path from 'path';
 
 import { BuildPhase, Generic } from '@expo/eas-build-job';
-import {
-  BuildConfigParser,
-  BuildStepGlobalContext,
-  BuildWorkflow,
-  errors,
-  StepsConfigParser,
-} from '@expo/steps';
+import { BuildStepGlobalContext, BuildWorkflow, errors, StepsConfigParser } from '@expo/steps';
 import { Result, asyncResult } from '@expo/results';
 
 import { BuildContext } from './context';
@@ -30,20 +24,11 @@ export async function runGenericJobAsync(
 
   const globalContext = new BuildStepGlobalContext(customBuildCtx, false);
 
-  const parser = ctx.job.steps
-    ? new StepsConfigParser(globalContext, {
-        externalFunctions: getEasFunctions(customBuildCtx),
-        externalFunctionGroups: getEasFunctionGroups(customBuildCtx),
-        steps: ctx.job.steps,
-      })
-    : new BuildConfigParser(globalContext, {
-        externalFunctions: getEasFunctions(customBuildCtx),
-        externalFunctionGroups: getEasFunctionGroups(customBuildCtx),
-        configPath: path.join(
-          customBuildCtx.projectSourceDirectory,
-          ctx.job.customBuildConfig.path
-        ),
-      });
+  const parser = new StepsConfigParser(globalContext, {
+    externalFunctions: getEasFunctions(customBuildCtx),
+    externalFunctionGroups: getEasFunctionGroups(customBuildCtx),
+    steps: ctx.job.steps,
+  });
 
   const workflow = await ctx.runBuildPhase(BuildPhase.PARSE_CUSTOM_WORKFLOW_CONFIG, async () => {
     try {

--- a/packages/eas-build-job/src/__tests__/android.test.ts
+++ b/packages/eas-build-job/src/__tests__/android.test.ts
@@ -246,17 +246,15 @@ describe('Android.JobSchema', () => {
         url: 'https://expo.dev/builds/123',
       },
       projectRootDirectory: '.',
-      customBuildConfig: {
-        steps: [
-          {
-            id: 'step1',
-            name: 'Step 1',
-            run: 'echo Hello, world!',
-            shell: 'sh',
-          },
-        ],
-        outputs: {},
-      },
+      steps: [
+        {
+          id: 'step1',
+          name: 'Step 1',
+          run: 'echo Hello, world!',
+          shell: 'sh',
+        },
+      ],
+      outputs: {},
       initiatingUserId: randomUUID(),
       appId: randomUUID(),
       workflowInterpolationContext: {

--- a/packages/eas-build-job/src/__tests__/android.test.ts
+++ b/packages/eas-build-job/src/__tests__/android.test.ts
@@ -259,6 +259,28 @@ describe('Android.JobSchema', () => {
       },
       initiatingUserId: randomUUID(),
       appId: randomUUID(),
+      workflowInterpolationContext: {
+        after: {
+          setup: {
+            status: 'success',
+            outputs: {},
+          },
+        },
+        needs: {
+          setup: {
+            status: 'success',
+            outputs: {},
+          },
+        },
+        github: {
+          event_name: 'push',
+          sha: '123',
+          ref: 'master',
+          ref_name: 'master',
+          ref_type: 'branch',
+        },
+        env: { EXPO_TOKEN: randomUUID() },
+      },
     };
 
     const { value, error } = Android.JobSchema.validate(customBuildJob, joiOptions);

--- a/packages/eas-build-job/src/__tests__/android.test.ts
+++ b/packages/eas-build-job/src/__tests__/android.test.ts
@@ -214,7 +214,7 @@ describe('Android.JobSchema', () => {
     expect(error?.message).toBe('"buildProfile" is required');
   });
 
-  test('valid custom build job', () => {
+  test('valid custom build job with path', () => {
     const customBuildJob = {
       mode: BuildMode.CUSTOM,
       type: Workflow.UNKNOWN,
@@ -226,6 +226,36 @@ describe('Android.JobSchema', () => {
       projectRootDirectory: '.',
       customBuildConfig: {
         path: 'production.android.yml',
+      },
+      initiatingUserId: randomUUID(),
+      appId: randomUUID(),
+    };
+
+    const { value, error } = Android.JobSchema.validate(customBuildJob, joiOptions);
+    expect(value).toMatchObject(customBuildJob);
+    expect(error).toBeFalsy();
+  });
+
+  test('valid custom build job with steps', () => {
+    const customBuildJob = {
+      mode: BuildMode.CUSTOM,
+      type: Workflow.UNKNOWN,
+      platform: Platform.ANDROID,
+      projectArchive: {
+        type: ArchiveSourceType.URL,
+        url: 'https://expo.dev/builds/123',
+      },
+      projectRootDirectory: '.',
+      customBuildConfig: {
+        steps: [
+          {
+            id: 'step1',
+            name: 'Step 1',
+            run: 'echo Hello, world!',
+            shell: 'sh',
+          },
+        ],
+        outputs: {},
       },
       initiatingUserId: randomUUID(),
       appId: randomUUID(),

--- a/packages/eas-build-job/src/__tests__/generic.test.ts
+++ b/packages/eas-build-job/src/__tests__/generic.test.ts
@@ -12,9 +12,14 @@ describe('Generic.JobZ', () => {
         gitCommitHash: '1234567890',
         gitRef: null,
       },
-      customBuildConfig: {
-        path: 'path/to/custom-build-config.yml',
-      },
+      steps: [
+        {
+          id: 'step1',
+          name: 'Step 1',
+          run: 'echo Hello, world!',
+          shell: 'sh',
+        },
+      ],
       secrets: {
         robotAccessToken: 'token',
         environmentSecrets: [
@@ -84,7 +89,7 @@ describe('Generic.JobZ', () => {
     expect(Generic.JobZ.parse(job)).toEqual(job);
   });
 
-  it('errors when neither customBuildConfig.path nor steps are provided', () => {
+  it('errors when steps are not provided', () => {
     const job: Omit<Generic.Job, 'customBuildConfig' | 'steps'> = {
       projectArchive: {
         type: ArchiveSourceType.GIT,
@@ -111,56 +116,6 @@ describe('Generic.JobZ', () => {
         },
       },
       triggeredBy: BuildTrigger.GIT_BASED_INTEGRATION,
-      appId: randomUUID(),
-      initiatingUserId: randomUUID(),
-    };
-    expect(() => Generic.JobZ.parse(job)).toThrow('Invalid input');
-  });
-
-  it('errors when both customBuildConfig.path and steps are provided', () => {
-    const job: Omit<Generic.Job, 'customBuildConfig' | 'steps'> & {
-      customBuildConfig: NonNullable<Generic.Job['customBuildConfig']>;
-      steps: NonNullable<Generic.Job['steps']>;
-    } = {
-      projectArchive: {
-        type: ArchiveSourceType.GIT,
-        repositoryUrl: 'https://github.com/expo/expo.git',
-        gitCommitHash: '1234567890',
-        gitRef: null,
-      },
-      secrets: {
-        robotAccessToken: 'token',
-        environmentSecrets: [
-          {
-            name: 'secret-name',
-            value: 'secret-value',
-            type: EnvironmentSecretType.STRING,
-          },
-        ],
-      },
-      expoDevUrl: 'https://expo.dev/accounts/name/builds/id',
-      builderEnvironment: {
-        image: 'macos-sonoma-14.5-xcode-15.4',
-        node: '20.15.1',
-        env: {
-          KEY1: 'value1',
-        },
-      },
-      triggeredBy: BuildTrigger.GIT_BASED_INTEGRATION,
-      customBuildConfig: {
-        path: 'path/to/custom-build-config.yml',
-      },
-      steps: [
-        {
-          id: 'step1',
-          name: 'Step 1',
-          run: 'echo Hello, world!',
-          shell: 'sh',
-          env: {
-            KEY1: 'value1',
-          },
-        },
-      ],
       appId: randomUUID(),
       initiatingUserId: randomUUID(),
     };

--- a/packages/eas-build-job/src/__tests__/generic.test.ts
+++ b/packages/eas-build-job/src/__tests__/generic.test.ts
@@ -1,5 +1,7 @@
 import { randomUUID } from 'crypto';
 
+import { ZodError } from 'zod';
+
 import { ArchiveSourceType, BuildTrigger, EnvironmentSecretType } from '../common';
 import { Generic } from '../generic';
 
@@ -119,6 +121,6 @@ describe('Generic.JobZ', () => {
       appId: randomUUID(),
       initiatingUserId: randomUUID(),
     };
-    expect(() => Generic.JobZ.parse(job)).toThrow('Invalid input');
+    expect(() => Generic.JobZ.parse(job)).toThrow(ZodError);
   });
 });

--- a/packages/eas-build-job/src/__tests__/ios.test.ts
+++ b/packages/eas-build-job/src/__tests__/ios.test.ts
@@ -139,17 +139,15 @@ describe('Ios.JobSchema', () => {
         url: 'https://expo.dev/builds/123',
       },
       projectRootDirectory: '.',
-      customBuildConfig: {
-        steps: [
-          {
-            id: 'step1',
-            name: 'Step 1',
-            run: 'echo Hello, world!',
-            shell: 'sh',
-          },
-        ],
-        outputs: {},
-      },
+      steps: [
+        {
+          id: 'step1',
+          name: 'Step 1',
+          run: 'echo Hello, world!',
+          shell: 'sh',
+        },
+      ],
+      outputs: {},
       initiatingUserId: randomUUID(),
       appId: randomUUID(),
       workflowInterpolationContext: {

--- a/packages/eas-build-job/src/__tests__/ios.test.ts
+++ b/packages/eas-build-job/src/__tests__/ios.test.ts
@@ -152,6 +152,28 @@ describe('Ios.JobSchema', () => {
       },
       initiatingUserId: randomUUID(),
       appId: randomUUID(),
+      workflowInterpolationContext: {
+        after: {
+          setup: {
+            status: 'success',
+            outputs: {},
+          },
+        },
+        needs: {
+          setup: {
+            status: 'success',
+            outputs: {},
+          },
+        },
+        github: {
+          event_name: 'push',
+          sha: '123',
+          ref: 'master',
+          ref_name: 'master',
+          ref_type: 'branch',
+        },
+        env: { EXPO_TOKEN: randomUUID() },
+      },
     };
 
     const { value, error } = Ios.JobSchema.validate(customBuildJob, joiOptions);

--- a/packages/eas-build-job/src/__tests__/ios.test.ts
+++ b/packages/eas-build-job/src/__tests__/ios.test.ts
@@ -129,6 +129,36 @@ describe('Ios.JobSchema', () => {
     expect(error).toBeFalsy();
   });
 
+  test('valid custom build job with steps', () => {
+    const customBuildJob = {
+      mode: BuildMode.CUSTOM,
+      type: Workflow.UNKNOWN,
+      platform: Platform.IOS,
+      projectArchive: {
+        type: ArchiveSourceType.URL,
+        url: 'https://expo.dev/builds/123',
+      },
+      projectRootDirectory: '.',
+      customBuildConfig: {
+        steps: [
+          {
+            id: 'step1',
+            name: 'Step 1',
+            run: 'echo Hello, world!',
+            shell: 'sh',
+          },
+        ],
+        outputs: {},
+      },
+      initiatingUserId: randomUUID(),
+      appId: randomUUID(),
+    };
+
+    const { value, error } = Ios.JobSchema.validate(customBuildJob, joiOptions);
+    expect(value).toMatchObject(customBuildJob);
+    expect(error).toBeFalsy();
+  });
+
   test('invalid generic job', () => {
     const genericJob = {
       secrets: {

--- a/packages/eas-build-job/src/android.ts
+++ b/packages/eas-build-job/src/android.ts
@@ -14,6 +14,8 @@ import {
   EnvironmentSecret,
   BuildTrigger,
   BuildMode,
+  StaticWorkflowInterpolationContextZ,
+  StaticWorkflowInterpolationContext,
 } from './common';
 import { Step, validateSteps } from './step';
 
@@ -120,7 +122,7 @@ export interface Job {
   };
   loggerLevel?: LoggerLevel;
 
-  workflowInterpolationContext?: never;
+  workflowInterpolationContext?: StaticWorkflowInterpolationContext;
 
   initiatingUserId: string;
   appId: string;
@@ -209,4 +211,8 @@ export const JobSchema = Joi.object({
   appId: Joi.string().required(),
 
   environment: Joi.string().valid('production', 'preview', 'development'),
+
+  workflowInterpolationContext: Joi.object().custom((workflowInterpolationContext) =>
+    StaticWorkflowInterpolationContextZ.optional().parse(workflowInterpolationContext)
+  ),
 });

--- a/packages/eas-build-job/src/android.ts
+++ b/packages/eas-build-job/src/android.ts
@@ -17,9 +17,8 @@ import {
   StaticWorkflowInterpolationContextZ,
   StaticWorkflowInterpolationContext,
   CustomBuildConfigSchema,
-  JobWithCustomBuildConfig,
-  JobWithSteps,
 } from './common';
+import { Step } from './step';
 
 export interface Keystore {
   dataBase64: string;
@@ -68,7 +67,7 @@ export interface BuildSecrets {
   robotAccessToken?: string;
 }
 
-interface IJob {
+export interface Job {
   mode: BuildMode;
   type: Workflow;
   triggeredBy: BuildTrigger;
@@ -102,6 +101,12 @@ interface IJob {
   buildType?: BuildType;
   username?: string;
 
+  customBuildConfig?: {
+    path: string;
+  };
+  steps?: Step[];
+  outputs?: Record<string, string>;
+
   experimental?: {
     prebuildCommand?: string;
   };
@@ -119,8 +124,6 @@ interface IJob {
 
   environment?: 'production' | 'preview' | 'development';
 }
-
-export type Job = IJob & (JobWithCustomBuildConfig | JobWithSteps);
 
 const SecretsSchema = Joi.object({
   buildCredentials: Joi.object({ keystore: KeystoreSchema.required() }),

--- a/packages/eas-build-job/src/common.ts
+++ b/packages/eas-build-job/src/common.ts
@@ -2,7 +2,7 @@ import Joi from 'joi';
 import { z } from 'zod';
 
 import { BuildPhase, BuildPhaseResult } from './logs';
-import { Step, validateSteps } from './step';
+import { validateSteps } from './step';
 
 export enum BuildMode {
   BUILD = 'build',
@@ -210,26 +210,6 @@ export type DynamicInterpolationContext = {
 
 export type WorkflowInterpolationContext = StaticWorkflowInterpolationContext &
   DynamicInterpolationContext;
-
-export interface JobWithCustomBuildConfig {
-  mode: BuildMode.CUSTOM;
-
-  customBuildConfig: {
-    path: string;
-  };
-
-  steps?: never;
-  outputs?: never;
-}
-
-export interface JobWithSteps {
-  mode: BuildMode.CUSTOM;
-
-  customBuildConfig?: never;
-
-  steps: Step[];
-  outputs: Record<string, string>;
-}
 
 export const CustomBuildConfigSchema = Joi.object().when('.mode', {
   is: BuildMode.CUSTOM,

--- a/packages/eas-build-job/src/generic.ts
+++ b/packages/eas-build-job/src/generic.ts
@@ -25,7 +25,8 @@ export namespace Generic {
     cocoapods: z.string().optional(),
   });
 
-  const CommonJobZ = z.object({
+  export type Job = z.infer<typeof JobZ>;
+  export const JobZ = z.object({
     projectArchive: ArchiveSourceSchemaZ,
     secrets: z.object({
       robotAccessToken: z.string(),
@@ -42,25 +43,11 @@ export namespace Generic {
 
     initiatingUserId: z.string(),
     appId: z.string(),
-  });
 
-  const PathJobZ = CommonJobZ.extend({
-    customBuildConfig: z.object({
-      path: z.string(),
-    }),
-    steps: z.never().optional(),
-    outputs: z.never().optional(),
-  });
-
-  const StepsJobZ = CommonJobZ.extend({
-    customBuildConfig: z.never().optional(),
     steps: z.array(StepZ).min(1),
     outputs: z.record(z.string()).optional(),
   });
 
-  export type Job = z.infer<typeof JobZ>;
-  export const JobZ = z.union([PathJobZ, StepsJobZ]);
-
   export type PartialJob = z.infer<typeof PartialJobZ>;
-  export const PartialJobZ = z.union([PathJobZ.partial(), StepsJobZ.partial()]);
+  export const PartialJobZ = JobZ.partial();
 }

--- a/packages/eas-build-job/src/ios.ts
+++ b/packages/eas-build-job/src/ios.ts
@@ -15,6 +15,7 @@ import {
   BuildTrigger,
   BuildMode,
 } from './common';
+import { Step, validateSteps } from './step';
 
 export type DistributionType = 'store' | 'internal' | 'simulator';
 
@@ -111,9 +112,17 @@ export interface Job {
 
   username?: string;
 
-  customBuildConfig?: {
-    path: string;
-  };
+  customBuildConfig?:
+    | {
+        path: string;
+        steps?: never;
+        outputs?: never;
+      }
+    | {
+        path?: never;
+        steps: Step[];
+        outputs: Record<string, string>;
+      };
 
   experimental?: {
     prebuildCommand?: string;
@@ -201,8 +210,21 @@ export const JobSchema = Joi.object({
 
   customBuildConfig: Joi.when('mode', {
     is: Joi.string().valid(BuildMode.CUSTOM),
-    then: Joi.object({
-      path: Joi.string(),
+    then: Joi.when('customBuildConfig.path', {
+      is: Joi.string().required(),
+      then: Joi.object({
+        path: Joi.string().required(),
+        steps: Joi.forbidden(),
+        outputs: Joi.forbidden(),
+      }),
+      otherwise: Joi.object({
+        path: Joi.forbidden(),
+        steps: Joi.array()
+          .items(Joi.any())
+          .required()
+          .custom((steps) => validateSteps(steps), 'steps validation'),
+        outputs: Joi.object().pattern(Joi.string(), Joi.string()).required(),
+      }),
     }).required(),
     otherwise: Joi.any().strip(),
   }),

--- a/packages/eas-build-job/src/ios.ts
+++ b/packages/eas-build-job/src/ios.ts
@@ -17,9 +17,8 @@ import {
   StaticWorkflowInterpolationContextZ,
   StaticWorkflowInterpolationContext,
   CustomBuildConfigSchema,
-  JobWithCustomBuildConfig,
-  JobWithSteps,
 } from './common';
+import { Step } from './step';
 
 export type DistributionType = 'store' | 'internal' | 'simulator';
 
@@ -78,7 +77,7 @@ export interface BuildSecrets {
   robotAccessToken?: string;
 }
 
-interface IJob {
+export interface Job {
   mode: BuildMode;
   type: Workflow;
   triggeredBy: BuildTrigger;
@@ -116,6 +115,12 @@ interface IJob {
 
   username?: string;
 
+  customBuildConfig?: {
+    path: string;
+  };
+  steps?: Step[];
+  outputs?: Record<string, string>;
+
   experimental?: {
     prebuildCommand?: string;
   };
@@ -133,8 +138,6 @@ interface IJob {
 
   environment?: 'production' | 'preview' | 'development';
 }
-
-export type Job = IJob & (JobWithCustomBuildConfig | JobWithSteps);
 
 const SecretsSchema = Joi.object({
   buildCredentials: BuildCredentialsSchema,

--- a/packages/eas-build-job/src/ios.ts
+++ b/packages/eas-build-job/src/ios.ts
@@ -14,6 +14,8 @@ import {
   EnvironmentSecret,
   BuildTrigger,
   BuildMode,
+  StaticWorkflowInterpolationContextZ,
+  StaticWorkflowInterpolationContext,
 } from './common';
 import { Step, validateSteps } from './step';
 
@@ -134,7 +136,7 @@ export interface Job {
   };
   loggerLevel?: LoggerLevel;
 
-  workflowInterpolationContext?: never;
+  workflowInterpolationContext?: StaticWorkflowInterpolationContext;
 
   initiatingUserId: string;
   appId: string;
@@ -243,4 +245,8 @@ export const JobSchema = Joi.object({
   appId: Joi.string().required(),
 
   environment: Joi.string().valid('production', 'preview', 'development'),
+
+  workflowInterpolationContext: Joi.object().custom((workflowInterpolationContext) =>
+    StaticWorkflowInterpolationContextZ.optional().parse(workflowInterpolationContext)
+  ),
 });


### PR DESCRIPTION
# Why

For workflows it'll be much easier to let users define `steps` in the workflow file instead of having to do the custom build config and stuff.

# How

Added ability to pass `steps` in build jobs. Alongside, we need to send `workflowInteprolationContext`, so added that too.

# Test Plan

Tested manually by running both manual and GitHub workflow build jobs. Also ran a custom build and a regular build from `eas-cli`.