### PR TITLE
Add eas/download_build function

### DIFF
--- a/packages/build-tools/src/steps/easFunctions.ts
+++ b/packages/build-tools/src/steps/easFunctions.ts
@@ -28,6 +28,7 @@ import { calculateEASUpdateRuntimeVersionFunction } from './functions/calculateE
 import { createRepackBuildFunction } from './functions/repack';
 import { eagerBundleBuildFunction } from './functions/eagerBundle';
 import { createSubmissionEntityFunction } from './functions/createSubmissionEntity';
+import { createDownloadBuildFunction } from './functions/download_build';
 
 export function getEasFunctions(ctx: CustomBuildContext): BuildFunction[] {
   const functions = [
@@ -38,6 +39,7 @@ export function getEasFunctions(ctx: CustomBuildContext): BuildFunction[] {
     createPrebuildBuildFunction(),
 
     configureEASUpdateIfInstalledFunction(),
+    createDownloadBuildFunction(),
     injectAndroidCredentialsFunction(),
     configureAndroidVersionFunction(),
     eagerBundleBuildFunction(),

--- a/packages/build-tools/src/steps/functions/download_build.ts
+++ b/packages/build-tools/src/steps/functions/download_build.ts
@@ -1,0 +1,82 @@
+import {
+  BuildFunction,
+  BuildStepInput,
+  BuildStepInputValueTypeName,
+  BuildStepOutput,
+} from '@expo/steps';
+
+export function createDownloadBuildFunction(): BuildFunction {
+  return new BuildFunction({
+    namespace: 'eas',
+    id: 'download_build',
+    name: 'Download build',
+    inputProviders: [
+      BuildStepInput.createProvider({
+        id: 'build_id',
+        required: true,
+        allowedValueTypeName: BuildStepInputValueTypeName.STRING,
+      }),
+      BuildStepInput.createProvider({
+        id: 'fail_on_error',
+        required: false,
+        allowedValueTypeName: BuildStepInputValueTypeName.BOOLEAN,
+        defaultValue: true,
+      }),
+    ],
+    outputProviders: [
+      BuildStepOutput.createProvider({
+        id: 'artifact_path',
+        required: false,
+      }),
+    ],
+    command: `
+    BUILD_ID='\${ inputs.build_id }'
+    FAIL_ON_ERROR='\${ inputs.fail_on_error }'
+    APPLICATION_ARCHIVE_URL="\${__API_SERVER_URL%/}/v2/artifacts/eas/$BUILD_ID"
+
+    echo "Downloading build from $APPLICATION_ARCHIVE_URL"
+    if ! STORED_FILE_URL=$(curl --remote-name --retry 3 --retry-delay 20 --location --fail -w %{url_effective} --silent --show-error "$APPLICATION_ARCHIVE_URL"); then
+    if [ "$FAIL_ON_ERROR" = "true" ]; then
+        echo "File not available."
+        exit 1
+        fi
+      echo "File not available, skipping..."
+      exit 0
+    fi
+    echo "done."
+    URL_ARCHIVE_NAME=$(basename "$APPLICATION_ARCHIVE_URL")
+    ARCHIVE_NAME=$(basename "\${STORED_FILE_URL%%\\?*}")
+    mv $URL_ARCHIVE_NAME $ARCHIVE_NAME
+    echo "Downloaded application archive to $ARCHIVE_NAME"
+
+    if [[ "$ARCHIVE_NAME" == *.tar.gz || "$ARCHIVE_NAME" == *.tgz ]]; then
+        EXTRACTION_DIR=$(mktemp -d)
+        echo "Extracting application archive..."
+        tar -xf "$ARCHIVE_NAME" -C "$EXTRACTION_DIR"
+        echo "Extracted application archive to $EXTRACTION_DIR"
+    fi
+
+    if [ -d "$EXTRACTION_DIR" ]; then
+        mkdir -p "artifacts"
+
+        find "$EXTRACTION_DIR" -name "*.ipa" -exec mv {} "artifacts/" ';'
+        ARTIFACT_PATH=$(find . -name '*.ipa')
+
+        if [ -z "$ARTIFACT_PATH" ]; then
+            find "$EXTRACTION_DIR" -name "*.apk" -exec mv {} "artifacts/" ';'
+            ARTIFACT_PATH="$(find . -name '*.apk')"
+        fi
+
+        if [ -z "$ARTIFACT_PATH" ]; then
+            find "$EXTRACTION_DIR" -name "*.aab" -exec mv {} "artifacts/" ';'
+            ARTIFACT_PATH="$(find . -name '*.aab')"
+        fi
+    else
+        ARTIFACT_PATH=$ARCHIVE_NAME
+    fi
+    ARTIFACT_PATH=$(realpath "$ARTIFACT_PATH")
+    set-output artifact_path "$ARTIFACT_PATH"
+    echo "Set output artifact path to $ARTIFACT_PATH"
+    `,
+  });
+}


### PR DESCRIPTION
# Why

[ENG-14848: Add `eas/download_artifact`](https://linear.app/expo/issue/ENG-14848/add-easdownload-artifact)

User should be able to download build artifacts in a workflow or a custom build step.

# How

- Implemented `eas/download_build' function, which downloads a file and optionally extracts it. The path to the file (or a directory with the unpacked content) is returned:

# Test Plan

1. Link eas build to the local turtle code
2. start local `www` and `turtle-v2` instances
3. Submit the following custom build

```
build:
  name: Download and display
  steps:
      - eas/download_build:
           id: download_build
           inputs:
               build_id: build-id # replace with a build id
               fail_on_error: false
       - run: ls -la ${ steps.download_build.artifact_path }
```


# Deploy plan

1. https://github.com/expo/universe/pull/18902
2. https://github.com/expo/eas-build/pull/512