### PR TITLE
[build-tools] Do not lose workflow interpolation context in `updateJobInformation`

### DIFF
--- a/packages/build-tools/src/__tests__/context.test.ts
+++ b/packages/build-tools/src/__tests__/context.test.ts
@@ -78,4 +78,40 @@ describe('BuildContext', () => {
       ],
     });
   });
+
+  it('should not lose worklfowInterpolationContext', async () => {
+    const robotAccessToken = randomUUID();
+    await vol.promises.mkdir('/workingdir/environment-secrets/', { recursive: true });
+
+    const ctx = new BuildContext(
+      {
+        triggeredBy: BuildTrigger.GIT_BASED_INTEGRATION,
+        secrets: {
+          robotAccessToken,
+          environmentSecrets: [
+            {
+              name: 'TEST_SECRET',
+              value: 'test-secret-value',
+            },
+          ],
+        },
+        workflowInterpolationContext: {
+          foo: 'bar',
+        } as any,
+      } as Job,
+      {
+        env: {},
+        workingdir: '/workingdir',
+        logger: createMockLogger(),
+        logBuffer: { getLogs: () => [], getPhaseLogs: () => [] },
+        uploadArtifact: jest.fn(),
+      }
+    );
+
+    ctx.updateJobInformation({} as Job, {} as Metadata);
+
+    expect(ctx.job.workflowInterpolationContext).toEqual({
+      foo: 'bar',
+    });
+  });
 });

--- a/packages/build-tools/src/context.ts
+++ b/packages/build-tools/src/context.ts
@@ -239,6 +239,8 @@ export class BuildContext<TJob extends Job = Job> {
     }
     this._job = {
       ...job,
+      workflowInterpolationContext:
+        job.workflowInterpolationContext ?? this.job.workflowInterpolationContext,
       triggeredBy: this._job.triggeredBy,
       secrets: {
         ...this.job.secrets,

--- a/packages/build-tools/src/customBuildContext.ts
+++ b/packages/build-tools/src/customBuildContext.ts
@@ -115,6 +115,7 @@ export class CustomBuildContext<TJob extends Job = Job> implements ExternalBuild
     }
     this.job = {
       ...job,
+      workflowInterpolationContext: this.job.workflowInterpolationContext,
       triggeredBy: this.job.triggeredBy,
       secrets: {
         ...this.job.secrets,


### PR DESCRIPTION
# Why

Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.

# How

How did you build this feature or fix this bug and why?

# Test Plan

Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
