### PR TITLE
[eas-build-job] Switch `preprocess` to `union+transform`

### DIFF
--- a/packages/eas-build-job/src/step.ts
+++ b/packages/eas-build-job/src/step.ts
@@ -127,19 +127,14 @@ export const ShellStepZ = CommonStepZ.extend({
    */
   outputs: z
     .array(
-      z.preprocess(
-        (input) => {
-          // We allow a shorthand for outputs
-          if (typeof input === 'string') {
-            return { name: input, required: false };
-          }
-          return input;
-        },
+      z.union([
+        // We allow a shorthand for outputs
+        z.string().transform((name) => ({ name, required: false })),
         z.object({
           name: z.string(),
           required: z.boolean().optional(),
-        })
-      )
+        }),
+      ])
     )
     .optional(),
 


### PR DESCRIPTION
# Why

A union works better for generating JSON schema later, because Zod is able to infer better what is the expected input.

# How

Instead of preprocessing input, we're going to transform it after parsing.

# Test Plan

Tests should pass.