### PR TITLE
[build-tools] Flag doctor result as warning only for non-0 exit codes

### DIFF
--- a/packages/build-tools/src/common/setup.ts
+++ b/packages/build-tools/src/common/setup.ts
@@ -93,10 +93,7 @@ export async function setupAsync<TJob extends BuildJob>(ctx: BuildContext<TJob>)
   if (!ctx.env.EAS_BUILD_DISABLE_EXPO_DOCTOR_STEP && hasExpoPackage) {
     await ctx.runBuildPhase(BuildPhase.RUN_EXPO_DOCTOR, async () => {
       try {
-        const { stdout } = await runExpoDoctor(ctx);
-        if (!stdout.match(/Didn't find any issues with the project/)) {
-          ctx.markBuildPhaseHasWarnings();
-        }
+        await runExpoDoctor(ctx);
       } catch (err) {
         if (err instanceof DoctorTimeoutError) {
           ctx.logger.error(err.message);


### PR DESCRIPTION
# Why

After some updates to the Doctor output, all Doctor steps started showing as warnings on EAS Build logs. It turns out that it was matching on a specific output string in order to declare doctor steps as successful. This may have been necessary in the past, but Doctor now returns an exit code of 1 for any warnings that it would like to alert the user to.
(there are a few other ancillary messages that could be part of the output (such as skipped tests) in an exit code 0 scenario, but none rise to the "alert" level).

# How

Removed the string check for "Didn't find any issues with the project". All non-exceptions from the async spawn should not flag as warnings now.

# Test Plan
I've never worked in this code and don't know how to setup this repo for testing. However, I think testing would involve:
- [ ] Build job with no Doctor warning: no warning on build logs
- [ ] Build job with Doctor warnings: warning on build logs
