### PR TITLE
[build-tools] Improve interpolation context on `job.outputs`

### DIFF
--- a/packages/build-tools/src/generic.ts
+++ b/packages/build-tools/src/generic.ts
@@ -42,8 +42,7 @@ export async function runGenericJobAsync(
   const runResult = await asyncResult(workflow.executeAsync());
 
   await ctx.runBuildPhase(BuildPhase.COMPLETE_JOB, async () => {
-    await uploadJobOutputsToWwwAsync(ctx, {
-      steps: workflow.buildSteps,
+    await uploadJobOutputsToWwwAsync(globalContext, {
       logger: ctx.logger,
       expoApiV2BaseUrl,
     });

--- a/packages/build-tools/src/utils/__tests__/outputs.test.ts
+++ b/packages/build-tools/src/utils/__tests__/outputs.test.ts
@@ -132,10 +132,11 @@ describe(collectJobOutputs, () => {
       collectJobOutputs({
         jobOutputDefinitions: {
           missing_output: '${{ steps.setup.outputs.missing_output }}',
+          not_set_output: '${{ steps.setup.outputs.test_3 }}',
         },
         interpolationContext,
       })
-    ).toEqual({ missing_output: '' });
+    ).toEqual({ missing_output: '', not_set_output: '' });
   });
 });
 

--- a/packages/build-tools/src/utils/outputs.ts
+++ b/packages/build-tools/src/utils/outputs.ts
@@ -29,7 +29,7 @@ export async function uploadJobOutputsToWwwAsync(
     };
     logger.debug({ dynamicValues: interpolationContext }, 'Using dynamic values');
 
-    const outputs = getJobOutputsFromSteps({
+    const outputs = collectJobOutputs({
       jobOutputDefinitions: ctx.staticContext.job.outputs,
       interpolationContext,
     });
@@ -50,7 +50,7 @@ export async function uploadJobOutputsToWwwAsync(
 }
 
 /** Function we use to get outputs of the whole job from steps. */
-export function getJobOutputsFromSteps({
+export function collectJobOutputs({
   jobOutputDefinitions,
   interpolationContext,
 }: {

--- a/packages/build-tools/src/utils/outputs.ts
+++ b/packages/build-tools/src/utils/outputs.ts
@@ -1,36 +1,36 @@
-import { Generic } from '@expo/eas-build-job';
-import { BuildStep, jsepEval } from '@expo/steps';
+import { JobInterpolationContext } from '@expo/eas-build-job';
+import { BuildStepGlobalContext, jsepEval } from '@expo/steps';
 import { bunyan } from '@expo/logger';
 import nullthrows from 'nullthrows';
-
-import { BuildContext } from '../context';
 
 import { turtleFetch } from './turtleFetch';
 
 export async function uploadJobOutputsToWwwAsync(
-  ctx: BuildContext<Generic.Job>,
-  {
-    steps,
-    logger,
-    expoApiV2BaseUrl,
-  }: { steps: BuildStep[]; logger: bunyan; expoApiV2BaseUrl: string }
+  ctx: BuildStepGlobalContext,
+  { logger, expoApiV2BaseUrl }: { logger: bunyan; expoApiV2BaseUrl: string }
 ): Promise<void> {
-  if (!ctx.job.outputs) {
+  if (!ctx.staticContext.job.outputs) {
     logger.info('Job defines no outputs, skipping upload');
     return;
   }
 
   try {
-    const workflowJobId = nullthrows(ctx.job.builderEnvironment?.env?.__WORKFLOW_JOB_ID);
-    const robotAccessToken = nullthrows(ctx.job.secrets?.robotAccessToken);
+    const workflowJobId = nullthrows(ctx.env.__WORKFLOW_JOB_ID);
+    const robotAccessToken = nullthrows(ctx.staticContext.job.secrets?.robotAccessToken);
 
-    const interpolationContext = {
-      steps: Object.fromEntries(steps.map((step) => [step.id, getStepOutputsAsObject(step)])),
+    const interpolationContext: JobInterpolationContext = {
+      ...ctx.staticContext,
+      always: () => true,
+      never: () => false,
+      success: () => !ctx.hasAnyPreviousStepFailed,
+      failure: () => ctx.hasAnyPreviousStepFailed,
+      fromJSON: (json: string) => JSON.parse(json),
+      toJSON: (value: unknown) => JSON.stringify(value),
     };
     logger.debug({ dynamicValues: interpolationContext }, 'Using dynamic values');
 
     const outputs = getJobOutputsFromSteps({
-      jobOutputDefinitions: ctx.job.outputs,
+      jobOutputDefinitions: ctx.staticContext.job.outputs,
       interpolationContext,
     });
     logger.info('Uploading outputs');
@@ -55,9 +55,7 @@ export function getJobOutputsFromSteps({
   interpolationContext,
 }: {
   jobOutputDefinitions: Record<string, string>;
-  interpolationContext: {
-    steps: Record<string, { outputs: Record<string, string | undefined> }>;
-  };
+  interpolationContext: JobInterpolationContext;
 }): Record<string, string | undefined> {
   const jobOutputs: Record<string, string | undefined> = {};
   for (const [outputKey, outputDefinition] of Object.entries(jobOutputDefinitions)) {
@@ -69,15 +67,4 @@ export function getJobOutputsFromSteps({
   }
 
   return jobOutputs;
-}
-
-/** This is what we'll use to generate an object representing a step. */
-export function getStepOutputsAsObject(step: BuildStep): {
-  outputs: Record<string, string | undefined>;
-} {
-  const outputs = Object.fromEntries(
-    Object.entries(step.outputById).map(([id, output]) => [id, output.value ?? '']) ?? []
-  );
-
-  return { outputs };
 }


### PR DESCRIPTION
# Why

I used `fromJSON` in `outputs` in https://github.com/expo/universe/pull/19328, but had to revert it in https://github.com/expo/universe/pull/19361, because `uploadJobOutputsToWwwAsync` was using custom interpolation context when generating values.

# How

Instead of using custom `{ steps }`, used global context to get static context and `JobInterpolationContext` type to ensure we provide `fromJSON`, `toJSON` and all.

# Test Plan

Ran a workflow 

```yaml
jobs:
  publish_update:
    outputs:
      updates_json: ${{ steps.step.outputs.updates_json }}
      first_update_group_id: ${{ fromJSON(steps.step.outputs.updates_json || '[]')[0].group }}
    steps:
      - uses: eas/checkout
      - uses: eas/install_node_modules
      - id: step
        run: |
          UPDATES_JSON=$(npx -y eas-cli@latest update --non-interactive --json --auto --branch test)
          set-output updates_json "$UPDATES_JSON"
```

and got

<img width="717" alt="Zrzut ekranu 2025-03-20 o 18 21 47" src="https://github.com/user-attachments/assets/2de40f01-c5e5-48cd-873b-6ea8cef8e5a6" />
