### PR TITLE
[build-tools] Use `rawValue` when collecting step outputs

### DIFF
--- a/packages/build-tools/src/utils/outputs.ts
+++ b/packages/build-tools/src/utils/outputs.ts
@@ -76,7 +76,7 @@ export function getStepOutputsAsObject(step: BuildStep): {
   outputs: Record<string, string | undefined>;
 } {
   const outputs = Object.fromEntries(
-    Object.entries(step.outputById).map(([id, output]) => [id, output.value ?? '']) ?? []
+    Object.entries(step.outputById).map(([id, output]) => [id, output.rawValue ?? '']) ?? []
   );
 
   return { outputs };


### PR DESCRIPTION
# Why

When testing another pull request and running failing workflow runs on my machine I noticed uploading outputs may fail if the workflow hasn't set outputs for the skipped steps.

<img width="1030" alt="Zrzut ekranu 2025-03-16 o 15 44 10" src="https://github.com/user-attachments/assets/1ec8bf91-5152-4550-8554-28225c0ac83e" />

# How

Instead of using `value` which is erroring if the output is required, but not set, use `rawValue` when collecting outputs. The only difference between them is that validation.

https://github.com/expo/eas-build/blob/ece9c10507a155f9b628c4ba4cbfb82780e3f599/packages/steps/src/BuildStepOutput.ts#L52-L63

# Test Plan

Later workflow run uploaded outputs successfully.