### PR TITLE
Add more properties to interpolation context

### DIFF
--- a/packages/build-tools/src/utils/outputs.ts
+++ b/packages/build-tools/src/utils/outputs.ts
@@ -26,6 +26,9 @@ export async function uploadJobOutputsToWwwAsync(
       failure: () => ctx.hasAnyPreviousStepFailed,
       fromJSON: (json: string) => JSON.parse(json),
       toJSON: (value: unknown) => JSON.stringify(value),
+      contains: (value, substring) => value.includes(substring),
+      startsWith: (value, prefix) => value.startsWith(prefix),
+      endsWith: (value, suffix) => value.endsWith(suffix),
     };
     logger.debug({ dynamicValues: interpolationContext }, 'Using dynamic values');
 

--- a/packages/eas-build-job/src/common.ts
+++ b/packages/eas-build-job/src/common.ts
@@ -205,6 +205,13 @@ export const StaticWorkflowInterpolationContextZ = z.object({
     // We need to .optional() to support jobs that are not triggered by a GitHub event.
     .optional(),
   env: z.record(z.string()),
+  workflow: z
+    .object({
+      id: z.string(),
+      name: z.string(),
+      url: z.string().url(),
+    })
+    .passthrough(),
 });
 
 export type StaticWorkflowInterpolationContext = z.infer<

--- a/packages/eas-build-job/src/common.ts
+++ b/packages/eas-build-job/src/common.ts
@@ -218,6 +218,9 @@ export type DynamicInterpolationContext = {
   never: () => boolean;
   fromJSON: (value: string) => unknown;
   toJSON: (value: unknown) => string;
+  contains: (value: string, substring: string) => boolean;
+  startsWith: (value: string, prefix: string) => boolean;
+  endsWith: (value: string, suffix: string) => boolean;
 };
 
 export type WorkflowInterpolationContext = StaticWorkflowInterpolationContext &

--- a/packages/steps/src/BuildStep.ts
+++ b/packages/steps/src/BuildStep.ts
@@ -358,6 +358,9 @@ export class BuildStep extends BuildStepOutputAccessor {
       env: this.getScriptEnv(),
       fromJSON: (json: string) => JSON.parse(json),
       toJSON: (value: unknown) => JSON.stringify(value),
+      contains: (value, substring) => value.includes(substring),
+      startsWith: (value, prefix) => value.startsWith(prefix),
+      endsWith: (value, suffix) => value.endsWith(suffix),
     };
   }
   private async executeCommandAsync(): Promise<void> {


### PR DESCRIPTION
https://exponent-internal.slack.com/archives/C083Q88U4M8/p1747424995129729?thread_ts=1747421594.493509&cid=C083Q88U4M8

<img width="687" alt="Zrzut ekranu 2025-05-16 o 23 16 52" src="https://github.com/user-attachments/assets/a8e67da5-4e2b-4cc9-a440-de1bd3e4da91" />


`workflow` is required, because first I'm going to update `eas-build-job` in `www` so it is required to send these and only then in `turtle-v2` where the data is validated.