### PR TITLE
[steps] Remove `allowedValues` from step input

### DIFF
--- a/packages/build-tools/src/steps/functions/__tests__/uploadArtifact.test.ts
+++ b/packages/build-tools/src/steps/functions/__tests__/uploadArtifact.test.ts
@@ -28,8 +28,7 @@ describe(createUploadArtifactBuildFunction, () => {
         path: '/',
       },
     });
-    const typeInput = buildStep.inputs?.find((input) => input.id === 'type')!;
-    expect(typeInput.isValueOneOfAllowedValues()).toBe(true);
+    await expect(buildStep.executeAsync()).resolves.not.toThrowError();
   });
 
   it('accepts `path` argument', async () => {
@@ -103,9 +102,7 @@ describe(createUploadArtifactBuildFunction, () => {
         path: '/',
       },
     });
-    for (const input of buildStep.inputs ?? []) {
-      expect(input.isValueOneOfAllowedValues()).toBe(true);
-    }
+    await expect(buildStep.executeAsync()).resolves.not.toThrowError();
   });
 
   it.each(['invalid-value'])('does not accept %s', async (type) => {
@@ -115,7 +112,6 @@ describe(createUploadArtifactBuildFunction, () => {
         path: '/',
       },
     });
-    const typeInput = buildStep.inputs?.find((input) => input.id === 'type')!;
-    expect(typeInput.isValueOneOfAllowedValues()).toBe(false);
+    await expect(buildStep.executeAsync()).rejects.toThrowError('Invalid type provided.');
   });
 });

--- a/packages/build-tools/src/steps/functions/uploadArtifact.ts
+++ b/packages/build-tools/src/steps/functions/uploadArtifact.ts
@@ -19,12 +19,6 @@ export function createUploadArtifactBuildFunction(ctx: CustomBuildContext): Buil
     inputProviders: [
       BuildStepInput.createProvider({
         id: 'type',
-        allowedValues: [
-          ManagedArtifactType.APPLICATION_ARCHIVE,
-          ManagedArtifactType.BUILD_ARTIFACTS,
-          ...Object.keys(artifactTypeInputToManagedArtifactType),
-          ...Object.values(GenericArtifactType),
-        ],
         required: false,
         allowedValueTypeName: BuildStepInputValueTypeName.STRING,
       }),
@@ -57,6 +51,18 @@ export function createUploadArtifactBuildFunction(ctx: CustomBuildContext): Buil
     ],
     fn: async ({ logger, global }, { inputs }) => {
       assert(inputs.path.value, 'Path input cannot be empty.');
+
+      const allowedTypeValues = [
+        ManagedArtifactType.APPLICATION_ARCHIVE,
+        ManagedArtifactType.BUILD_ARTIFACTS,
+        ...Object.keys(artifactTypeInputToManagedArtifactType),
+        ...Object.values(GenericArtifactType),
+      ];
+      if (inputs.type.value && !allowedTypeValues.includes(inputs.type.value as string)) {
+        throw new Error(
+          `Invalid type provided. Allowed values: ${Array.from(allowedTypeValues).join(', ')}`
+        );
+      }
 
       const artifactSearchPaths = inputs.path.value
         .toString()

--- a/packages/steps/src/BuildConfig.ts
+++ b/packages/steps/src/BuildConfig.ts
@@ -139,22 +139,6 @@ const BuildFunctionInputsSchema = Joi.array().items(
               '{{#label}} must be a object or reference to output or context value',
           }),
         }),
-      allowedValues: Joi.when('allowedValueType', {
-        is: BuildStepInputValueTypeName.STRING,
-        then: Joi.array().items(Joi.string().allow('')),
-      })
-        .when('allowedValueType', {
-          is: BuildStepInputValueTypeName.BOOLEAN,
-          then: Joi.array().items(Joi.boolean()),
-        })
-        .when('allowedValueType', {
-          is: BuildStepInputValueTypeName.NUMBER,
-          then: Joi.array().items(Joi.number()),
-        })
-        .when('allowedValueType', {
-          is: BuildStepInputValueTypeName.JSON,
-          then: Joi.array().items(Joi.object()),
-        }),
       allowedValueType: Joi.string()
         .valid(...Object.values(BuildStepInputValueTypeName))
         .default(BuildStepInputValueTypeName.STRING),

--- a/packages/steps/src/BuildConfigParser.ts
+++ b/packages/steps/src/BuildConfigParser.ts
@@ -313,7 +313,6 @@ export class BuildConfigParser extends AbstractConfigParser {
             id: entry.name,
             required: entry.required ?? true,
             defaultValue: entry.defaultValue,
-            allowedValues: entry.allowedValues,
             allowedValueTypeName: entry.allowedValueType,
           });
     });

--- a/packages/steps/src/BuildStepInput.ts
+++ b/packages/steps/src/BuildStepInput.ts
@@ -37,7 +37,6 @@ interface BuildStepInputProviderParams<
   R extends boolean = boolean,
 > {
   id: string;
-  allowedValues?: unknown[];
   defaultValue?: unknown;
   required: R;
   allowedValueTypeName: T;
@@ -52,7 +51,6 @@ export interface SerializedBuildStepInput {
   id: string;
   stepDisplayName: string;
   defaultValue?: unknown;
-  allowedValues?: unknown[];
   allowedValueTypeName: BuildStepInputValueTypeName;
   required: boolean;
   value?: unknown;
@@ -66,7 +64,6 @@ export class BuildStepInput<
   public readonly id: string;
   public readonly stepDisplayName: string;
   public readonly defaultValue?: unknown;
-  public readonly allowedValues?: unknown[];
   public readonly allowedValueTypeName: T;
   public readonly required: R;
 
@@ -81,7 +78,6 @@ export class BuildStepInput<
     {
       id,
       stepDisplayName,
-      allowedValues,
       defaultValue,
       required,
       allowedValueTypeName,
@@ -89,7 +85,6 @@ export class BuildStepInput<
   ) {
     this.id = id;
     this.stepDisplayName = stepDisplayName;
-    this.allowedValues = allowedValues;
     this.defaultValue = defaultValue;
     this.required = required;
     this.allowedValueTypeName = allowedValueTypeName;
@@ -147,14 +142,6 @@ export class BuildStepInput<
     return this;
   }
 
-  public isValueOneOfAllowedValues(): boolean {
-    const value = this._value ?? this.defaultValue;
-    if (this.allowedValues === undefined || value === undefined) {
-      return true;
-    }
-    return this.allowedValues.includes(value);
-  }
-
   public isRawValueStepOrContextReference(): boolean {
     return (
       typeof this.rawValue === 'string' &&
@@ -167,7 +154,6 @@ export class BuildStepInput<
       id: this.id,
       stepDisplayName: this.stepDisplayName,
       defaultValue: this.defaultValue,
-      allowedValues: this.allowedValues,
       allowedValueTypeName: this.allowedValueTypeName,
       required: this.required,
       value: this._value,
@@ -184,7 +170,6 @@ export class BuildStepInput<
       id: serializedInput.id,
       stepDisplayName: serializedInput.stepDisplayName,
       defaultValue: serializedInput.defaultValue,
-      allowedValues: serializedInput.allowedValues,
       allowedValueTypeName: serializedInput.allowedValueTypeName,
       required: serializedInput.required,
     });

--- a/packages/steps/src/BuildWorkflowValidator.ts
+++ b/packages/steps/src/BuildWorkflowValidator.ts
@@ -77,18 +77,6 @@ export class BuildWorkflowValidator {
         if (currentStepInput.defaultValue === undefined) {
           continue;
         }
-        if (!currentStepInput.isValueOneOfAllowedValues()) {
-          const error = new BuildConfigError(
-            `Input parameter "${currentStepInput.id}" for step "${
-              currentStep.displayName
-            }" is set to "${
-              currentStepInput.value
-            }" which is not one of the allowed values: ${nullthrows(currentStepInput.allowedValues)
-              .map((i) => `"${i}"`)
-              .join(', ')}.`
-          );
-          errors.push(error);
-        }
         const paths =
           typeof currentStepInput.defaultValue === 'string'
             ? findOutputPaths(currentStepInput.defaultValue)

--- a/packages/steps/src/__tests__/BuildStepInput-test.ts
+++ b/packages/steps/src/__tests__/BuildStepInput-test.ts
@@ -506,7 +506,6 @@ describe(BuildStepInput, () => {
       defaultValue: 'bar',
       allowedValueTypeName: BuildStepInputValueTypeName.STRING,
       required: true,
-      allowedValues: ['bar', 'baz'],
     });
     i.set('bar');
     expect(i.serialize()).toEqual(
@@ -515,7 +514,6 @@ describe(BuildStepInput, () => {
         stepDisplayName: BuildStep.getDisplayName({ id: 'test1' }),
         defaultValue: 'bar',
         allowedValueTypeName: BuildStepInputValueTypeName.STRING,
-        allowedValues: ['bar', 'baz'],
         required: true,
         value: 'bar',
       })
@@ -529,7 +527,6 @@ describe(BuildStepInput, () => {
       stepDisplayName: BuildStep.getDisplayName({ id: 'test1' }),
       defaultValue: 'bar',
       allowedValueTypeName: BuildStepInputValueTypeName.STRING,
-      allowedValues: ['bar', 'baz'],
       required: true,
       value: 'bar',
       ctx: ctx.serialize(),
@@ -540,7 +537,6 @@ describe(BuildStepInput, () => {
     expect(input.stepDisplayName).toBe(BuildStep.getDisplayName({ id: 'test1' }));
     expect(input.defaultValue).toBe('bar');
     expect(input.allowedValueTypeName).toBe(BuildStepInputValueTypeName.STRING);
-    expect(input.allowedValues).toEqual(['bar', 'baz']);
     expect(input.required).toBe(true);
     expect(input.value).toBe('bar');
   });

--- a/packages/steps/src/__tests__/BuildWorkflowValidator-test.ts
+++ b/packages/steps/src/__tests__/BuildWorkflowValidator-test.ts
@@ -74,7 +74,6 @@ describe(BuildWorkflowValidator, () => {
               stepDisplayName: displayName1,
               required: true,
               defaultValue: '3',
-              allowedValues: ['1', '2'],
               allowedValueTypeName: BuildStepInputValueTypeName.STRING,
             }),
             new BuildStepInput<BuildStepInputValueTypeName>(ctx, {
@@ -82,7 +81,6 @@ describe(BuildWorkflowValidator, () => {
               stepDisplayName: displayName1,
               required: true,
               defaultValue: '3',
-              allowedValues: [true, false],
               allowedValueTypeName: BuildStepInputValueTypeName.STRING,
             }),
           ],


### PR DESCRIPTION
# Why

I'm trying to simplify the architecture here. I want to add interpolation to step inputs and it's hard for me to wrap my head around all the classes and logic here. I noticed `allowedValues` is currently only used in one function so decided to move the validation to runtime.

In the future the functions should expose Zod schema to validate input like we do with workflows.

# How

Removed `allowedValue*` code.

# Test Plan

Adjusted tests.