### PR TITLE
[build-tools] bump repack 0.2.5

### DIFF
--- a/packages/build-tools/package.json
+++ b/packages/build-tools/package.json
@@ -30,7 +30,7 @@
     "@expo/logger": "1.0.117",
     "@expo/package-manager": "1.7.0",
     "@expo/plist": "^0.2.0",
-    "@expo/repack-app": "~0.2.4",
+    "@expo/repack-app": "~0.2.5",
     "@expo/results": "^1.0.0",
     "@expo/steps": "1.0.186",
     "@expo/template-file": "1.0.117",

--- a/yarn.lock
+++ b/yarn.lock
@@ -772,10 +772,10 @@
     base64-js "^1.2.3"
     xmlbuilder "^14.0.0"
 
-"@expo/repack-app@~0.2.4":
-  version "0.2.4"
-  resolved "https://registry.yarnpkg.com/@expo/repack-app/-/repack-app-0.2.4.tgz#0f71020e860de7790dedb3234120470d6c377a9f"
-  integrity sha512-RM2lSYoIicCL84rw1s6DTpZ1DNnVl+0rNXedHRbJAPMPssmXmWeDBrukC57FsLrzt5ED8W0kJN5rTclM5tTSxA==
+"@expo/repack-app@~0.2.5":
+  version "0.2.5"
+  resolved "https://registry.yarnpkg.com/@expo/repack-app/-/repack-app-0.2.5.tgz#834b85c2e6b32dbe1ae7960bdcad3c9230ea889c"
+  integrity sha512-2P7Ce78DXe5qcs23USLyrJWHty9lpe46Lt/BHILKfqSjD9ekfFx6Cwt6xdKlDxPxuTjKOQ5JxjWcMuj4R1n/qg==
   dependencies:
     commander "^13.1.0"
     picocolors "^1.1.1"


### PR DESCRIPTION
# Why

repack 0.2.5 added [environment variables support](https://github.com/expo/repack-app/pull/30). that would help to resolve build variants issue using environment variables. 

# How

bump repack 0.2.5

# Test Plan

- ci passed
- test local turtle with build variants and pass `EXPO_PUBLIC_TEST` from eas.json
```js
const bundleIdentifier = process.env.EXPO_PUBLIC_TEST === 'test' ? 'dev.expo.kudo.sdk53' : 'dev.expo.kudo.sdk53.develop';
/** @type {import('expo/config').ExpoConfig} */
module.exports = ({ config }) => ({
  ...config,
  ios: {
    bundleIdentifier,
  }
});
```
