### PR TITLE
[eas-build-job] add corepack option to tools section of eas.json

### DIFF
--- a/packages/eas-build-job/src/__tests__/android.test.ts
+++ b/packages/eas-build-job/src/__tests__/android.test.ts
@@ -39,6 +39,7 @@ describe('Android.JobSchema', () => {
       builderEnvironment: {
         image: 'default',
         node: '1.2.3',
+        corepack: true,
         yarn: '2.3.4',
         ndk: '4.5.6',
         bun: '1.0.0',
@@ -72,6 +73,7 @@ describe('Android.JobSchema', () => {
       builderEnvironment: {
         image: 'default',
         node: '1.2.3',
+        corepack: false,
         yarn: '2.3.4',
         ndk: '4.5.6',
         bun: '1.0.0',

--- a/packages/eas-build-job/src/__tests__/generic.test.ts
+++ b/packages/eas-build-job/src/__tests__/generic.test.ts
@@ -36,6 +36,7 @@ describe('Generic.JobZ', () => {
       builderEnvironment: {
         image: 'macos-sonoma-14.5-xcode-15.4',
         node: '20.15.1',
+        corepack: true,
         env: {
           KEY1: 'value1',
         },
@@ -80,6 +81,7 @@ describe('Generic.JobZ', () => {
       builderEnvironment: {
         image: 'macos-sonoma-14.5-xcode-15.4',
         node: '20.15.1',
+        corepack: false,
         env: {
           KEY1: 'value1',
         },

--- a/packages/eas-build-job/src/__tests__/ios.test.ts
+++ b/packages/eas-build-job/src/__tests__/ios.test.ts
@@ -41,6 +41,7 @@ describe('Ios.JobSchema', () => {
       builderEnvironment: {
         image: 'default',
         node: '1.2.3',
+        corepack: true,
         yarn: '2.3.4',
         fastlane: '3.4.5',
         cocoapods: '4.5.6',

--- a/packages/eas-build-job/src/android.ts
+++ b/packages/eas-build-job/src/android.ts
@@ -42,6 +42,7 @@ export enum BuildType {
 export interface BuilderEnvironment {
   image?: string;
   node?: string;
+  corepack?: boolean;
   pnpm?: string;
   yarn?: string;
   bun?: string;
@@ -52,6 +53,7 @@ export interface BuilderEnvironment {
 const BuilderEnvironmentSchema = Joi.object({
   image: Joi.string(),
   node: Joi.string(),
+  corepack: Joi.boolean(),
   yarn: Joi.string(),
   pnpm: Joi.string(),
   bun: Joi.string(),

--- a/packages/eas-build-job/src/generic.ts
+++ b/packages/eas-build-job/src/generic.ts
@@ -13,6 +13,7 @@ export namespace Generic {
   const BuilderEnvironmentSchemaZ = z.object({
     image: z.string(),
     node: z.string().optional(),
+    corepack: z.boolean().optional(),
     yarn: z.string().optional(),
     pnpm: z.string().optional(),
     bun: z.string().optional(),

--- a/packages/eas-build-job/src/ios.ts
+++ b/packages/eas-build-job/src/ios.ts
@@ -50,6 +50,7 @@ export interface DistributionCertificate {
 export interface BuilderEnvironment {
   image?: string;
   node?: string;
+  corepack?: boolean;
   yarn?: string;
   bun?: string;
   pnpm?: string;
@@ -62,6 +63,7 @@ export interface BuilderEnvironment {
 const BuilderEnvironmentSchema = Joi.object({
   image: Joi.string(),
   node: Joi.string(),
+  corepack: Joi.boolean(),
   yarn: Joi.string(),
   pnpm: Joi.string(),
   bun: Joi.string(),


### PR DESCRIPTION
# Why

Allow people to auto-enable corepack for their builds/generic jobs by setting `corepack: true` in `eas.json` 

# How

Add `corepack` to job schema

# Test Plan

Tests