### PR TITLE
[ENG-14950][build-tools] replace EAS Secrets with EAS environment variables in error messages

### DIFF
--- a/packages/build-tools/src/buildErrors/userErrorHandlers.ts
+++ b/packages/build-tools/src/buildErrors/userErrorHandlers.ts
@@ -69,8 +69,8 @@ export const userErrorHandlers: ErrorHandler<UserFacingError>[] = [
     createError: () =>
       new UserFacingError(
         'EAS_BUILD_MISSING_GOOGLE_SERVICES_JSON_ERROR',
-        '"google-services.json" is missing, make sure that the file exists. Remember that EAS Build only uploads the files tracked by git. Use EAS secrets to provide EAS Build with the file.',
-        'https://docs.expo.dev/build-reference/variables/#how-to-upload-a-secret-file-and'
+        '"google-services.json" is missing, make sure that the file exists. Remember that EAS Build only uploads the files tracked by git. Use EAS environment variables to provide EAS Build with the file.',
+        'https://docs.expo.dev/eas/environment-variables/#file-environment-variables'
       ),
   },
   {
@@ -84,8 +84,8 @@ export const userErrorHandlers: ErrorHandler<UserFacingError>[] = [
     createError: () =>
       new UserFacingError(
         'EAS_BUILD_MISSING_GOOGLE_SERVICES_JSON_ERROR',
-        '"google-services.json" is missing, make sure that the file exists. Remember that EAS Build only uploads the files tracked by git. Use EAS secrets to provide EAS Build with the file.',
-        'https://docs.expo.dev/build-reference/variables/#how-to-upload-a-secret-file-and'
+        '"google-services.json" is missing, make sure that the file exists. Remember that EAS Build only uploads the files tracked by git. Use EAS environment variables to provide EAS Build with the file.',
+        'https://docs.expo.dev/eas/environment-variables/#file-environment-variables'
       ),
   },
   {
@@ -97,8 +97,8 @@ export const userErrorHandlers: ErrorHandler<UserFacingError>[] = [
     createError: () =>
       new UserFacingError(
         'EAS_BUILD_MISSING_GOOGLE_SERVICES_PLIST_ERROR',
-        '"GoogleService-Info.plist" is missing, make sure that the file exists. Remember that EAS Build only uploads the files tracked by git. Use EAS secrets to provide EAS Build with the file.',
-        'https://docs.expo.dev/build-reference/variables/#how-to-upload-a-secret-file-and'
+        '"GoogleService-Info.plist" is missing, make sure that the file exists. Remember that EAS Build only uploads the files tracked by git. Use EAS environment variables to provide EAS Build with the file.',
+        'https://docs.expo.dev/eas/environment-variables/#file-environment-variables'
       ),
   },
   {

--- a/packages/build-tools/src/common/setup.ts
+++ b/packages/build-tools/src/common/setup.ts
@@ -227,7 +227,7 @@ async function validateAppConfigAsync(
       extraMessage = 'Make sure you connected your GitHub repository to the correct Expo project. ';
     } else if (isUsingDynamicConfig) {
       extraMessage =
-        'If you are using environment variables to switch between projects in app.config.js/app.config.ts, make sure those variables are also set inside EAS Build. You can do that using "env" field in eas.json or EAS Secrets. ';
+        'If you are using environment variables to switch between projects in app.config.js/app.config.ts, make sure those variables are also set inside EAS Build. You can do that using "env" field in eas.json or EAS environment variables. ';
     }
     throw new UserFacingError(
       'EAS_BUILD_PROJECT_ID_MISMATCH',

--- a/packages/build-tools/src/steps/utils/expoUpdates.ts
+++ b/packages/build-tools/src/steps/utils/expoUpdates.ts
@@ -40,7 +40,7 @@ export async function configureEASUpdateAsync({
       `Runtime version from the app config evaluated on your local machine (${metadata.runtimeVersion}) does not match the one resolved here (${runtimeVersion}).`
     );
     logger.warn(
-      "If you're using conditional app configs, e.g. depending on an environment variable, make sure to set the variable in eas.json or configure it with EAS Secret."
+      "If you're using conditional app configs, e.g. depending on an environment variable, make sure to set the variable in eas.json or configure it with EAS environment variables."
     );
   }
 


### PR DESCRIPTION
# Why

https://linear.app/expo/issue/ENG-14950/update-failure-message-to-account-for-eas-variables-rather-than

# How

Replace EAS Secrets in error messages with EAS environment variables

# Test Plan

Tests
