### PR TITLE
[build-tools] Increase memory granted to Android emulator to 8 GB

### DIFF
--- a/packages/build-tools/src/steps/functions/startAndroidEmulator.ts
+++ b/packages/build-tools/src/steps/functions/startAndroidEmulator.ts
@@ -138,6 +138,8 @@ async function startAndroidSimulator({
       '-no-boot-anim',
       '-writable-system',
       '-noaudio',
+      '-memory',
+      '8192',
       '-avd',
       deviceName,
       '-prop',


### PR DESCRIPTION
# Why

Emulator is slow.

# How

Found that it is granted default 2 GB of RAM. Increased it to 8 GB which should be ok in all resource classes.

<img width="952" alt="Zrzut ekranu 2025-03-26 o 13 01 52" src="https://github.com/user-attachments/assets/91a611df-6d8a-4912-8b77-6c60518a66de" />


# Test Plan

Ran the command manually in a worker environment.