### PR TITLE
[build-tools] Use "`--frozen-lockfile`" for SDK53+

### DIFF
--- a/packages/build-tools/src/common/installDependencies.ts
+++ b/packages/build-tools/src/common/installDependencies.ts
@@ -18,7 +18,7 @@ export async function installDependenciesAsync({
   packageManager: PackageManager;
   env: Record<string, string | undefined>;
   cwd: string;
-  logger?: SpawnOptions['logger'];
+  logger: Exclude<SpawnOptions['logger'], undefined>;
   infoCallbackFn?: SpawnOptions['infoCallbackFn'];
   useFrozenLockfile: boolean;
 }): Promise<{ spawnPromise: SpawnPromise<SpawnResult> }> {
@@ -50,7 +50,7 @@ export async function installDependenciesAsync({
   if (env['EAS_VERBOSE'] === '1') {
     args = [...args, '--verbose'];
   }
-  logger?.info(`Running "${packageManager} ${args.join(' ')}" in ${cwd} directory`);
+  logger.info(`Running "${packageManager} ${args.join(' ')}" in ${cwd} directory`);
   return {
     spawnPromise: spawn(packageManager, args, {
       cwd,

--- a/packages/build-tools/src/common/prebuild.ts
+++ b/packages/build-tools/src/common/prebuild.ts
@@ -32,10 +32,13 @@ export async function prebuildAsync<TJob extends BuildJob>(
     packageManager: ctx.packageManager,
   });
   const installDependenciesSpawnPromise = (
-    await installDependenciesAsync(ctx, {
+    await installDependenciesAsync({
+      packageManager: ctx.packageManager,
+      env: ctx.env,
       logger,
       cwd: resolvePackagerDir(ctx),
-      withoutFrozenLockfile: true, // prebuild should can modify package.json in some cases
+      // prebuild sometimes modifies package.json, so we don't want to use frozen lockfile
+      useFrozenLockfile: false,
     })
   ).spawnPromise;
   await installDependenciesSpawnPromise;

--- a/packages/build-tools/src/common/prebuild.ts
+++ b/packages/build-tools/src/common/prebuild.ts
@@ -35,6 +35,7 @@ export async function prebuildAsync<TJob extends BuildJob>(
     await installDependenciesAsync(ctx, {
       logger,
       cwd: resolvePackagerDir(ctx),
+      withoutFrozenLockfile: true, // prebuild should can modify package.json in some cases
     })
   ).spawnPromise;
   await installDependenciesSpawnPromise;

--- a/packages/build-tools/src/steps/functions/installNodeModules.ts
+++ b/packages/build-tools/src/steps/functions/installNodeModules.ts
@@ -9,7 +9,7 @@ import {
   PackageManager,
   resolvePackageManager,
 } from '../../utils/packageManager';
-import { isUsingYarn2 } from '../../utils/project';
+import { isUsingModernYarnVersion } from '../../utils/project';
 
 export function createInstallNodeModulesBuildFunction(): BuildFunction {
   return new BuildFunction({
@@ -44,7 +44,7 @@ export async function installNodeModules(
   if (packageManager === PackageManager.PNPM) {
     args = ['install', '--no-frozen-lockfile'];
   } else if (packageManager === PackageManager.YARN) {
-    const isYarn2 = await isUsingYarn2(stepCtx.workingDirectory);
+    const isYarn2 = await isUsingModernYarnVersion(stepCtx.workingDirectory);
     if (isYarn2) {
       args = ['install', '--no-immutable', '--inline-builds'];
     }

--- a/packages/build-tools/src/steps/functions/installNodeModules.ts
+++ b/packages/build-tools/src/steps/functions/installNodeModules.ts
@@ -46,7 +46,7 @@ export async function installNodeModules(
     packageJson = readPackageJson(stepCtx.workingDirectory);
   } catch {
     logger.info(
-      `Failed to read package.json. We won't know if we can use frozen lockfile. You can use EAS_NO_FROZEN_LOCKFILE=1 to disable it.`
+      `Failed to read package.json, defaulting to installing dependencies with a frozen lockfile. You can use EAS_NO_FROZEN_LOCKFILE=1 to disable it.`
     );
   }
 

--- a/packages/build-tools/src/steps/functions/installNodeModules.ts
+++ b/packages/build-tools/src/steps/functions/installNodeModules.ts
@@ -5,6 +5,7 @@ import { BuildStepContext } from '@expo/steps/dist_esm/BuildStepContext';
 
 import {
   findPackagerRootDir,
+  getPackageVersionFromPackageJson,
   resolvePackageManager,
   shouldUseFrozenLockfile,
 } from '../../utils/packageManager';
@@ -49,12 +50,30 @@ export async function installNodeModules(
     );
   }
 
+  const expoVersion =
+    stepCtx.global.staticContext.metadata?.sdkVersion ??
+    getPackageVersionFromPackageJson({
+      packageJson,
+      packageName: 'expo',
+    });
+
+  const reactNativeVersion =
+    stepCtx.global.staticContext.metadata?.reactNativeVersion ??
+    getPackageVersionFromPackageJson({
+      packageJson,
+      packageName: 'react-native',
+    });
+
   const { spawnPromise } = await installDependenciesAsync({
     packageManager,
     env,
     logger: stepCtx.logger,
     cwd: packagerRunDir,
-    useFrozenLockfile: shouldUseFrozenLockfile({ packageJson, env }),
+    useFrozenLockfile: shouldUseFrozenLockfile({
+      env,
+      sdkVersion: expoVersion,
+      reactNativeVersion,
+    }),
   });
   await spawnPromise;
 }

--- a/packages/build-tools/src/utils/__tests__/packageManager.test.ts
+++ b/packages/build-tools/src/utils/__tests__/packageManager.test.ts
@@ -188,6 +188,9 @@ describe(getPackageVersionFromPackageJson, () => {
       'react-native',
       '0.79.0',
     ],
+    [null, 'react-native', undefined],
+    ['not-a-package-json', 'react-native', undefined],
+    [42, 'react-native', undefined],
   ] as const;
 
   for (const [packageJson, packageName, expectedVersion] of CASES) {

--- a/packages/build-tools/src/utils/packageManager.ts
+++ b/packages/build-tools/src/utils/packageManager.ts
@@ -59,8 +59,8 @@ export function shouldUseFrozenLockfile({
   const parsedPackageJson = PackageJsonZ.safeParse(packageJson);
   if (!parsedPackageJson.success) {
     // We don't know what the dependencies are,
-    // so we default to NOT using frozen lockfile.
-    return false;
+    // so we default to using frozen lockfile.
+    return true;
   }
 
   const dependencies = parsedPackageJson.data.dependencies;

--- a/packages/build-tools/src/utils/packageManager.ts
+++ b/packages/build-tools/src/utils/packageManager.ts
@@ -1,6 +1,7 @@
 import spawnAsync from '@expo/turtle-spawn';
 import * as PackageManagerUtils from '@expo/package-manager';
 import semver from 'semver';
+import { z } from 'zod';
 
 export enum PackageManager {
   YARN = 'yarn',
@@ -33,4 +34,51 @@ export function findPackagerRootDir(currentDir: string): string {
 export async function isAtLeastNpm7Async(): Promise<boolean> {
   const version = (await spawnAsync('npm', ['--version'], { stdio: 'pipe' })).stdout.trim();
   return semver.gte(version, '7.0.0');
+}
+
+const PackageJsonZ = z.object({
+  dependencies: z
+    .object({
+      expo: z.string().optional(),
+      'react-native': z.string().optional(),
+    })
+    .optional(),
+});
+
+export function shouldUseFrozenLockfile({
+  env,
+  packageJson,
+}: {
+  env: Record<string, string | undefined>;
+  packageJson: unknown;
+}): boolean {
+  if (env.EAS_NO_FROZEN_LOCKFILE) {
+    return false;
+  }
+
+  const parsedPackageJson = PackageJsonZ.safeParse(packageJson);
+  if (!parsedPackageJson.success) {
+    // We don't know what the dependencies are,
+    // so we default to NOT using frozen lockfile.
+    return false;
+  }
+
+  const dependencies = parsedPackageJson.data.dependencies;
+
+  const sdkVersion = semver.coerce(dependencies?.expo)?.version;
+  if (sdkVersion && semver.lt(sdkVersion, '52.0.0')) {
+    // Before SDK 52 we could not have used frozen lockfile.
+    return false;
+  }
+
+  const reactNativeVersion = semver.coerce(dependencies?.['react-native'])?.version;
+  if (reactNativeVersion && semver.lt(reactNativeVersion, '0.76')) {
+    // Before react-native 0.76 we could not have used frozen lockfile.
+    return false;
+  }
+
+  // We either don't know expo and react-native versions,
+  // so we can try to use frozen lockfile, or the versions are
+  // new enough that we do want to use it.
+  return true;
 }

--- a/packages/build-tools/src/utils/packageManager.ts
+++ b/packages/build-tools/src/utils/packageManager.ts
@@ -54,7 +54,7 @@ export function shouldUseFrozenLockfile({
     return false;
   }
 
-  if (reactNativeVersion && semver.lt(reactNativeVersion, '0.79')) {
+  if (reactNativeVersion && semver.lt(reactNativeVersion, '0.79.0')) {
     // Before react-native 0.79 we could not have used frozen lockfile.
     return false;
   }

--- a/packages/build-tools/src/utils/project.ts
+++ b/packages/build-tools/src/utils/project.ts
@@ -8,7 +8,7 @@ import { findPackagerRootDir, PackageManager } from '../utils/packageManager';
 /**
  * check if .yarnrc.yml exists in the project dir or in the workspace root dir
  */
-export async function isUsingYarn2(projectDir: string): Promise<boolean> {
+export async function isUsingModernYarnVersion(projectDir: string): Promise<boolean> {
   const yarnrcPath = path.join(projectDir, '.yarnrc.yml');
   const yarnrcRootPath = path.join(findPackagerRootDir(projectDir), '.yarnrc.yml');
   return (await fs.pathExists(yarnrcPath)) || (await fs.pathExists(yarnrcRootPath));


### PR DESCRIPTION
Takeover of https://github.com/expo/eas-build/pull/463

# Why

https://exponent-internal.slack.com/archives/C02123T524U/p1731420965266849?thread_ts=1731420501.834709&cid=C02123T524U
https://exponent-internal.slack.com/archives/C02123T524U/p1731421835879399

We want to move over to using "frozen lockfile" when installing dependencies on EAS.

# How

Use "frozen lockfile" if :
- `EAS_NO_FROZEN_LOCKFILE` environment variable is _not_ present AND
- we know the SDK version is not <= 52 AND
- we know the React Native version is not <= 0.79.

Don't use frozen lockfile after prebuild as prebuild can sometimes modify `the package.json`.

This is technically a breaking change? Which is why I'm making it for SDK53+ (not SDK52+). Can't do anything about the non-SDK projects though… we can do the switch now or never…

# Test Plan

- [x] tested locally

Left: SDK53, right: SDK52

<img width="1440" alt="Zrzut ekranu 2025-04-28 o 13 25 17" src="https://github.com/user-attachments/assets/e524df0b-e1a6-4195-b036-17e2a01b1631" />
