### PR TITLE
[build-tools] Fix `mkdtemp` trying to create `/tmpabcdef`

### DIFF
--- a/packages/build-tools/src/steps/functions/downloadBuild.ts
+++ b/packages/build-tools/src/steps/functions/downloadBuild.ts
@@ -82,7 +82,9 @@ export async function downloadBuildAsync({
   expoToken: string | null;
   extensions: string[];
 }): Promise<{ artifactPath: string }> {
-  const tempDirectory = await fs.promises.mkdtemp(os.tmpdir());
+  const downloadDestinationDirectory = await fs.promises.mkdtemp(
+    path.join(os.tmpdir(), 'download_build-downloaded-')
+  );
 
   const response = await retryOnDNSFailure(fetch)(
     new URL(`/v2/artifacts/eas/${buildId}`, expoApiServerURL),
@@ -101,7 +103,7 @@ export async function downloadBuildAsync({
   const archiveFilename = path
     .basename(new URL(response.url).pathname)
     .replace(/([^a-z0-9.-]+)/gi, '_');
-  const archivePath = path.join(tempDirectory, archiveFilename);
+  const archivePath = path.join(downloadDestinationDirectory, archiveFilename);
 
   await streamPipeline(response.body, fs.createWriteStream(archivePath));
 
@@ -116,7 +118,9 @@ export async function downloadBuildAsync({
     return { artifactPath: archivePath };
   }
 
-  const extractionDirectory = await fs.promises.mkdtemp(os.tmpdir());
+  const extractionDirectory = await fs.promises.mkdtemp(
+    path.join(os.tmpdir(), 'download_build-extracted-')
+  );
   await decompressTarAsync({
     archivePath,
     destinationDirectory: extractionDirectory,


### PR DESCRIPTION
# Why

<img width="545" alt="Zrzut ekranu 2025-05-14 o 21 50 50" src="https://github.com/user-attachments/assets/677696f9-f47a-4aef-b4ee-80369b16a538" />

# How

Fixed how we create temp directories. We have a working example here we can follow: https://github.com/expo/eas-build/blob/1ef1754153197e74568677b1761be35d764b82c4/packages/build-tools/src/steps/functions/installMaestro.ts#L133

# Test Plan

Once deployed I'll rerun https://staging.expo.dev/accounts/sjchmiela/projects/staging-app/workflows/0196cf0e-512f-7727-81de-e3491a045d10.