### PR TITLE
[eas-build-job] keep job steps for repack

### DIFF
--- a/packages/eas-build-job/src/__tests__/android.test.ts
+++ b/packages/eas-build-job/src/__tests__/android.test.ts
@@ -337,11 +337,20 @@ describe('Android.JobSchema', () => {
     expect(error).toBeFalsy();
   });
 
-  test('can set build mode === repack', () => {
+  test('can set build mode === repack with steps', () => {
     const job = {
       mode: BuildMode.REPACK,
       type: Workflow.UNKNOWN,
       platform: Platform.ANDROID,
+      steps: [
+        {
+          id: 'step1',
+          name: 'Step 1',
+          run: 'echo Hello, world!',
+          shell: 'sh',
+        },
+      ],
+      outputs: {},
       projectArchive: {
         type: ArchiveSourceType.URL,
         url: 'https://expo.dev/builds/123',

--- a/packages/eas-build-job/src/__tests__/ios.test.ts
+++ b/packages/eas-build-job/src/__tests__/ios.test.ts
@@ -334,11 +334,20 @@ describe('Ios.JobSchema', () => {
     expect(error).toBeFalsy();
   });
 
-  test('can set build mode === repack', () => {
+  test('can set build mode === repack with steps', () => {
     const job = {
       mode: BuildMode.REPACK,
       type: Workflow.UNKNOWN,
       platform: Platform.IOS,
+      steps: [
+        {
+          id: 'step1',
+          name: 'Step 1',
+          run: 'echo Hello, world!',
+          shell: 'sh',
+        },
+      ],
+      outputs: {},
       projectArchive: {
         type: ArchiveSourceType.URL,
         url: 'https://expo.dev/builds/123',

--- a/packages/eas-build-job/src/common.ts
+++ b/packages/eas-build-job/src/common.ts
@@ -235,7 +235,7 @@ export type WorkflowInterpolationContext = StaticWorkflowInterpolationContext &
   DynamicInterpolationContext;
 
 export const CustomBuildConfigSchema = Joi.object().when('.mode', {
-  is: BuildMode.CUSTOM,
+  is: [BuildMode.CUSTOM, BuildMode.REPACK],
   then: Joi.object().when('.customBuildConfig.path', {
     is: Joi.exist(),
     then: Joi.object({


### PR DESCRIPTION
# Why

to reuse `BuildMode.REPACK` for the new workflow repack job.

# How

the new workflow repack acts like a custom build. we should keep its job steps.

# Test Plan

test with local turtle repack workflow run
