### PR TITLE
feat: allow to enable abi splitting via env var for local builds

### DIFF
--- a/packages/build-tools/templates/eas-build.gradle
+++ b/packages/build-tools/templates/eas-build.gradle
@@ -51,4 +51,29 @@ android {
       signingConfig android.signingConfigs.release
     }
   }
+
+  // Dynamic ABI Splitting Configuration
+  def enableAbiSplittingEnv = System.getenv("EAS_BUILD_ENABLE_ABI_SPLITTING")
+  boolean enableAbiSplitting = "true".equalsIgnoreCase(enableAbiSplittingEnv)
+
+  if (enableAbiSplitting) {
+    def abiListEnv = System.getenv("EAS_BUILD_ABI_LIST")
+    List<String> abiListToInclude = []
+
+    if (abiListEnv) {
+      abiListToInclude = abiListEnv.split(',').collect { it.trim() } // Split by comma and trim whitespace
+    } else {
+      // Default ABI list if EAS_BUILD_ABI_LIST is not set
+      abiListToInclude = ['armeabi-v7a', 'arm64-v8a', 'x86', 'x86_64']
+    }
+
+    splits {
+      abi {
+        enable true
+        reset()
+        include abiListToInclude as String[]
+        universalApk false
+      }
+    }
+  }
 }


### PR DESCRIPTION
- `EAS_BUILD_ENABLE_ABI_SPLITTING` enables abi splitting for all abis
- `EAS_BUILD_ABI_LIST` lets you select which abis to build (e.g. "armeabi-v7a,arm64-v8a"

# Why

In the early phases of development (especially in hobby projects), you end up sending around your apks quite a bit.
The more features you add, the bigger your apks become and it is quite cumbersome to send them around easily.

Abi splitting helps in that regard by only including the abi that is needed.

It was also requested here: https://expo.canny.io/feature-requests/p/build-only-one-abi-during-development-android-only

# How

I edited the gradle file to include an abi split section when some env vars are set

# Test Plan

Simply pass the corresponding env vars in your eas.json:

```
    "preview": {
      "distribution": "internal",
      "env": {
        "EAS_BUILD_ENABLE_ABI_SPLITTING": "true",
        "EAS_BUILD_ABI_LIST": "armeabi-v7a,arm64-v8a" // optional. Will build all abis by default
      }
    },
```

And then do a local build. When only using a single abi, the resulting apk should be places as usual into your output dir. When specifying multple abis, a tar.gz package with all abis is created instead