### PR TITLE
[build-tools] resolve correct projectRootDirectory during eas build:internal

### DIFF
--- a/packages/build-tools/src/common/easBuildInternal.ts
+++ b/packages/build-tools/src/common/easBuildInternal.ts
@@ -23,11 +23,13 @@ export async function runEasBuildInternalAsync<TJob extends BuildJob>({
   logger,
   env,
   cwd,
+  projectRootOverride,
 }: {
   job: TJob;
   logger: bunyan;
   env: BuildStepEnv;
   cwd: string;
+  projectRootOverride?: string;
 }): Promise<{
   newJob: TJob;
   newMetadata: Metadata;
@@ -64,6 +66,7 @@ export async function runEasBuildInternalAsync<TJob extends BuildJob>({
           EXPO_TOKEN: nullthrows(job.secrets, 'Secrets must be defined for non-custom builds')
             .robotAccessToken,
           ...extraEnv,
+          EAS_PROJECT_ROOT: projectRootOverride,
         },
         logger,
         mode: PipeMode.STDERR_ONLY_AS_STDOUT,

--- a/packages/build-tools/src/common/setup.ts
+++ b/packages/build-tools/src/common/setup.ts
@@ -83,6 +83,7 @@ export async function setupAsync<TJob extends BuildJob>(ctx: BuildContext<TJob>)
         env: ctx.env,
         logger: ctx.logger,
         cwd: ctx.getReactNativeProjectDirectory(),
+        projectRootOverride: ctx.env.EAS_NO_VCS ? ctx.buildDirectory : undefined,
       });
       ctx.updateJobInformation(newJob, newMetadata);
     });

--- a/packages/build-tools/src/steps/functions/resolveBuildConfig.ts
+++ b/packages/build-tools/src/steps/functions/resolveBuildConfig.ts
@@ -37,6 +37,7 @@ export async function resolveBuildConfigAsync({
       env,
       logger,
       cwd: workingDirectory,
+      projectRootOverride: env.EAS_NO_VCS ? ctx.projectTargetDirectory : undefined,
     });
     ctx.updateJobInformation(newJob, newMetadata);
   }


### PR DESCRIPTION
# Why

We resolve incorrect and override `projectRootDirectory` when running `eas build:internal` for GCS builds that use NoVcsClient in EAS CLI as VCS client. Adding `EAS_PROJECT_ROOT` env var should fix it.

# How

Use `EAS_PROJECT_ROOT` env var if `EAS_NO_VCS` is used

# Test Plan

Tests
