### PR TITLE
[steps] Do not trim step output value

### DIFF
--- a/packages/steps/bin/set-output
+++ b/packages/steps/bin/set-output
@@ -15,4 +15,8 @@ if [[ -z "$NAME" || -z "$VALUE" ]]; then
   exit 2
 fi
 
-echo $VALUE > $__EXPO_STEPS_OUTPUTS_DIR/$NAME
+if [[ "$OSTYPE" == "linux"* ]]; then
+  echo -n "$VALUE" | base64 -w 0 > $__EXPO_STEPS_OUTPUTS_DIR/$NAME
+else
+  echo -n "$VALUE" | base64 > $__EXPO_STEPS_OUTPUTS_DIR/$NAME
+fi

--- a/packages/steps/src/BuildStep.ts
+++ b/packages/steps/src/BuildStep.ts
@@ -444,8 +444,8 @@ export class BuildStep extends BuildStepOutputAccessor {
 
       const file = path.join(outputsDir, outputId);
       const rawContents = await fs.readFile(file, 'utf-8');
-      const value = rawContents.trim();
-      this.outputById[outputId].set(value);
+      const decodedContents = Buffer.from(rawContents, 'base64').toString('utf-8');
+      this.outputById[outputId].set(decodedContents);
     }
 
     const nonSetRequiredOutputIds: string[] = [];

--- a/packages/steps/src/__tests__/BuildStep-test.ts
+++ b/packages/steps/src/__tests__/BuildStep-test.ts
@@ -343,7 +343,7 @@ describe(BuildStep, () => {
           command,
         });
         await step.executeAsync();
-        expect(step.getOutputValueByName('foo2')).toBe('bar linux {"foo":"bar","baz":[1,"aaa"]}');
+        expect(step.getOutputValueByName('foo2')).toBe('bar  linux {"foo":"bar","baz":[1,"aaa"]}');
       });
 
       it('interpolates the outputs in command template', async () => {


### PR DESCRIPTION
# Why

I think we've been doing `.trim()` on output values because of plain `echo` in `set-output`.

# How

Added `-n` to `echo`, removed `.trim()`. Then changed to use Base64 encoding as we do for environment variables.

# Test Plan

Adjusted test. It was wrong all along! Passing of the rest of existing steps confirms steps work in general, right?