### PR TITLE
[build-tools] Allow specifying `deviceTemplateId`

### DIFF
--- a/packages/build-tools/src/steps/functions/startAndroidEmulator.ts
+++ b/packages/build-tools/src/steps/functions/startAndroidEmulator.ts
@@ -30,6 +30,11 @@ export function createStartAndroidEmulatorBuildFunction(): BuildFunction {
         allowedValueTypeName: BuildStepInputValueTypeName.STRING,
       }),
       BuildStepInput.createProvider({
+        id: 'device_template_id',
+        required: false,
+        allowedValueTypeName: BuildStepInputValueTypeName.STRING,
+      }),
+      BuildStepInput.createProvider({
         id: 'system_image_package',
         required: false,
         defaultValue: defaultSystemImagePackage,
@@ -45,6 +50,9 @@ export function createStartAndroidEmulatorBuildFunction(): BuildFunction {
     fn: async ({ logger }, { inputs, env }) => {
       const deviceName = `${inputs.device_name.value}`;
       const systemImagePackage = `${inputs.system_image_package.value}`;
+      // We can cast because allowedValueTypeName validated this is a string.
+      const deviceTemplateId = inputs.device_template_id.value as string | undefined;
+
       logger.info('Making sure system image is installed');
       await retryAsync(
         async () => {
@@ -65,7 +73,16 @@ export function createStartAndroidEmulatorBuildFunction(): BuildFunction {
       logger.info('Creating emulator device');
       const avdManager = spawn(
         'avdmanager',
-        ['create', 'avd', '--name', deviceName, '--package', systemImagePackage, '--force'],
+        [
+          'create',
+          'avd',
+          '--name',
+          deviceName,
+          '--package',
+          systemImagePackage,
+          '--force',
+          ...(deviceTemplateId ? ['--device', deviceTemplateId] : []),
+        ],
         {
           env,
           stdio: 'pipe',


### PR DESCRIPTION
# Why

https://exponent-internal.slack.com/archives/C06EFBQK3B7/p1748635317883789

# How

So for iOS we already have `device_identifier` which is "the device we want to use". Well, when Xcode is installed it autocreates a bunch of devices so the user just picks one or we default to shortest which is usually "iPhone XX".

Android comes with no virtual devices preset, so we create one. There is a `device_name` parameter which I have set a long time ago to `EasAndroidDevice01` and this is the name of the emulator we create.

However, we now need to have a way of providing a name of the device ID to use (`pixel_6` and others). So, I'm creating `device_template_id`. Or maybe it should be `device_identifier`, like it is on iOS?

# Test Plan

```yaml
jobs:
  hello_world:
    steps:
      - uses: eas/start_android_emulator
        with:
          device_template_id: pixel_6_pro
      - uses: eas/start_ios_simulator
        with:
          device_identifier: "iPad Pro 11-inch (M4)"
```

<img width="1164" alt="Zrzut ekranu 2025-06-2 o 22 19 28" src="https://github.com/user-attachments/assets/81983732-3b06-4e44-bb84-6139e7f7a9d6" />
<img width="660" alt="Zrzut ekranu 2025-06-2 o 22 19 50" src="https://github.com/user-attachments/assets/c5a68622-ac6b-4594-b413-3503a37eba38" />
