### PR TITLE
[build-tools][ENG-13286] Use EAS_BUILD_ENABLE_VERBOSE_LOGGING variable to enable more verbose logging.

### DIFF
--- a/packages/build-tools/src/android/gradle.ts
+++ b/packages/build-tools/src/android/gradle.ts
@@ -31,7 +31,9 @@ export async function runGradleCommand(
 ): Promise<void> {
   logger.info(`Running 'gradlew ${gradleCommand}' in ${androidDir}`);
   await fs.chmod(path.join(androidDir, 'gradlew'), 0o755);
-  const spawnPromise = spawn('bash', ['-c', `./gradlew ${gradleCommand}`], {
+  const verboseFlag = ctx.env['EAS_VERBOSE'] === '1' ? '--info' : '';
+
+  const spawnPromise = spawn('bash', ['-c', `./gradlew ${gradleCommand} ${verboseFlag}`], {
     cwd: androidDir,
     logger,
     lineTransformer: (line?: string) => {

--- a/packages/build-tools/src/common/installDependencies.ts
+++ b/packages/build-tools/src/common/installDependencies.ts
@@ -20,6 +20,9 @@ export async function installDependenciesAsync<TJob extends Job>(
       args = ['install', '--no-immutable', '--inline-builds'];
     }
   }
+  if (ctx.env['EAS_VERBOSE'] === '1') {
+    args = [...args, '--verbose'];
+  }
   logger?.info(`Running "${ctx.packageManager} ${args.join(' ')}" in ${cwd} directory`);
   return {
     spawnPromise: spawn(ctx.packageManager, args, {

--- a/packages/build-tools/src/ios/pod.ts
+++ b/packages/build-tools/src/ios/pod.ts
@@ -11,8 +11,10 @@ export async function installPods<TJob extends Ios.Job>(
 ): Promise<{ spawnPromise: SpawnPromise<SpawnResult> }> {
   const iosDir = path.join(ctx.getReactNativeProjectDirectory(), 'ios');
 
+  const verboseFlag = ctx.env['EAS_VERBOSE'] === '1' ? ['--verbose'] : [];
+
   return {
-    spawnPromise: spawn('pod', ['install'], {
+    spawnPromise: spawn('pod', ['install', ...verboseFlag], {
       cwd: iosDir,
       logger: ctx.logger,
       env: {

--- a/packages/build-tools/src/steps/functions/installNodeModules.ts
+++ b/packages/build-tools/src/steps/functions/installNodeModules.ts
@@ -49,6 +49,11 @@ export async function installNodeModules(
       args = ['install', '--no-immutable', '--inline-builds'];
     }
   }
+
+  if (env['EAS_VERBOSE'] === '1') {
+    args = [...args, '--verbose'];
+  }
+
   logger.info(`Running "${packageManager} ${args.join(' ')}" in ${packagerRunDir} directory`);
   await spawn(packageManager, args, {
     cwd: packagerRunDir,

--- a/packages/build-tools/src/steps/functions/installPods.ts
+++ b/packages/build-tools/src/steps/functions/installPods.ts
@@ -8,7 +8,9 @@ export function createInstallPodsBuildFunction(): BuildFunction {
     name: 'Install Pods',
     fn: async (stepsCtx, { env }) => {
       stepsCtx.logger.info('Installing pods');
-      await spawn('pod', ['install'], {
+      const verboseFlag = stepsCtx.global.env['EAS_VERBOSE'] === '1' ? ['--verbose'] : [];
+
+      await spawn('pod', ['install', ...verboseFlag], {
         logger: stepsCtx.logger,
         env: {
           ...env,

--- a/packages/build-tools/src/steps/functions/runGradle.ts
+++ b/packages/build-tools/src/steps/functions/runGradle.ts
@@ -50,6 +50,7 @@ export function runGradleFunction(): BuildFunction {
         stepCtx.global.staticContext.job,
         inputs.command.value as string | undefined
       );
+
       const resolvedEASUpdateRuntimeVersion = inputs.resolved_eas_update_runtime_version.value as
         | string
         | undefined;

--- a/packages/build-tools/src/steps/utils/android/gradle.ts
+++ b/packages/build-tools/src/steps/utils/android/gradle.ts
@@ -20,9 +20,11 @@ export async function runGradleCommand({
   env: BuildStepEnv;
   extraEnv?: BuildStepEnv;
 }): Promise<void> {
-  logger.info(`Running 'gradlew ${gradleCommand}' in ${androidDir}`);
+  const verboseFlag = env['EAS_VERBOSE'] === '1' ? '--info' : '';
+
+  logger.info(`Running 'gradlew ${gradleCommand} ${verboseFlag}' in ${androidDir}`);
   await fs.chmod(path.join(androidDir, 'gradlew'), 0o755);
-  const spawnPromise = spawn('bash', ['-c', `./gradlew ${gradleCommand}`], {
+  const spawnPromise = spawn('bash', ['-c', `./gradlew ${gradleCommand} ${verboseFlag}`], {
     cwd: androidDir,
     logger,
     lineTransformer: (line?: string) => {


### PR DESCRIPTION
# Why

[ENG-13286: Provide an option for EAS Build that indicates we should use the verbose logging version of the install command](https://linear.app/expo/issue/ENG-13286/provide-an-option-for-eas-build-that-indicates-we-should-use-the)

User should be able to easily enable verbose logs for build phase for easier debugging.

# How

- added verbose flag to `installDependencies` (js package manager)
- added verbose flag to pod install commands
- added `--info` to gradlew

# Test Plan

See https://github.com/expo/eas-cli/pull/3000

# Deploy

1. https://github.com/expo/eas-build/pull/527
2. https://github.com/expo/eas-cli/pull/3000