### PR TITLE
[build-tools] skip throwing MAVEN_CACHE_ERROR if Could not find BlurView-version-2.0.3.jar line is present

### DIFF
--- a/packages/build-tools/src/buildErrors/__tests__/detectError.test.ts
+++ b/packages/build-tools/src/buildErrors/__tests__/detectError.test.ts
@@ -249,4 +249,46 @@ note`;
 - The last one
 Refer to "Xcode Logs" below for additional, more detailed logs.`);
   });
+
+  it('detects MAVEN_CACHE_ERROR correctly', async () => {
+    const err = await resolveBuildPhaseErrorAsync(
+      new Error(),
+      [`https://szymon.pl/maven/cache`],
+      {
+        job: { platform: Platform.ANDROID, mode: BuildMode.BUILD } as Job,
+        phase: BuildPhase.RUN_GRADLEW,
+        env: {
+          EAS_BUILD_MAVEN_CACHE_URL: 'https://szymon.pl/maven/cache',
+        },
+      },
+      '/fake/path'
+    );
+
+    expect(err.errorCode).toBe('MAVEN_CACHE_ERROR');
+    expect(err.userFacingErrorCode).toBe('EAS_BUILD_UNKNOWN_GRADLE_ERROR');
+    expect(err.userFacingMessage).toBe(
+      `Gradle build failed with unknown error. See logs for the "Run gradlew" phase for more information.`
+    );
+  });
+
+  it('does not throw MAVEN_CACHE_ERROR if "Could not find BlurView-version-2.0.3.jar" log is present', async () => {
+    const err = await resolveBuildPhaseErrorAsync(
+      new Error(),
+      [`Could not find BlurView-version-2.0.3.jar sth sthelse https://szymon.pl/maven/cache`],
+      {
+        job: { platform: Platform.ANDROID, mode: BuildMode.BUILD } as Job,
+        phase: BuildPhase.RUN_GRADLEW,
+        env: {
+          EAS_BUILD_MAVEN_CACHE_URL: 'https://szymon.pl/maven/cache',
+        },
+      },
+      '/fake/path'
+    );
+
+    expect(err.errorCode).toBe('EAS_BUILD_UNKNOWN_GRADLE_ERROR');
+    expect(err.userFacingErrorCode).toBe('EAS_BUILD_UNKNOWN_GRADLE_ERROR');
+    expect(err.userFacingMessage).toBe(
+      `Gradle build failed with unknown error. See logs for the "Run gradlew" phase for more information.`
+    );
+  });
 });

--- a/packages/build-tools/src/buildErrors/buildErrorHandlers.ts
+++ b/packages/build-tools/src/buildErrors/buildErrorHandlers.ts
@@ -299,7 +299,11 @@ export const buildErrorHandlers: ErrorHandler<TrackedBuildError>[] = [
     phase: BuildPhase.RUN_GRADLEW,
     regexp: ({ env }: ErrorContext) =>
       env.EAS_BUILD_MAVEN_CACHE_URL
-        ? new RegExp(escapeRegExp(env.EAS_BUILD_MAVEN_CACHE_URL))
+        ? new RegExp(
+            `^(?!.*Could not find BlurView-version-2\\.0\\.3\\.jar).*${escapeRegExp(
+              env.EAS_BUILD_MAVEN_CACHE_URL
+            )}`
+          )
         : undefined,
     createError: () => new TrackedBuildError('MAVEN_CACHE_ERROR', `maven: cache error`),
   },


### PR DESCRIPTION
# Why

Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.

# How

How did you build this feature or fix this bug and why?

# Test Plan

Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
