### PR TITLE
Support bash 3 in local builds

### DIFF
--- a/packages/build-tools/src/steps/functionGroups/maestroTest.ts
+++ b/packages/build-tools/src/steps/functionGroups/maestroTest.ts
@@ -91,16 +91,16 @@ export function createEasMaestroTestFunctionGroup(
             name: 'install_app',
             displayName: `Install app to Emulator`,
             command: `
-              # shopt -s globstar is necessary to add /**/ support
-              shopt -s globstar
               # shopt -s nullglob is necessary not to try to install
               # SEARCH_PATH literally if there are no matching files.
               shopt -s nullglob
 
               SEARCH_PATH="${searchPath}"
+              SEARCH_DIR=\${SEARCH_PATH%"*/"*}
+              BASENAME=\${SEARCH_PATH##*/}
               FILES_FOUND=false
 
-              for APP_PATH in $SEARCH_PATH; do
+              for APP_PATH in $(find $SEARCH_DIR -name "$BASENAME"); do
                 FILES_FOUND=true
                 echo "Installing \\"$APP_PATH\\""
                 adb install "$APP_PATH"


### PR DESCRIPTION
# Why

When testing an android app with maestro, the bash script that's generated relies the globstar option. This is only available on bash 4 or higher but mac os only comes with bash 3 (and will probably never move to bash 4 or 5 because they use the gplv3 license). Because of this if you run `eas -p android --local` on a mac the build will fail with this error (if the build runs maestro):

    shopt: globstar: invalid shell option name

# How

To resolve this and support bash 3 I've refactored the maestro test code to use `find` rather than globstar, which should make it possible to run local builds on mac.

# Test Plan

To test this you will need an eas build that runs maestro tests and has an android configuration.

* This should change nothing about builds on ios or android builds made on linux
* On main the build should fail when trying to start maestro with this error: "shopt: globstar: invalid shell option name", but on this branch it should successfully run the tests.