### PR TITLE
[steps] Do not print warning about non-defined outputs in step

### DIFF
--- a/packages/steps/src/BuildStep.ts
+++ b/packages/steps/src/BuildStep.ts
@@ -432,31 +432,20 @@ export class BuildStep extends BuildStepOutputAccessor {
   private async collectAndValidateOutputsAsync(outputsDir: string): Promise<void> {
     const files = await fs.readdir(outputsDir);
 
-    const nonDefinedOutputIds: string[] = [];
     for (const outputId of files) {
       if (!(outputId in this.outputById)) {
-        nonDefinedOutputIds.push(outputId);
         const newOutput = new BuildStepOutput(this.ctx.global, {
           id: outputId,
           stepDisplayName: this.displayName,
           required: false,
         });
-        const file = path.join(outputsDir, outputId);
-        const rawContents = await fs.readFile(file, 'utf-8');
-        const value = rawContents.trim();
-        newOutput.set(value);
         this.outputById[outputId] = newOutput;
-      } else {
-        const file = path.join(outputsDir, outputId);
-        const rawContents = await fs.readFile(file, 'utf-8');
-        const value = rawContents.trim();
-        this.outputById[outputId].set(value);
       }
-    }
 
-    if (nonDefinedOutputIds.length > 0) {
-      const idsString = nonDefinedOutputIds.map((i) => `"${i}"`).join(', ');
-      this.ctx.logger.warn(`Some outputs are not defined in step config: ${idsString}`);
+      const file = path.join(outputsDir, outputId);
+      const rawContents = await fs.readFile(file, 'utf-8');
+      const value = rawContents.trim();
+      this.outputById[outputId].set(value);
     }
 
     const nonSetRequiredOutputIds: string[] = [];

--- a/packages/steps/src/__tests__/BuildStep-test.ts
+++ b/packages/steps/src/__tests__/BuildStep-test.ts
@@ -480,30 +480,6 @@ describe(BuildStep, () => {
         expect(abc?.value).toBe('d o m i n i k');
       });
 
-      it('prints a warning if some of the outputs set with set-output are not defined in step config', async () => {
-        const logger = createMockLogger();
-        const warnLines: string[] = [];
-        jest.mocked(logger.warn as any).mockImplementation((line: string) => {
-          warnLines.push(line);
-        });
-        jest.mocked(logger.child).mockReturnValue(logger);
-
-        (baseStepCtx as any).baseLogger = logger;
-
-        const id = 'test1';
-        const command = 'set-output abc 123';
-        const displayName = BuildStep.getDisplayName({ id, command });
-
-        const step = new BuildStep(baseStepCtx, {
-          id,
-          command,
-          displayName,
-        });
-        await step.executeAsync();
-        const found = warnLines.find((l) => l.match(/Some outputs are not defined in step config/));
-        expect(found).not.toBeUndefined();
-      });
-
       it('throws an error if some required outputs have not been set with set-output in script', async () => {
         const id = 'test1';
         const command = 'echo 123';


### PR DESCRIPTION
# Why

https://exponent-internal.slack.com/archives/C06EFBQK3B7/p1737419576613249

# How

Removed warning. Unified logic.

# Test Plan

Removed test.