### PR TITLE
[submission-config] add changelog parameter

### DIFF
--- a/packages/eas-build-job/src/submission-config.ts
+++ b/packages/eas-build-job/src/submission-config.ts
@@ -14,6 +14,7 @@ export namespace SubmissionConfig {
         ascAppIdentifier: z.string(),
         isVerboseFastlaneEnabled: z.boolean().optional(),
         groups: z.array(z.string()).optional(),
+        changelog: z.string().optional(),
       })
       .and(
         z.union([
@@ -61,6 +62,7 @@ export namespace SubmissionConfig {
         changesNotSentForReview: z.boolean().default(false),
         googleServiceAccountKeyJson: z.string(),
         isVerboseFastlaneEnabled: z.boolean().optional(),
+        changelog: z.string().optional(),
       })
       .and(
         z.union([


### PR DESCRIPTION
# Why

https://linear.app/expo/issue/ENG-15743

This PR adds support for the `changelog` field in both iOS and Android submission configurations. This allows users to specify release notes for their app submissions with `eas submit`.

# How

Updated the Zod schema in `submission-config.ts` to include an optional `changelog` field for both iOS and Android.

# Test Plan

- tested as part of a larger chunk of pending changes with `eas submit --changelog someValue`