### PR TITLE
Add an opt in env for deployment pod install

### DIFF
--- a/packages/build-tools/src/ios/pod.ts
+++ b/packages/build-tools/src/ios/pod.ts
@@ -12,7 +12,7 @@ export async function installPods<TJob extends Ios.Job>(
   const iosDir = path.join(ctx.getReactNativeProjectDirectory(), 'ios');
 
   const verboseFlag = ctx.env['EAS_VERBOSE'] === '1' ? ['--verbose'] : [];
-  const cocoapodsDeploymentFlag = ctx.env['POD_INSTALL_DEPLOYMENT'] === '0' ? [] : ['--deployment'];
+  const cocoapodsDeploymentFlag = ctx.env['POD_INSTALL_DEPLOYMENT'] === '1' ? ['--deployment'] : [];
 
   return {
     spawnPromise: spawn('pod', ['install', ...verboseFlag, ...cocoapodsDeploymentFlag], {

--- a/packages/build-tools/src/steps/functions/installPods.ts
+++ b/packages/build-tools/src/steps/functions/installPods.ts
@@ -10,7 +10,7 @@ export function createInstallPodsBuildFunction(): BuildFunction {
       stepsCtx.logger.info('Installing pods');
       const verboseFlag = stepsCtx.global.env['EAS_VERBOSE'] === '1' ? ['--verbose'] : [];
       const cocoapodsDeploymentFlag =
-        stepsCtx.global.env['POD_INSTALL_DEPLOYMENT'] === '0' ? [] : ['--deployment'];
+        stepsCtx.global.env['POD_INSTALL_DEPLOYMENT'] === '1' ? ['--deployment'] : [];
 
       await spawn('pod', ['install', ...verboseFlag, ...cocoapodsDeploymentFlag], {
         logger: stepsCtx.logger,


### PR DESCRIPTION
# Why

This PR adds an option to use the `--deployment` flag on the `pod install` command.

This feature would:
- make the build fail on the pod install step rather than fingerprint check one
- give a more descriptive error in case user forgot to run `pod install`
- allow developers to use this stricter installation mode without requiring custom build configurations

[CocoaPods docs](https://guides.cocoapods.org/terminal/commands.html#pod_install)

# How

We read the feature flag `POD_INSTALL_DEPLOYMENT` and if it is set we add `--deployment` flag to `pod install` command

# Test Plan

Not needed