### PR TITLE
[build-tools] Do not print job in case of error

### DIFF
--- a/packages/build-tools/src/common/easBuildInternal.ts
+++ b/packages/build-tools/src/common/easBuildInternal.ts
@@ -46,42 +46,31 @@ export async function runEasBuildInternalAsync<TJob extends BuildJob>({
     autoSubmitArgs.push('--auto-submit');
   }
 
-  let result;
-  try {
-    result = await spawn(
-      cmd,
-      [
-        ...args,
-        'build:internal',
-        '--platform',
-        job.platform,
-        '--profile',
-        buildProfile,
-        ...autoSubmitArgs,
-      ],
-      {
-        cwd,
-        env: {
-          ...env,
-          EXPO_TOKEN: nullthrows(job.secrets, 'Secrets must be defined for non-custom builds')
-            .robotAccessToken,
-          ...extraEnv,
-          EAS_PROJECT_ROOT: projectRootOverride,
-        },
-        logger,
-        mode: PipeMode.STDERR_ONLY_AS_STDOUT,
-      }
-    );
-  } catch (err: any) {
-    // Logging of build:internal is weird. We set mode = STDERR_ONLY_AS_STDOUT,
-    // because we don't want to pipe stdout to to the logger as it will contain
-    // the job object with its secrets. However, if the build fails, stderr alone
-    // is often not enough to debug the issue, so we also log stdout in those cases.
-    // It will look awkward (first stderr from pipe, then stdout from here), but
-    // it's better than nothing.
-    logger.error(`${err.stdout}`);
-    throw err;
-  }
+  const result = await spawn(
+    cmd,
+    [
+      ...args,
+      'build:internal',
+      '--platform',
+      job.platform,
+      '--profile',
+      buildProfile,
+      ...autoSubmitArgs,
+    ],
+    {
+      cwd,
+      env: {
+        ...env,
+        EXPO_TOKEN: nullthrows(job.secrets, 'Secrets must be defined for non-custom builds')
+          .robotAccessToken,
+        ...extraEnv,
+        EAS_PROJECT_ROOT: projectRootOverride,
+      },
+      logger,
+      // This prevents printing stdout with job secrets and credentials to logs.
+      mode: PipeMode.STDERR_ONLY_AS_STDOUT,
+    }
+  );
 
   const stdout = result.stdout.toString();
   const parsed = JSON.parse(stdout);


### PR DESCRIPTION
# Why

https://exponent-internal.slack.com/archives/C02123T524U/p1750892856735459

Turns out, if `--auto-submit` is defined, a job may be printed out _and later_ `eas-cli` may fail.

# How

Removed `try-catch` in which we would print stdout of the process.

# Test Plan

CI should pass.