### PR TITLE
[build-tools] Increase time waiting for emulator to start

### DIFF
--- a/packages/build-tools/src/steps/functions/startAndroidEmulator.ts
+++ b/packages/build-tools/src/steps/functions/startAndroidEmulator.ts
@@ -260,8 +260,7 @@ async function ensureEmulatorIsReadyAsync({
     {
       logger,
       retryOptions: {
-        // Emulators usually take 30 second tops to boot.
-        retries: 60,
+        retries: 3 * 60,
         retryIntervalMs: 1_000,
       },
     }


### PR DESCRIPTION
# Why

I've been trying to run newer emulators on EAS and they don't start in 30 seconds.

<img width="804" alt="Zrzut ekranu 2025-04-25 o 11 05 49" src="https://github.com/user-attachments/assets/1e694e49-d17a-4c24-a317-e739461856d0" />

# How

Increased the time we wait for emulator to start.

# Test Plan

CI should pass.