### PR TITLE
[steps] Simplify inputs passed to step functions

### DIFF
--- a/packages/steps/src/BuildStep.ts
+++ b/packages/steps/src/BuildStep.ts
@@ -50,7 +50,11 @@ export type BuildStepFunction = (
     inputs,
     outputs,
     env,
-  }: { inputs: BuildStepInputById; outputs: BuildStepOutputById; env: BuildStepEnv }
+  }: {
+    inputs: { [key: string]: { value: unknown } | undefined };
+    outputs: BuildStepOutputById;
+    env: BuildStepEnv;
+  }
 ) => unknown;
 
 // TODO: move to a place common with tests

--- a/packages/steps/src/BuildStep.ts
+++ b/packages/steps/src/BuildStep.ts
@@ -51,7 +51,7 @@ export type BuildStepFunction = (
     outputs,
     env,
   }: {
-    inputs: { [key: string]: { value: unknown } | undefined };
+    inputs: { [key: string]: { value: unknown } };
     outputs: BuildStepOutputById;
     env: BuildStepEnv;
   }

--- a/packages/steps/src/BuildStepInput.ts
+++ b/packages/steps/src/BuildStepInput.ts
@@ -1,8 +1,6 @@
 import assert from 'assert';
 
-import { bunyan } from '@expo/logger';
-
-import { BuildStepGlobalContext, SerializedBuildStepGlobalContext } from './BuildStepContext.js';
+import { BuildStepGlobalContext } from './BuildStepContext.js';
 import { BuildStepRuntimeError } from './errors.js';
 import {
   BUILD_STEP_OR_BUILD_GLOBAL_CONTEXT_REFERENCE_REGEX,
@@ -46,17 +44,6 @@ interface BuildStepInputProviderParams<
 interface BuildStepInputParams<T extends BuildStepInputValueTypeName, R extends boolean>
   extends BuildStepInputProviderParams<T, R> {
   stepDisplayName: string;
-}
-
-export interface SerializedBuildStepInput {
-  id: string;
-  stepDisplayName: string;
-  defaultValue?: unknown;
-  allowedValues?: unknown[];
-  allowedValueTypeName: BuildStepInputValueTypeName;
-  required: boolean;
-  value?: unknown;
-  ctx: SerializedBuildStepGlobalContext;
 }
 
 export class BuildStepInput<
@@ -160,36 +147,6 @@ export class BuildStepInput<
       typeof this.rawValue === 'string' &&
       !!BUILD_STEP_OR_BUILD_GLOBAL_CONTEXT_REFERENCE_REGEX.exec(this.rawValue)
     );
-  }
-
-  public serialize(): SerializedBuildStepInput {
-    return {
-      id: this.id,
-      stepDisplayName: this.stepDisplayName,
-      defaultValue: this.defaultValue,
-      allowedValues: this.allowedValues,
-      allowedValueTypeName: this.allowedValueTypeName,
-      required: this.required,
-      value: this._value,
-      ctx: this.ctx.serialize(),
-    };
-  }
-
-  public static deserialize(
-    serializedInput: SerializedBuildStepInput,
-    logger: bunyan
-  ): BuildStepInput {
-    const deserializedContext = BuildStepGlobalContext.deserialize(serializedInput.ctx, logger);
-    const input = new BuildStepInput(deserializedContext, {
-      id: serializedInput.id,
-      stepDisplayName: serializedInput.stepDisplayName,
-      defaultValue: serializedInput.defaultValue,
-      allowedValues: serializedInput.allowedValues,
-      allowedValueTypeName: serializedInput.allowedValueTypeName,
-      required: serializedInput.required,
-    });
-    input._value = serializedInput.value;
-    return input;
   }
 
   private parseInputValueToAllowedType(value: string | object): BuildStepInputValueType<T> {

--- a/packages/steps/src/__tests__/BuildStep-test.ts
+++ b/packages/steps/src/__tests__/BuildStep-test.ts
@@ -6,13 +6,9 @@ import { instance, mock, verify, when } from 'ts-mockito';
 import { v4 as uuidv4 } from 'uuid';
 
 import { BuildStep, BuildStepFunction, BuildStepStatus } from '../BuildStep.js';
-import {
-  BuildStepInput,
-  BuildStepInputById,
-  BuildStepInputValueTypeName,
-} from '../BuildStepInput.js';
+import { BuildStepInput, BuildStepInputValueTypeName } from '../BuildStepInput.js';
 import { BuildStepGlobalContext, BuildStepContext } from '../BuildStepContext.js';
-import { BuildStepOutput, BuildStepOutputById } from '../BuildStepOutput.js';
+import { BuildStepOutput } from '../BuildStepOutput.js';
 import { BuildStepRuntimeError } from '../errors.js';
 import { nullthrows } from '../utils/nullthrows.js';
 import { BuildRuntimePlatform } from '../BuildRuntimePlatform.js';
@@ -404,17 +400,12 @@ describe(BuildStep, () => {
 
       it('collects the envs after calling the fn', async () => {
         const id = 'test1';
-        const fn = jest.fn(
-          async (
-            ctx: BuildStepContext,
-            { env }: { inputs: BuildStepInputById; outputs: BuildStepOutputById; env: BuildStepEnv }
-          ) => {
-            await spawnAsync('set-env', ['ABC', '123'], {
-              cwd: ctx.workingDirectory,
-              env,
-            });
-          }
-        );
+        const fn = jest.fn(async (ctx: BuildStepContext, { env }: { env: BuildStepEnv }) => {
+          await spawnAsync('set-env', ['ABC', '123'], {
+            cwd: ctx.workingDirectory,
+            env,
+          });
+        });
         const displayName = BuildStep.getDisplayName({ id });
 
         const step = new BuildStep(baseStepCtx, {
@@ -428,17 +419,12 @@ describe(BuildStep, () => {
 
       it('collects the outputs after calling the fn', async () => {
         const id = 'test1';
-        const fn = jest.fn(
-          async (
-            ctx: BuildStepContext,
-            { env }: { inputs: BuildStepInputById; outputs: BuildStepOutputById; env: BuildStepEnv }
-          ) => {
-            await spawnAsync('set-output', ['abc', '123'], {
-              cwd: ctx.workingDirectory,
-              env,
-            });
-          }
-        );
+        const fn = jest.fn(async (ctx: BuildStepContext, { env }: { env: BuildStepEnv }) => {
+          await spawnAsync('set-output', ['abc', '123'], {
+            cwd: ctx.workingDirectory,
+            env,
+          });
+        });
         const displayName = BuildStep.getDisplayName({ id });
 
         const step = new BuildStep(baseStepCtx, {
@@ -625,7 +611,7 @@ describe(BuildStep, () => {
 
         const fn: BuildStepFunction = (_ctx, { inputs, outputs }) => {
           outputs.abc.set(
-            `${inputs.foo1.value} ${inputs.foo2.value} ${inputs.foo3.value} ${inputs.foo4.value}`
+            `${inputs.foo1?.value} ${inputs.foo2?.value} ${inputs.foo3?.value} ${inputs.foo4?.value}`
           );
         };
 

--- a/packages/steps/src/__tests__/BuildStepInput-test.ts
+++ b/packages/steps/src/__tests__/BuildStepInput-test.ts
@@ -9,7 +9,6 @@ import {
 } from '../BuildStepInput.js';
 
 import { createGlobalContextMock } from './utils/context.js';
-import { createMockLogger } from './utils/logger.js';
 
 describe(BuildStepInput, () => {
   test('basic case string', () => {
@@ -496,53 +495,6 @@ describe(BuildStepInput, () => {
     }).toThrowError(
       new BuildStepRuntimeError('Input parameter "foo" for step "test1" is required.')
     );
-  });
-
-  test('serializes correctly', () => {
-    const ctx = createGlobalContextMock();
-    const i = new BuildStepInput<BuildStepInputValueTypeName>(ctx, {
-      id: 'foo',
-      stepDisplayName: BuildStep.getDisplayName({ id: 'test1' }),
-      defaultValue: 'bar',
-      allowedValueTypeName: BuildStepInputValueTypeName.STRING,
-      required: true,
-      allowedValues: ['bar', 'baz'],
-    });
-    i.set('bar');
-    expect(i.serialize()).toEqual(
-      expect.objectContaining({
-        id: 'foo',
-        stepDisplayName: BuildStep.getDisplayName({ id: 'test1' }),
-        defaultValue: 'bar',
-        allowedValueTypeName: BuildStepInputValueTypeName.STRING,
-        allowedValues: ['bar', 'baz'],
-        required: true,
-        value: 'bar',
-      })
-    );
-  });
-
-  test('deserializes correctly', () => {
-    const ctx = createGlobalContextMock();
-    const serializedInput = {
-      id: 'foo',
-      stepDisplayName: BuildStep.getDisplayName({ id: 'test1' }),
-      defaultValue: 'bar',
-      allowedValueTypeName: BuildStepInputValueTypeName.STRING,
-      allowedValues: ['bar', 'baz'],
-      required: true,
-      value: 'bar',
-      ctx: ctx.serialize(),
-    };
-    const input = BuildStepInput.deserialize(serializedInput, createMockLogger());
-    expect(input).toBeInstanceOf(BuildStepInput);
-    expect(input.id).toBe('foo');
-    expect(input.stepDisplayName).toBe(BuildStep.getDisplayName({ id: 'test1' }));
-    expect(input.defaultValue).toBe('bar');
-    expect(input.allowedValueTypeName).toBe(BuildStepInputValueTypeName.STRING);
-    expect(input.allowedValues).toEqual(['bar', 'baz']);
-    expect(input.required).toBe(true);
-    expect(input.value).toBe('bar');
   });
 });
 

--- a/packages/steps/src/scripts/runCustomFunction.ts
+++ b/packages/steps/src/scripts/runCustomFunction.ts
@@ -5,8 +5,10 @@ import { SpawnPromise, SpawnResult } from '@expo/spawn-async';
 import cloneDeep from 'lodash.clonedeep';
 
 import { BuildStepOutput } from '../BuildStepOutput.js';
-import { BuildStepInput } from '../BuildStepInput.js';
-import { SerializedCustomBuildFunctionArguments } from '../utils/customFunction.js';
+import {
+  SerializedCustomBuildFunctionArguments,
+  deserializeInputs,
+} from '../utils/customFunction.js';
 import { BuildStepContext } from '../BuildStepContext.js';
 import { BuildStepFunction } from '../BuildStep.js';
 import { spawnAsync } from '../utils/shell/spawn.js';
@@ -67,12 +69,7 @@ async function runCustomJsFunctionAsync(): Promise<void> {
   });
 
   const ctx = BuildStepContext.deserialize(serializedFunctionArguments.ctx, logger);
-  const inputs = Object.fromEntries(
-    Object.entries(serializedFunctionArguments.inputs).map(([id, input]) => [
-      id,
-      BuildStepInput.deserialize(input, logger),
-    ])
-  );
+  const inputs = deserializeInputs(serializedFunctionArguments.inputs);
   const outputs = Object.fromEntries(
     Object.entries(serializedFunctionArguments.outputs).map(([id, output]) => [
       id,

--- a/packages/steps/src/utils/__tests__/customFunction-test.ts
+++ b/packages/steps/src/utils/__tests__/customFunction-test.ts
@@ -1,0 +1,44 @@
+import { deserializeInputs, serializeInputs } from '../customFunction.js';
+
+describe(serializeInputs, () => {
+  test('serializes inputs correctly', () => {
+    const inputs = {
+      foo: { value: 'bar' },
+      baz: { value: 123 },
+      qux: { value: true },
+      quux: { value: { foo: 'bar' } },
+      quuux: { value: ['foo', 'bar'] },
+      quuuux: { value: null },
+    };
+    const serializedInputs = serializeInputs(inputs);
+    expect(serializedInputs).toEqual({
+      foo: { serializedValue: '"bar"' },
+      baz: { serializedValue: '123' },
+      qux: { serializedValue: 'true' },
+      quux: { serializedValue: '{"foo":"bar"}' },
+      quuux: { serializedValue: '["foo","bar"]' },
+      quuuux: { serializedValue: 'null' },
+    });
+  });
+});
+
+describe(deserializeInputs, () => {
+  test('deserializes inputs correctly', () => {
+    const inputs = deserializeInputs({
+      foo: { serializedValue: '"bar"' },
+      baz: { serializedValue: '123' },
+      qux: { serializedValue: 'true' },
+      quux: { serializedValue: '{"foo":"bar"}' },
+      quuux: { serializedValue: '["foo","bar"]' },
+      quuuux: { serializedValue: 'null' },
+    });
+    expect(inputs).toEqual({
+      foo: { value: 'bar' },
+      baz: { value: 123 },
+      qux: { value: true },
+      quux: { value: { foo: 'bar' } },
+      quuux: { value: ['foo', 'bar'] },
+      quuuux: { value: null },
+    });
+  });
+});


### PR DESCRIPTION
# Why

Currently, the legacy `${ ... }` interpolation uses env from global context, meaning it won't have access to `env:` provided to the step. That `env:` provided to the step is only accessible in `BuildStep`.

To add support for step `env` interpolation, we're going to need to provide `interpolationContext` from the `BuildStep` to `BuildStepInput` when getting the input value.

At the same time I think using `.value` to get input value is convenient and I don't want to change the API so functions need to `getValue({ interpolationContext })`. Let's let functions keep doing `inputs.app_path.value` and interpolation happen behind the scenes.

In order to do that, I'm changing the type of `inputs` passed to build step functions from `BuildStepInputById = Record<string, BuildStepInput>` to `Record<string, { value: unknown }>`. Note: technically this should be `{ value: unknown } | undefined`, but this would require a lot of unnecessary changes in existing functions. Maybe in a separate pull request.

Most of `eas-build` is ok with this change. The exception is custom functions.

In Custom Builds we support [custom functions](https://docs.expo.dev/custom-builds/schema/#functions). Custom functions can be implemented as [JS/TS functions](https://docs.expo.dev/custom-builds/functions/). The function the build process uses consists of a precompiled JS file we execute with more or less `node runCustomFunction.cjs userFunction.js "{env:...,inputs:...,outputs:...,ctx:...}"` — notice we are _not_ importing the module, we're executing it in a separate process and to forward it all the context we serialize env, inputs, outputs.

So, `BuildStepInput` (and other classes) have `.serialize()` and `.deserialize()`. Now that `BuildStepFunction` is not going to receive `BuildStepInput` which can serialize and deserialize itself, but a `{ value: unknown }`, we need to serialize and deserialize inputs ourselves. Which is very simple for `{ value: unknown }`.

# How

Changed typing of `BuildStepFunction` so `inputs` is _not_ about `BuildStepInput`, but rather about plain `{ value: unknown }` object.

Adjusted custom functions runner and inputs serialization / deserialization.

# Test Plan

Adjusted serialization / deserialization tests. Remaining tests should pass.