### PR TITLE
[build-tools] Delete `.expo` directory when preparing project

### DIFF
--- a/packages/build-tools/src/common/__tests__/setup.test.ts
+++ b/packages/build-tools/src/common/__tests__/setup.test.ts
@@ -1,0 +1,100 @@
+import { randomUUID } from 'crypto';
+import path from 'path';
+
+import { vol } from 'memfs';
+import fs from 'fs-extra';
+import {
+  Platform,
+  BuildMode,
+  BuildTrigger,
+  Workflow,
+  ArchiveSourceType,
+  BuildJob,
+} from '@expo/eas-build-job';
+
+import { BuildContext } from '../..';
+import { prepareProjectAsync } from '../setup';
+import { createMockLogger } from '../../__tests__/utils/logger';
+
+jest.mock('../projectSources');
+
+describe('setup', () => {
+  beforeEach(() => {
+    vol.reset();
+  });
+
+  it('should delete .expo directory if it exists', async () => {
+    // Arrange
+    const projectRoot = '/app';
+    await vol.promises.mkdir(path.join(projectRoot, '.expo'), { recursive: true });
+    await vol.promises.writeFile(path.join(projectRoot, '.expo', 'test.txt'), 'test');
+
+    const ctx = new BuildContext(
+      {
+        triggeredBy: BuildTrigger.EAS_CLI,
+        type: Workflow.MANAGED,
+        mode: BuildMode.BUILD,
+        initiatingUserId: randomUUID(),
+        appId: randomUUID(),
+        projectArchive: {
+          type: ArchiveSourceType.PATH,
+          path: projectRoot,
+        },
+        platform: Platform.IOS,
+        secrets: {
+          robotAccessToken: randomUUID(),
+          environmentSecrets: [],
+        },
+      } as BuildJob,
+      {
+        env: {},
+        workingdir: '/workingdir',
+        logger: createMockLogger(),
+        logBuffer: { getLogs: () => [], getPhaseLogs: () => [] },
+        uploadArtifact: jest.fn(),
+      }
+    );
+    jest.spyOn(ctx, 'getReactNativeProjectDirectory').mockReturnValue(projectRoot);
+
+    // Act
+    await prepareProjectAsync(ctx);
+
+    // Assert
+    expect(await fs.pathExists(path.join(projectRoot, '.expo'))).toBe(false);
+  });
+
+  it('should not fail if .expo directory does not exist', async () => {
+    const projectRoot = '/app';
+
+    const ctx = new BuildContext(
+      {
+        triggeredBy: BuildTrigger.EAS_CLI,
+        type: Workflow.MANAGED,
+        mode: BuildMode.BUILD,
+        initiatingUserId: randomUUID(),
+        appId: randomUUID(),
+        projectArchive: {
+          type: ArchiveSourceType.PATH,
+          path: projectRoot,
+        },
+        platform: Platform.IOS,
+        secrets: {
+          robotAccessToken: randomUUID(),
+          environmentSecrets: [],
+        },
+      } as BuildJob,
+      {
+        env: {},
+        workingdir: '/workingdir',
+        logger: createMockLogger(),
+        logBuffer: { getLogs: () => [], getPhaseLogs: () => [] },
+        uploadArtifact: jest.fn(),
+      }
+    );
+    jest.spyOn(ctx, 'getReactNativeProjectDirectory').mockReturnValue(projectRoot);
+
+    await prepareProjectAsync(ctx);
+
+    expect(await fs.pathExists(path.join(projectRoot, '.expo'))).toBe(false);
+  });
+});

--- a/packages/build-tools/src/common/setup.ts
+++ b/packages/build-tools/src/common/setup.ts
@@ -38,6 +38,18 @@ export async function setupAsync<TJob extends BuildJob>(ctx: BuildContext<TJob>)
     if (ctx.job.platform === Platform.IOS && ctx.env.EAS_BUILD_RUNNER === 'eas-build') {
       await deleteXcodeEnvLocalIfExistsAsync(ctx as BuildContext<Ios.Job>);
     }
+
+    // Delete .expo directory if it exists.
+    const expoDir = path.join(ctx.getReactNativeProjectDirectory(), '.expo');
+    try {
+      if (await fs.pathExists(expoDir)) {
+        await fs.remove(expoDir);
+        ctx.logger.info('Deleted .expo directory.');
+      }
+    } catch (err) {
+      ctx.logger.warn({ err }, 'Failed to delete .expo directory.');
+    }
+
     if (ctx.job.triggeredBy === BuildTrigger.GIT_BASED_INTEGRATION) {
       // We need to setup envs from eas.json before
       // eas-build-pre-install hook is called.


### PR DESCRIPTION
# Why

https://exponent-internal.slack.com/archives/C02123T524U/p1750714495497629

# How

The prepare project phase is run for Android and iOS builds.

I'm not 100% convinced this is a good change. I worry down the build process some things may, for instance, expect the repository to be clean and, if `.expo` is being tracked, we'll make the working directory dirty. Isn't it better to fail here than there? What do you think?

# Test Plan

Added tests.