### PR TITLE
[build-tools] Add `eas/download_build`

### DIFF
--- a/packages/build-tools/jest/setup-tests.ts
+++ b/packages/build-tools/jest/setup-tests.ts
@@ -1,5 +1,21 @@
+import os from 'node:os';
+
+import { vol, fs } from 'memfs';
+
 if (process.env.NODE_ENV !== 'test') {
   throw new Error("NODE_ENV environment variable must be set to 'test'.");
 }
 
 // Always mock:
+jest.mock('fs');
+jest.mock('node:fs', () => fs);
+jest.mock('fs/promises');
+jest.mock('node:fs/promises', () => fs.promises);
+jest.mock('node-fetch');
+
+beforeEach(() => {
+  vol.reset();
+  vol.fromNestedJSON({
+    [os.tmpdir()]: {},
+  });
+});

--- a/packages/build-tools/package.json
+++ b/packages/build-tools/package.json
@@ -49,7 +49,8 @@
     "promise-retry": "^2.0.1",
     "resolve-from": "^5.0.0",
     "retry": "^0.13.1",
-    "semver": "^7.6.2"
+    "semver": "^7.6.2",
+    "tar": "^7.4.3"
   },
   "devDependencies": {
     "@types/fs-extra": "^11.0.4",
@@ -64,7 +65,7 @@
     "@types/semver": "^7.5.8",
     "@types/uuid": "^9.0.8",
     "jest": "^29.7.0",
-    "memfs": "^4.6.0",
+    "memfs": "^4.17.1",
     "ts-jest": "^29.1.4",
     "ts-mockito": "^2.6.1",
     "tslib": "^2.6.3",

--- a/packages/build-tools/src/__mocks__/fs.ts
+++ b/packages/build-tools/src/__mocks__/fs.ts
@@ -1,10 +1,5 @@
 import { fs } from 'memfs';
 
-fs.mkdirSync('/tmp', { recursive: true });
-if (process.env.TMPDIR) {
-  fs.mkdirSync(process.env.TMPDIR, { recursive: true });
-}
-
 const fsRealpath = fs.realpath;
 (fsRealpath as any).native = fsRealpath;
 
@@ -24,6 +19,3 @@ const fsRm = (
 };
 
 module.exports = { ...fs, realpath: fsRealpath, rm: fsRm };
-
-// NOTE(cedric): workaround to also mock `node:fs`
-jest.mock('node:fs', () => require('fs'));

--- a/packages/build-tools/src/__mocks__/fs/promises.ts
+++ b/packages/build-tools/src/__mocks__/fs/promises.ts
@@ -1,10 +1,5 @@
 import { fs } from 'memfs';
 
-fs.mkdirSync('/tmp', { recursive: true });
-if (process.env.TMPDIR) {
-  fs.mkdirSync(process.env.TMPDIR, { recursive: true });
-}
-
 const fsRealpath = fs.realpath;
 (fsRealpath as any).native = fsRealpath;
 
@@ -13,6 +8,3 @@ const fsRm = (path: string, options: object): Promise<void> => {
 };
 
 module.exports = { ...fs.promises, realpath: fsRealpath, rm: fsRm };
-
-// NOTE(cedric): workaround to also mock `node:fs/promises`
-jest.mock('node:fs/promises', () => require('memfs').fs.promises);

--- a/packages/build-tools/src/ios/credentials/__tests__/distributionCertificate.test.ios.ts
+++ b/packages/build-tools/src/ios/credentials/__tests__/distributionCertificate.test.ios.ts
@@ -1,4 +1,5 @@
 import fs from 'fs-extra';
+import { vol } from 'memfs';
 
 import { getFingerprint, getCommonName } from '../distributionCertificate';
 
@@ -25,6 +26,7 @@ describe('distributionCertificate module', () => {
   });
   describe(getCommonName, () => {
     it('returns cert common name', async () => {
+      vol.fromNestedJSON({ '/tmp': {} });
       const commonName = getCommonName({
         dataBase64: distributionCertificate.dataBase64,
         password: distributionCertificate.password,

--- a/packages/build-tools/src/ios/credentials/__tests__/keychain.test.ios.ts
+++ b/packages/build-tools/src/ios/credentials/__tests__/keychain.test.ios.ts
@@ -15,6 +15,10 @@ const mockLogger = createLogger({ name: 'mock-logger' });
 
 jest.setTimeout(60 * 1000);
 
+// Those are in fact "real" tests in that they really execute the `fastlane` commands.
+// We need the JS code to modify the file system, so we need to mock it.
+jest.unmock('fs');
+
 let ctx: BuildContext<Ios.Job>;
 
 describe('Keychain class', () => {

--- a/packages/build-tools/src/ios/credentials/__tests__/manager.test.ios.ts
+++ b/packages/build-tools/src/ios/credentials/__tests__/manager.test.ios.ts
@@ -11,6 +11,10 @@ import IosCredentialsManager from '../manager';
 
 jest.setTimeout(60 * 1000);
 
+// Those are in fact "real" tests in that they really execute the `fastlane` commands.
+// We need the JS code to modify the file system, so we need to mock it.
+jest.unmock('fs');
+
 const mockLogger = createLogger({ name: 'mock-logger' });
 
 const iosCredentials: Ios.BuildCredentials = {

--- a/packages/build-tools/src/ios/credentials/__tests__/provisioningProfile.test.ios.ts
+++ b/packages/build-tools/src/ios/credentials/__tests__/provisioningProfile.test.ios.ts
@@ -11,6 +11,10 @@ const mockLogger = createLogger({ name: 'mock-logger' });
 
 jest.setTimeout(60 * 1000);
 
+// Those are in fact "real" tests in that they really execute the `fastlane` commands.
+// We need the JS code to modify the file system, so we need to mock it.
+jest.unmock('fs');
+
 describe('ProvisioningProfile class', () => {
   describe('verifyCertificate method', () => {
     let ctx: BuildContext<Ios.Job>;

--- a/packages/build-tools/src/steps/easFunctions.ts
+++ b/packages/build-tools/src/steps/easFunctions.ts
@@ -28,6 +28,7 @@ import { calculateEASUpdateRuntimeVersionFunction } from './functions/calculateE
 import { createRepackBuildFunction } from './functions/repack';
 import { eagerBundleBuildFunction } from './functions/eagerBundle';
 import { createSubmissionEntityFunction } from './functions/createSubmissionEntity';
+import { createDownloadBuildFunction } from './functions/downloadBuild';
 
 export function getEasFunctions(ctx: CustomBuildContext): BuildFunction[] {
   const functions = [
@@ -36,6 +37,7 @@ export function getEasFunctions(ctx: CustomBuildContext): BuildFunction[] {
     createSetUpNpmrcBuildFunction(),
     createInstallNodeModulesBuildFunction(),
     createPrebuildBuildFunction(),
+    createDownloadBuildFunction(),
 
     configureEASUpdateIfInstalledFunction(),
     injectAndroidCredentialsFunction(),

--- a/packages/build-tools/src/steps/functions/__tests__/downloadBuild.test.ts
+++ b/packages/build-tools/src/steps/functions/__tests__/downloadBuild.test.ts
@@ -1,0 +1,77 @@
+import { randomUUID } from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+import { Readable } from 'node:stream';
+
+import { createLogger } from '@expo/logger';
+import fetch, { Response } from 'node-fetch';
+
+import { downloadBuildAsync } from '../downloadBuild';
+
+// contains a 'TestApp.app/TestApp' file with 'i am executable' content
+const APP_TAR_GZ_BUFFER = Buffer.from(
+  'H4sIAMK9HGgAA+2SWwrDIBBF/e4qXIEZjY/v7qEbsMHQlASkGujyI40UWvqgEFNK5/xcYUSvHFlFigMARil6ST0nCDlnhnKVhrzWOg2Ai1pwQlX5aoSMIdpTqhKOzWHoXG+f7Evb2vbFOfkd1/wRWLVzIW69Z9b7Qn/hI/8Gkn8pNfpfhVv/eb3wHW/9i3v/yihDKCzc4yF/7r+jdqDu7Jox2n3vNt/ugyAIgqzDBKNW1bQAD' +
+    Array.from({ length: 442 }, () => 'A') +
+    '=',
+  'base64'
+);
+
+describe('downloadBuild', () => {
+  it('should handle an archive', async () => {
+    jest.mocked(fetch).mockResolvedValue({
+      ok: true,
+      body: Readable.from(APP_TAR_GZ_BUFFER),
+      url: `https://storage.googleapis.com/eas-workflows-production/artifacts/${randomUUID()}/${randomUUID()}/application-${randomUUID()}.tar.gz?X-Goog-Algorithm=GOOG4-RSA-SHA256`,
+    } as unknown as Response);
+
+    const { artifactPath } = await downloadBuildAsync({
+      logger: createLogger({ name: 'test' }),
+      buildId: randomUUID(),
+      expoApiServerURL: 'http://api.expo.test',
+      expoToken: null,
+      extensions: ['app'],
+    });
+
+    expect(artifactPath).toBeDefined();
+    expect(await fs.promises.readFile(path.join(artifactPath, 'TestApp'), 'utf8')).toBe(
+      'i am executable\n'
+    );
+  });
+
+  it('should handle a straight-up file', async () => {
+    jest.mocked(fetch).mockResolvedValue({
+      ok: true,
+      body: Readable.from(Buffer.from('hello')),
+      url: `https://storage.googleapis.com/eas-workflows-production/artifacts/${randomUUID()}/${randomUUID()}/application-${randomUUID()}.txt?X-Goog-Algorithm=GOOG4-RSA-SHA256`,
+    } as unknown as Response);
+
+    const { artifactPath } = await downloadBuildAsync({
+      logger: createLogger({ name: 'test' }),
+      buildId: randomUUID(),
+      expoApiServerURL: 'http://api.expo.test',
+      expoToken: null,
+      extensions: ['app'],
+    });
+
+    expect(artifactPath).toBeDefined();
+    expect(await fs.promises.readFile(artifactPath, 'utf-8')).toBe('hello');
+  });
+
+  it('should throw an error if no matching files are found', async () => {
+    jest.mocked(fetch).mockResolvedValue({
+      ok: true,
+      body: Readable.from(APP_TAR_GZ_BUFFER),
+      url: `https://storage.googleapis.com/eas-workflows-production/artifacts/${randomUUID()}/${randomUUID()}/application-${randomUUID()}.tar.gz?X-Goog-Algorithm=GOOG4-RSA-SHA256`,
+    } as unknown as Response);
+
+    await expect(
+      downloadBuildAsync({
+        logger: createLogger({ name: 'test' }),
+        buildId: randomUUID(),
+        expoApiServerURL: 'http://api.expo.test',
+        expoToken: null,
+        extensions: ['apk'],
+      })
+    ).rejects.toThrow('No .apk entries found in the archive.');
+  });
+});

--- a/packages/build-tools/src/steps/functions/downloadBuild.ts
+++ b/packages/build-tools/src/steps/functions/downloadBuild.ts
@@ -1,0 +1,144 @@
+import path from 'node:path';
+import fs from 'node:fs';
+import os from 'node:os';
+import stream from 'stream';
+import { promisify } from 'util';
+
+import {
+  BuildFunction,
+  BuildStepInput,
+  BuildStepInputValueTypeName,
+  BuildStepOutput,
+} from '@expo/steps';
+import { asyncResult } from '@expo/results';
+import fetch from 'node-fetch';
+import { glob } from 'fast-glob';
+import { z } from 'zod';
+import { bunyan } from '@expo/logger';
+import { UserFacingError } from '@expo/eas-build-job/dist/errors';
+
+import { retryOnDNSFailure } from '../../utils/retryOnDNSFailure';
+import { formatBytes } from '../../utils/artifacts';
+import { decompressTarAsync, isFileTarGzAsync } from '../../utils/files';
+import { pluralize } from '../../utils/strings';
+
+const streamPipeline = promisify(stream.pipeline);
+
+export function createDownloadBuildFunction(): BuildFunction {
+  return new BuildFunction({
+    namespace: 'eas',
+    id: 'download_build',
+    name: 'Download build',
+    inputProviders: [
+      BuildStepInput.createProvider({
+        id: 'build_id',
+        required: true,
+        allowedValueTypeName: BuildStepInputValueTypeName.STRING,
+      }),
+      BuildStepInput.createProvider({
+        id: 'extensions',
+        required: false,
+        allowedValueTypeName: BuildStepInputValueTypeName.JSON,
+        defaultValue: ['apk', 'aab', 'ipa', 'app'],
+      }),
+    ],
+    outputProviders: [
+      BuildStepOutput.createProvider({
+        id: 'artifact_path',
+        required: true,
+      }),
+    ],
+    fn: async (stepsCtx, { inputs, outputs, env }) => {
+      const { logger } = stepsCtx;
+
+      const extensions = z.array(z.string()).parse(inputs.extensions.value);
+      logger.info(`Expected extensions: [${extensions.join(', ')}]`);
+      const buildId = z.string().uuid().parse(inputs.build_id.value);
+      logger.info(`Downloading build ${buildId}...`);
+
+      const { artifactPath } = await downloadBuildAsync({
+        logger,
+        buildId,
+        expoApiServerURL: stepsCtx.global.staticContext.expoApiServerURL,
+        expoToken: env.EXPO_TOKEN ?? null,
+        extensions,
+      });
+
+      outputs.artifact_path.set(artifactPath);
+    },
+  });
+}
+
+export async function downloadBuildAsync({
+  logger,
+  buildId,
+  expoApiServerURL,
+  expoToken,
+  extensions,
+}: {
+  logger: bunyan;
+  buildId: string;
+  expoApiServerURL: string;
+  expoToken: string | null;
+  extensions: string[];
+}): Promise<{ artifactPath: string }> {
+  const tempDirectory = await fs.promises.mkdtemp(os.tmpdir());
+
+  const response = await retryOnDNSFailure(fetch)(
+    new URL(`/v2/artifacts/eas/${buildId}`, expoApiServerURL),
+    {
+      headers: expoToken ? { Authorization: `Bearer ${expoToken}` } : undefined,
+    }
+  );
+
+  if (!response.ok) {
+    const textResult = await asyncResult(response.text());
+    throw new Error(`Unexpected response from server (${response.status}): ${textResult.value}`);
+  }
+
+  // URL may contain percent-encoded characters, e.g. my%20file.apk
+  // this replaces all non-alphanumeric characters (excluding dot) with underscore
+  const archiveFilename = path
+    .basename(new URL(response.url).pathname)
+    .replace(/([^a-z0-9.-]+)/gi, '_');
+  const archivePath = path.join(tempDirectory, archiveFilename);
+
+  await streamPipeline(response.body, fs.createWriteStream(archivePath));
+
+  const { size } = await fs.promises.stat(archivePath);
+
+  logger.info(`Downloaded ${archivePath} (${formatBytes(size)} bytes).`);
+
+  const isFileATarGzArchive = await isFileTarGzAsync(archivePath);
+
+  if (!isFileATarGzArchive) {
+    logger.info(`Artifact is not a .tar.gz archive, skipping decompression and validation.`);
+    return { artifactPath: archivePath };
+  }
+
+  const extractionDirectory = await fs.promises.mkdtemp(os.tmpdir());
+  await decompressTarAsync({
+    archivePath,
+    destinationDirectory: extractionDirectory,
+  });
+
+  const matchingFiles = await glob(`**/*.(${extensions.join('|')})`, {
+    absolute: true,
+    cwd: extractionDirectory,
+    onlyFiles: false,
+    onlyDirectories: false,
+  });
+
+  if (matchingFiles.length === 0) {
+    throw new UserFacingError(
+      'EAS_DOWNLOAD_BUILD_NO_MATCHING_FILES',
+      `No ${extensions.map((ext) => `.${ext}`).join(', ')} entries found in the archive.`
+    );
+  }
+
+  logger.info(
+    `Found ${matchingFiles.length} matching ${pluralize(matchingFiles.length, 'entry')}:\n${matchingFiles.map((f) => `- ${path.relative(extractionDirectory, f)}`).join('\n')}`
+  );
+
+  return { artifactPath: matchingFiles[0] };
+}

--- a/packages/build-tools/src/steps/utils/ios/credentials/__tests__/distributionCertificate.test.ios.ts
+++ b/packages/build-tools/src/steps/utils/ios/credentials/__tests__/distributionCertificate.test.ios.ts
@@ -1,4 +1,5 @@
 import fs from 'fs-extra';
+import { vol } from 'memfs';
 
 import { getFingerprint, getCommonName } from '../distributionCertificate';
 
@@ -25,6 +26,7 @@ describe('distributionCertificate module', () => {
   });
   describe(getCommonName, () => {
     it('returns cert common name', async () => {
+      vol.fromNestedJSON({ '/tmp': {} });
       const commonName = getCommonName({
         dataBase64: distributionCertificate.dataBase64,
         password: distributionCertificate.password,

--- a/packages/build-tools/src/steps/utils/ios/credentials/__tests__/keychain.test.ios.ts
+++ b/packages/build-tools/src/steps/utils/ios/credentials/__tests__/keychain.test.ios.ts
@@ -13,6 +13,10 @@ const mockLogger = createLogger({ name: 'mock-logger' });
 
 jest.setTimeout(60 * 1000);
 
+// Those are in fact "real" tests in that they really execute the `fastlane` commands.
+// We need the JS code to modify the file system, so we need to mock it.
+jest.unmock('fs');
+
 describe('Keychain class', () => {
   describe('ensureCertificateImported method', () => {
     let keychain: Keychain;

--- a/packages/build-tools/src/steps/utils/ios/credentials/__tests__/manager.test.ios.ts
+++ b/packages/build-tools/src/steps/utils/ios/credentials/__tests__/manager.test.ios.ts
@@ -10,6 +10,10 @@ import IosCredentialsManager from '../manager';
 
 jest.setTimeout(60 * 1000);
 
+// Those are in fact "real" tests in that they really execute the `fastlane` commands.
+// We need the JS code to modify the file system, so we need to mock it.
+jest.unmock('fs');
+
 const mockLogger = createLogger({ name: 'mock-logger' });
 
 const iosCredentials: Ios.BuildCredentials = {

--- a/packages/build-tools/src/steps/utils/ios/credentials/__tests__/provisioningProfile.test.ios.ts
+++ b/packages/build-tools/src/steps/utils/ios/credentials/__tests__/provisioningProfile.test.ios.ts
@@ -9,6 +9,10 @@ const mockLogger = createLogger({ name: 'mock-logger' });
 
 jest.setTimeout(60 * 1000);
 
+// Those are in fact "real" tests in that they really execute the `fastlane` commands.
+// We need the JS code to modify the file system, so we need to mock it.
+jest.unmock('fs');
+
 describe('ProvisioningProfile class', () => {
   describe('verifyCertificate method', () => {
     let keychain: Keychain;

--- a/packages/build-tools/src/utils/__tests__/files.test.ts
+++ b/packages/build-tools/src/utils/__tests__/files.test.ts
@@ -1,0 +1,57 @@
+import { vol } from 'memfs';
+
+import { decompressTarAsync, isFileTarGzAsync } from '../files';
+
+// contains a 'hello.txt' file with 'hello' content
+const HELLO_TAR_GZ_BUFFER = Buffer.from(
+  'H4sIACyzHGgAA9PTZ6A5MDAwMDc1VQDTZhDawMgEQkOBgqEpUNLQ2NDExFTBwNDI2NCUQcGU9k5jYCgtLkksAjqlOCs5IzczNScRhzqgsrQ0POZA/QGnhwjQ0w9ydXTxddXLTaGZHcDwMDMxwRf/Zoj4NzIHxr+xqbkBg4IBzVyEBEZ4/Gek5uTkcw20K0bBQAE9fXAK0ANmAr30KtrYQSD/G2KW/yamxmaj+Z8eQL6bg0F1s0wGA/Pbqd58TQYCbbu/idg6zrRju6a2qeQx76pFHQouJal7dod2rnfp7WyVeH77TNMy2R+n/igl3GNs4Jg4P6ti3YIzO80KOt8tvHJJ4onC1GknLH7l927M3bsx+7rXXN9LSROffDtptT3HrHqj/2e56b+UOxJEvrMfjhAJzk/f8V5Q6vOp+oqv65Wexyez9DRv78v7Ufw/c9Lz1PWv9TrWCTSuXXUrn6PG5P9dnYL/+51m/V974Yf+qY9K/jaxzf1/Xif/kw5R/JnfXP1/6lydtzaCkbHr9pUf+/3nOv8/ZYYlf/Kb7847NF+B45G8JQPT5FmMDEIDHd6DDejpJxYUFNO2EUhS+w/YFgDW/0amo+0/ugBo/OfmJ2XmpNIoGZAU/8aQ8t/IbDT+6QFQ478gMTk7MT1VL6s4P496dhBu/xujxb+5gYHpaP1PD1BdO9r4HwWjYBSMgpEIANczH2UAFg' +
+    Array.from({ length: 652 }, () => 'A') +
+    '==',
+  'base64'
+);
+
+describe('isFileTarGzAsync', () => {
+  it('should return true for a tar.gz-named file', async () => {
+    vol.fromJSON({
+      'test.tar.gz': 'whatever',
+    });
+
+    const result = await isFileTarGzAsync('test.tar.gz');
+    expect(result).toBe(true);
+  });
+
+  it('should return true for a tar.gz file', async () => {
+    vol.fromJSON({
+      test: HELLO_TAR_GZ_BUFFER,
+    });
+
+    const result = await isFileTarGzAsync('test');
+    expect(result).toBe(true);
+  });
+
+  it('should return false for a non-tar.gz file', async () => {
+    vol.fromJSON({
+      'test.txt': 'Hello, world!',
+    });
+
+    const result = await isFileTarGzAsync('test.txt');
+    expect(result).toBe(false);
+  });
+});
+
+describe('decompressTarAsync', () => {
+  it('should decompress a tar.gz file', async () => {
+    vol.fromNestedJSON({
+      'test.tar.gz': HELLO_TAR_GZ_BUFFER,
+      test: {},
+    });
+
+    await decompressTarAsync({
+      archivePath: 'test.tar.gz',
+      destinationDirectory: 'test',
+    });
+
+    expect(vol.readFileSync('test/README.md', 'utf8')).toBe('hello\n');
+    expect(vol.readFileSync('test/apps/mobile/package.json', 'utf8')).toBe('{}\n');
+  });
+});

--- a/packages/build-tools/src/utils/artifacts.ts
+++ b/packages/build-tools/src/utils/artifacts.ts
@@ -176,7 +176,7 @@ async function getArtifactSize(artifact: string): Promise<number | undefined> {
 
 // same as in
 // https://github.com/expo/eas-cli/blob/f0e3b648a1634266e7d723bd49a84866ab9b5801/packages/eas-cli/src/utils/files.ts#L33-L60
-function formatBytes(bytes: number): string {
+export function formatBytes(bytes: number): string {
   if (bytes === 0) {
     return `0`;
   }

--- a/packages/build-tools/src/utils/files.ts
+++ b/packages/build-tools/src/utils/files.ts
@@ -1,0 +1,42 @@
+// import fs from 'node:fs';
+import fsPromises from 'node:fs/promises';
+import stream from 'node:stream';
+import { promisify } from 'node:util';
+
+import * as tar from 'tar';
+
+const streamPipeline = promisify(stream.pipeline);
+
+export async function decompressTarAsync({
+  archivePath,
+  destinationDirectory,
+}: {
+  archivePath: string;
+  destinationDirectory: string;
+}): Promise<void> {
+  const fileHandle = await fsPromises.open(archivePath, 'r');
+  await streamPipeline(
+    fileHandle.createReadStream(),
+    tar.extract({ cwd: destinationDirectory }, [])
+  );
+}
+
+export async function isFileTarGzAsync(path: string): Promise<boolean> {
+  if (path.endsWith('tar.gz') || path.endsWith('.tgz')) {
+    return true;
+  }
+
+  // read only first 3 bytes to check if it's gzip
+  const fd = await fsPromises.open(path, 'r');
+  const { buffer } = await fd.read(Buffer.alloc(3), 0, 3, 0);
+  await fd.close();
+
+  if (buffer.length < 3) {
+    return false;
+  }
+
+  // Check whether provided `buffer` is a valid Gzip file header
+  // Gzip files always begin with 0x1F 0x8B 0x08 magic bytes
+  // Source: https://en.wikipedia.org/wiki/Gzip#File_format
+  return buffer[0] === 0x1f && buffer[1] === 0x8b && buffer[2] === 0x08;
+}

--- a/packages/build-tools/src/utils/strings.ts
+++ b/packages/build-tools/src/utils/strings.ts
@@ -1,0 +1,10 @@
+const PLURAL_WORDS: Record<string, string> = {
+  entry: 'entries',
+};
+
+export const pluralize = (count: number, word: string): string => {
+  const shouldUsePluralWord = count > 1 || count === 0;
+  const pluralWord = PLURAL_WORDS[word] ?? `${word}s`;
+
+  return shouldUsePluralWord ? pluralWord : word;
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1335,6 +1335,26 @@
     "@jridgewell/resolve-uri" "3.1.0"
     "@jridgewell/sourcemap-codec" "1.4.14"
 
+"@jsonjoy.com/base64@^1.1.1":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@jsonjoy.com/base64/-/base64-1.1.2.tgz#cf8ea9dcb849b81c95f14fc0aaa151c6b54d2578"
+  integrity sha512-q6XAnWQDIMA3+FTiOYajoYqySkO+JSat0ytXGSuRdq9uXE7o92gzuQwQM14xaCRlBLGq3v5miDGC4vkVTn54xA==
+
+"@jsonjoy.com/json-pack@^1.0.3":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@jsonjoy.com/json-pack/-/json-pack-1.2.0.tgz#e658900e81d194903171c42546e1aa27f446846a"
+  integrity sha512-io1zEbbYcElht3tdlqEOFxZ0dMTYrHz9iMf0gqn1pPjZFTCgM5R4R5IMA20Chb2UPYYsxjzs8CgZ7Nb5n2K2rA==
+  dependencies:
+    "@jsonjoy.com/base64" "^1.1.1"
+    "@jsonjoy.com/util" "^1.1.2"
+    hyperdyperid "^1.2.0"
+    thingies "^1.20.0"
+
+"@jsonjoy.com/util@^1.1.2", "@jsonjoy.com/util@^1.3.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@jsonjoy.com/util/-/util-1.6.0.tgz#23991b2fe12cb3a006573d9dc97c768d3ed2c9f1"
+  integrity sha512-sw/RMbehRhN68WRtcKCpQOPfnH6lLP4GJfqzi3iYej8tnzpZUDr6UkZYJjcjjC0FWEJOJbyM3PTIwxucUmDG2A==
+
 "@lerna/child-process@7.1.4":
   version "7.1.4"
   resolved "https://registry.yarnpkg.com/@lerna/child-process/-/child-process-7.1.4.tgz#5ab64540b01a339ecc6787f4f06d29aee99d71d5"
@@ -6804,14 +6824,6 @@ json-buffer@3.0.1:
   resolved "https://registry.yarnpkg.com/json-buffer/-/json-buffer-3.0.1.tgz#9338802a30d3b6605fbe0613e094008ca8c05a13"
   integrity sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==
 
-json-joy@^9.2.0:
-  version "9.4.0"
-  resolved "https://registry.yarnpkg.com/json-joy/-/json-joy-9.4.0.tgz#4e9aa2cd0378974132ec6c097d2c1a2cbc0282e7"
-  integrity sha512-qSWB6VlyQGOdzhjP5eKABYTqAzNlzFaR+uYPYzYijfbhcOSuqWP9Q6bfU7AVvNMFPnaU79vqFqezHeqFtCPXDA==
-  dependencies:
-    arg "^5.0.2"
-    hyperdyperid "^1.2.0"
-
 json-parse-better-errors@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz#bb867cfb3450e69107c131d1c514bab3dc8bcaa9"
@@ -7297,13 +7309,15 @@ math-intrinsics@^1.1.0:
   resolved "https://registry.yarnpkg.com/math-intrinsics/-/math-intrinsics-1.1.0.tgz#a0dd74be81e2aa5c2f27e65ce283605ee4e2b7f9"
   integrity sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==
 
-memfs@^4.6.0:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/memfs/-/memfs-4.6.0.tgz#e812d438f73482a7110420d13d381c730b9a4de5"
-  integrity sha512-I6mhA1//KEZfKRQT9LujyW6lRbX7RkC24xKododIDO3AGShcaFAMKElv1yFGWX8fD4UaSiwasr3NeQ5TdtHY1A==
+memfs@^4.17.1:
+  version "4.17.1"
+  resolved "https://registry.yarnpkg.com/memfs/-/memfs-4.17.1.tgz#3112332cbc2b055da3f1c0ba1fd29fdcb863621a"
+  integrity sha512-thuTRd7F4m4dReCIy7vv4eNYnU6XI/tHMLSMMHLiortw/Y0QxqKtinG523U2aerzwYWGi606oBP4oMPy4+edag==
   dependencies:
-    json-joy "^9.2.0"
-    thingies "^1.11.1"
+    "@jsonjoy.com/json-pack" "^1.0.3"
+    "@jsonjoy.com/util" "^1.3.0"
+    tree-dump "^1.0.1"
+    tslib "^2.0.0"
 
 meow@^8.1.2:
   version "8.1.2"
@@ -9819,7 +9833,7 @@ tar@^6.1.11, tar@^6.1.2:
     mkdirp "^1.0.3"
     yallist "^4.0.0"
 
-tar@^7.2.0:
+tar@^7.2.0, tar@^7.4.3:
   version "7.4.3"
   resolved "https://registry.yarnpkg.com/tar/-/tar-7.4.3.tgz#88bbe9286a3fcd900e94592cda7a22b192e80571"
   integrity sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==
@@ -9885,10 +9899,10 @@ thenify-all@^1.0.0:
   dependencies:
     any-promise "^1.0.0"
 
-thingies@^1.11.1:
-  version "1.12.0"
-  resolved "https://registry.yarnpkg.com/thingies/-/thingies-1.12.0.tgz#a815c224482d607aa70f563d3cbb351a338e4710"
-  integrity sha512-AiGqfYC1jLmJagbzQGuoZRM48JPsr9yB734a7K6wzr34NMhjUPrWSQrkF7ZBybf3yCerCL2Gcr02kMv4NmaZfA==
+thingies@^1.20.0:
+  version "1.21.0"
+  resolved "https://registry.yarnpkg.com/thingies/-/thingies-1.21.0.tgz#e80fbe58fd6fdaaab8fad9b67bd0a5c943c445c1"
+  integrity sha512-hsqsJsFMsV+aD4s3CWKk85ep/3I9XzYV/IXaSouJMYIoDlgyi11cBhsqYe9/geRfB0YIikBQg6raRaM+nIMP9g==
 
 this-file@^2.0.3:
   version "2.0.3"
@@ -9943,6 +9957,11 @@ tr46@~0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
   integrity sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=
+
+tree-dump@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/tree-dump/-/tree-dump-1.0.2.tgz#c460d5921caeb197bde71d0e9a7b479848c5b8ac"
+  integrity sha512-dpev9ABuLWdEubk+cIaI9cHwRNNDjkBBLXTwI4UCUFdQ5xXKqNXoK4FEciw/vxf+NQ7Cb7sGUyeUtORvHIdRXQ==
 
 trim-newlines@^3.0.0:
   version "3.0.1"
@@ -10017,6 +10036,11 @@ tsconfig-paths@^4.1.2:
     json5 "^2.2.2"
     minimist "^1.2.6"
     strip-bom "^3.0.0"
+
+tslib@^2.0.0:
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
+  integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
 
 tslib@^2.1.0, tslib@^2.3.0, tslib@^2.4.0:
   version "2.4.1"


### PR DESCRIPTION
# Why

https://exponent-internal.slack.com/archives/C06EFBQK3B7/p1746668839849089 Closes https://github.com/expo/eas-build/pull/512.

# How

Followed Szymon's suggestion from https://github.com/expo/eas-build/pull/512#pullrequestreview-2650487396 and set up downloading builds in TS. Mostly used what we've had in `submission-worker`. Cleaned up the logic a bit and added test.

# Test Plan

Added integration-ish tests for the function. Planning to land this, then replace a few builds-downloading scripts in staging with `eas/download_build` and test on staging.

Also tested a bunch locally.