### PR TITLE
Add support for Android Emulator Device Identifiers

### DIFF
--- a/packages/build-tools/src/steps/functionGroups/maestroTest.ts
+++ b/packages/build-tools/src/steps/functionGroups/maestroTest.ts
@@ -34,6 +34,11 @@ export function createEasMaestroTestFunctionGroup(
         id: 'android_emulator_system_image_package',
         required: false,
       }),
+      BuildStepInput.createProvider({
+        allowedValueTypeName: BuildStepInputValueTypeName.STRING,
+        id: 'android_emulator_device_identifier',
+        required: false,
+      }),
     ],
     createBuildStepsFromFunctionGroupCall: (globalCtx, { inputs }) => {
       const steps: BuildStep[] = [
@@ -72,16 +77,20 @@ export function createEasMaestroTestFunctionGroup(
           })
         );
       } else if (buildToolsContext.job.platform === Platform.ANDROID) {
+        const callInputs: any = {};
+        
+        if (inputs.android_emulator_system_image_package.value) {
+          callInputs.system_image_package = inputs.android_emulator_system_image_package.value;
+        }
+        
+        if (inputs.android_emulator_device_identifier.value) {
+          callInputs.device_identifier = inputs.android_emulator_device_identifier.value;
+        }
+        
         steps.push(
           createStartAndroidEmulatorBuildFunction().createBuildStepFromFunctionCall(
             globalCtx,
-            inputs.android_emulator_system_image_package.value
-              ? {
-                  callInputs: {
-                    system_image_package: inputs.android_emulator_system_image_package.value,
-                  },
-                }
-              : undefined
+            Object.keys(callInputs).length > 0 ? { callInputs } : undefined
           )
         );
         const searchPath = inputs.app_path.value ?? 'android/app/build/outputs/**/*.apk';


### PR DESCRIPTION
# Why

This PR adds support for Android tablet testing in Maestro Test by introducing a new `android_emulator_device_identifier` parameter. Previously, Maestro Test could only run on the default Android emulator device (typically a phone), which limited testing capabilities for apps that need to be validated on different form factors like tablets.

Android tablets have different screen sizes, resolutions, and UI behaviors compared to phones, making it essential for developers to test their apps on tablet devices to ensure proper responsive design and user experience across all supported form factors.

# How

I added a new optional string input parameter `android_emulator_device_identifier` to the `createEasMaestroTestFunctionGroup` function in `packages/build-tools/src/steps/functionGroups/maestroTest.ts`. This parameter allows users to specify any device identifier that is supported by Android's `avdmanager` tool.

The implementation:
1. Added the new `BuildStepInput.createProvider` for `android_emulator_device_identifier` as an optional string parameter
2. Modified the Android emulator creation logic to pass the `device_identifier` to the `createStartAndroidEmulatorBuildFunction` when the parameter is provided
3. Used a flexible approach that accepts any device identifier value, not just tablets, making it extensible for future device types

The parameter is passed through to the existing `startAndroidEmulator` function which already supports the `device_identifier` parameter via `avdmanager create avd --device <device_identifier>`.

# Test Plan

To test this change:

1. **Basic tablet testing:**
   ```yaml
   - eas/maestro_test:
       flow_path: "path/to/maestro/test.yaml"
       android_emulator_device_identifier: "tablet"
   ```

2. **Specific device testing:**
   ```yaml
   - eas/maestro_test:
       flow_path: "path/to/maestro/test.yaml" 
       android_emulator_device_identifier: "Nexus 10"
   ```

3. **Backward compatibility (no device identifier specified):**
   ```yaml
   - eas/maestro_test:
       flow_path: "path/to/maestro/test.yaml"
   ```

**Expected behavior:**
- When `android_emulator_device_identifier` is provided, the Android emulator should start with the specified device characteristics
- When the parameter is omitted, the emulator should start with default device settings (maintaining backward compatibility)
- The Maestro tests should run successfully on the specified device type

**Manual verification steps:**
1. Run a build with the tablet device identifier and verify the emulator starts with tablet screen dimensions
2. Run a build without the parameter and verify it works as before
3. Check the build logs to confirm the correct `avdmanager` command is executed with the `--device` parameter when specified

**To verify the device identifier is working:**
- Check emulator logs for device creation: `avdmanager create avd --name <name> --package <package> --device <device_identifier>`
- Verify the emulator screen size matches the expected device dimensions
- Confirm Maestro tests execute properly on the specified device type