### PR TITLE
Add `groups` to iOS submission config

### DIFF
--- a/packages/eas-build-job/src/submission-config.ts
+++ b/packages/eas-build-job/src/submission-config.ts
@@ -13,6 +13,7 @@ export namespace SubmissionConfig {
          */
         ascAppIdentifier: z.string(),
         isVerboseFastlaneEnabled: z.boolean().optional(),
+        groups: z.array(z.string()).optional(),
       })
       .and(
         z.union([


### PR DESCRIPTION
# Why

[ENG-14634: Add support for `groups` option in `fastlane pilot` call](https://linear.app/expo/issue/ENG-14634/add-support-for-groups-option-in-fastlane-pilot-call)

Allow specifying the `groups` option for `fastlane pilot`. This requires passing the `groups` parameter in the submission config, as Turtle validates submit jobs against this schema.

# How

* Allow passing an optional string array parameter `groups` in iOS submission config.

# Test Plan

Tested manually.
