### PR TITLE
[build-tools] don't override __EXPO_RELATIVE_BASE_DIRECTORY env var when running eas build:internal

### DIFF
--- a/packages/build-tools/src/context.ts
+++ b/packages/build-tools/src/context.ts
@@ -250,6 +250,14 @@ export class BuildContext<TJob extends Job = Job> {
     this._job = {
       ...job,
       triggeredBy: this._job.triggeredBy,
+      builderEnvironment: {
+        ...job.builderEnvironment,
+        env: {
+          ...job.builderEnvironment?.env,
+          __EXPO_RELATIVE_BASE_DIRECTORY:
+            this.job.builderEnvironment?.env?.__EXPO_RELATIVE_BASE_DIRECTORY,
+        },
+      },
       secrets: {
         ...this.job.secrets,
         ...job.secrets,


### PR DESCRIPTION
# Why

https://discord.com/channels/695411232856997968/1328498879930433606/1329125958006870048

# How

It seems like this env is used for workflow builds in ctx.getReactNativeDirectory which is used to determine the package manager. Overriding this env var resulted in setting getReactNativeDirectory result to root working dir and causing the build to fail.

https://github.com/expo/eas-build/blob/4c6aaaaaff93755662e0ac9534c9efcf5eb2afa5/packages/build-tools/src/context.ts#L300-L306

https://github.com/expo/eas-build/blob/4c6aaaaaff93755662e0ac9534c9efcf5eb2afa5/packages/build-tools/src/context.ts#L160-L162

# Test Plan

Tests
