### PR TITLE
[build-tools] Move from `EXPO_TOKEN` to `robotAccessToken`

### DIFF
--- a/packages/build-tools/src/common/projectSources.ts
+++ b/packages/build-tools/src/common/projectSources.ts
@@ -50,7 +50,10 @@ export async function prepareProjectSourcesAsync<TJob extends Job>(
 async function fetchRepositoryUrlAsync(ctx: BuildContext<Job>): Promise<string> {
   const taskId = nullthrows(ctx.env.EAS_BUILD_ID, 'EAS_BUILD_ID is not set');
   const expoApiServerURL = nullthrows(ctx.env.__API_SERVER_URL, '__API_SERVER_URL is not set');
-  const expoToken = nullthrows(ctx.env.EXPO_TOKEN, 'EXPO_TOKEN is not set');
+  const robotAccessToken = nullthrows(
+    ctx.job.secrets?.robotAccessToken,
+    'robot access token is not set'
+  );
 
   const response = await turtleFetch(
     new URL(`/v2/github/fetch-github-repository-url`, expoApiServerURL).toString(),
@@ -58,7 +61,7 @@ async function fetchRepositoryUrlAsync(ctx: BuildContext<Job>): Promise<string> 
     {
       json: { taskId },
       headers: {
-        Authorization: `Bearer ${expoToken}`,
+        Authorization: `Bearer ${robotAccessToken}`,
       },
       timeout: 20000,
       retries: 3,

--- a/packages/build-tools/src/steps/functions/__tests__/downloadBuild.test.ts
+++ b/packages/build-tools/src/steps/functions/__tests__/downloadBuild.test.ts
@@ -30,7 +30,7 @@ describe('downloadBuild', () => {
       logger: createLogger({ name: 'test' }),
       buildId: randomUUID(),
       expoApiServerURL: 'http://api.expo.test',
-      expoToken: null,
+      robotAccessToken: null,
       extensions: ['app'],
     });
 
@@ -51,7 +51,7 @@ describe('downloadBuild', () => {
       logger: createLogger({ name: 'test' }),
       buildId: randomUUID(),
       expoApiServerURL: 'http://api.expo.test',
-      expoToken: null,
+      robotAccessToken: null,
       extensions: ['app'],
     });
 
@@ -71,7 +71,7 @@ describe('downloadBuild', () => {
         logger: createLogger({ name: 'test' }),
         buildId: randomUUID(),
         expoApiServerURL: 'http://api.expo.test',
-        expoToken: null,
+        robotAccessToken: null,
         extensions: ['apk'],
       })
     ).rejects.toThrow('No .apk entries found in the archive.');
@@ -88,6 +88,7 @@ describe('createDownloadBuildFunction', () => {
         logger,
         staticContextContent: {
           expoApiServerURL: 'http://api.expo.test',
+          job: {},
         },
       }),
       {

--- a/packages/build-tools/src/steps/functions/downloadBuild.ts
+++ b/packages/build-tools/src/steps/functions/downloadBuild.ts
@@ -48,7 +48,7 @@ export function createDownloadBuildFunction(): BuildFunction {
         required: true,
       }),
     ],
-    fn: async (stepsCtx, { inputs, outputs, env }) => {
+    fn: async (stepsCtx, { inputs, outputs }) => {
       const { logger } = stepsCtx;
 
       const extensions = z.array(z.string()).parse(inputs.extensions.value);
@@ -60,7 +60,7 @@ export function createDownloadBuildFunction(): BuildFunction {
         logger,
         buildId,
         expoApiServerURL: stepsCtx.global.staticContext.expoApiServerURL,
-        expoToken: env.EXPO_TOKEN ?? null,
+        robotAccessToken: stepsCtx.global.staticContext.job.secrets?.robotAccessToken ?? null,
         extensions,
       });
 
@@ -73,13 +73,13 @@ export async function downloadBuildAsync({
   logger,
   buildId,
   expoApiServerURL,
-  expoToken,
+  robotAccessToken,
   extensions,
 }: {
   logger: bunyan;
   buildId: string;
   expoApiServerURL: string;
-  expoToken: string | null;
+  robotAccessToken: string | null;
   extensions: string[];
 }): Promise<{ artifactPath: string }> {
   const downloadDestinationDirectory = await fs.promises.mkdtemp(
@@ -89,7 +89,7 @@ export async function downloadBuildAsync({
   const response = await retryOnDNSFailure(fetch)(
     new URL(`/v2/artifacts/eas/${buildId}`, expoApiServerURL),
     {
-      headers: expoToken ? { Authorization: `Bearer ${expoToken}` } : undefined,
+      headers: robotAccessToken ? { Authorization: `Bearer ${robotAccessToken}` } : undefined,
     }
   );
 


### PR DESCRIPTION
# Why

https://github.com/expo/universe/pull/20604#issuecomment-2979765403

We should use `robotAccessToken` because `EXPO_TOKEN` may be overridden by the user to an `AccessTokenEntity`.

# How

Instead of using `env.EXPO_TOKEN` we're going to use `robotAccessToken` from secrets.

# Test Plan

Tested manually by:
- changing `launcher` to pass some invalid `repositoryUrl` to worker for clone.
- running an `eas/download_build`.

```yaml
on:
  push:
    branches: ['*']

jobs:
  download_build:
    steps:
      - run: ls -lah
      - uses: eas/checkout
      - run: ls -lah
      - uses: eas/download_build
        with:
          build_id: 6a3ff454-6a8b-42fc-b540-3e2ed831abbd
```

The URL must have refreshed, because I see directory contents. Downloading build would have succeeded, otherwise I would get `UNAUTHORIZED`, not `GCS_FILE_NOT_FOUND`.

<img width="1154" alt="Zrzut ekranu 2025-06-17 o 16 48 36" src="https://github.com/user-attachments/assets/7735af81-4056-405d-9273-994ec67da785" />
