### PR TITLE
[build-tools] Add `eas/download_artifact`

### DIFF
--- a/packages/build-tools/src/context.ts
+++ b/packages/build-tools/src/context.ts
@@ -43,7 +43,7 @@ export type ArtifactToUpload =
     }
   | {
       type: GenericArtifactType;
-      key: string;
+      name: string;
       paths: string[];
     };
 

--- a/packages/build-tools/src/steps/easFunctions.ts
+++ b/packages/build-tools/src/steps/easFunctions.ts
@@ -29,10 +29,12 @@ import { eagerBundleBuildFunction } from './functions/eagerBundle';
 import { createSubmissionEntityFunction } from './functions/createSubmissionEntity';
 import { createDownloadBuildFunction } from './functions/downloadBuild';
 import { createRepackBuildFunction } from './functions/repack';
+import { createDownloadArtifactFunction } from './functions/downloadArtifact';
 
 export function getEasFunctions(ctx: CustomBuildContext): BuildFunction[] {
   const functions = [
     createCheckoutBuildFunction(),
+    createDownloadArtifactFunction(),
     createUploadArtifactBuildFunction(ctx),
     createSetUpNpmrcBuildFunction(),
     createInstallNodeModulesBuildFunction(),

--- a/packages/build-tools/src/steps/functions/downloadArtifact.ts
+++ b/packages/build-tools/src/steps/functions/downloadArtifact.ts
@@ -1,0 +1,158 @@
+import path from 'node:path';
+import fs from 'node:fs';
+import os from 'node:os';
+import stream from 'stream';
+import { promisify } from 'util';
+
+import {
+  BuildFunction,
+  BuildStepInput,
+  BuildStepInputValueTypeName,
+  BuildStepOutput,
+} from '@expo/steps';
+import { asyncResult } from '@expo/results';
+import fetch from 'node-fetch';
+import { z } from 'zod';
+import { bunyan } from '@expo/logger';
+import { UserFacingError } from '@expo/eas-build-job/dist/errors';
+
+import { retryOnDNSFailure } from '../../utils/retryOnDNSFailure';
+import { formatBytes } from '../../utils/artifacts';
+import { decompressTarAsync, isFileTarGzAsync } from '../../utils/files';
+
+const streamPipeline = promisify(stream.pipeline);
+
+export function createDownloadArtifactFunction(): BuildFunction {
+  return new BuildFunction({
+    namespace: 'eas',
+    id: 'download_artifact',
+    name: 'Download artifact',
+    inputProviders: [
+      BuildStepInput.createProvider({
+        id: 'key',
+        required: false,
+        allowedValueTypeName: BuildStepInputValueTypeName.STRING,
+      }),
+      BuildStepInput.createProvider({
+        id: 'artifact_id',
+        required: false,
+        allowedValueTypeName: BuildStepInputValueTypeName.STRING,
+      }),
+    ],
+    outputProviders: [
+      BuildStepOutput.createProvider({
+        id: 'artifact_path',
+        required: true,
+      }),
+    ],
+    fn: async (stepsCtx, { inputs, outputs }) => {
+      const params = z
+        .union([z.object({ artifactId: z.string() }), z.object({ key: z.string() })])
+        .parse({
+          artifactId: inputs.artifact_id.value,
+          key: inputs.key.value,
+        });
+
+      const interpolationContext = stepsCtx.global.getInterpolationContext();
+
+      if (!('workflow' in interpolationContext)) {
+        throw new UserFacingError(
+          'EAS_DOWNLOAD_ARTIFACT_NO_WORKFLOW',
+          'No workflow found in the interpolation context.'
+        );
+      }
+
+      const robotAccessToken = stepsCtx.global.staticContext.job.secrets?.robotAccessToken;
+      if (!robotAccessToken) {
+        throw new UserFacingError(
+          'EAS_DOWNLOAD_ARTIFACT_NO_ROBOT_ACCESS_TOKEN',
+          'No robot access token found in the job secrets.'
+        );
+      }
+
+      const workflowRunId = interpolationContext.workflow.id;
+      const { logger } = stepsCtx;
+
+      if ('artifactId' in params) {
+        logger.info(`Downloading artifact with ID "${params.artifactId}"...`);
+      } else {
+        logger.info(`Downloading artifact with key "${params.key}"...`);
+      }
+
+      const { artifactPath } = await downloadArtifactAsync({
+        logger,
+        workflowRunId,
+        expoApiServerURL: stepsCtx.global.staticContext.expoApiServerURL,
+        robotAccessToken,
+        params,
+      });
+
+      outputs.artifact_path.set(artifactPath);
+    },
+  });
+}
+
+export async function downloadArtifactAsync({
+  logger,
+  workflowRunId,
+  expoApiServerURL,
+  robotAccessToken,
+  params,
+}: {
+  logger: bunyan;
+  workflowRunId: string;
+  expoApiServerURL: string;
+  robotAccessToken: string;
+  params: { artifactId: string } | { key: string };
+}): Promise<{ artifactPath: string }> {
+  const downloadDestinationDirectory = await fs.promises.mkdtemp(
+    path.join(os.tmpdir(), 'download_artifact-')
+  );
+
+  const url = new URL(`/v2/workflows/${workflowRunId}/artifacts`, expoApiServerURL);
+
+  if ('artifactId' in params) {
+    url.searchParams.set('artifactId', params.artifactId);
+  } else {
+    url.searchParams.set('key', params.key);
+  }
+
+  const response = await retryOnDNSFailure(fetch)(url, {
+    headers: robotAccessToken ? { Authorization: `Bearer ${robotAccessToken}` } : undefined,
+  });
+
+  if (!response.ok) {
+    const textResult = await asyncResult(response.text());
+    throw new Error(`Unexpected response from server (${response.status}): ${textResult.value}`);
+  }
+
+  // URL may contain percent-encoded characters, e.g. my%20file.apk
+  // this replaces all non-alphanumeric characters (excluding dot) with underscore
+  const archiveFilename = path
+    .basename(new URL(response.url).pathname)
+    .replace(/([^a-z0-9.-]+)/gi, '_');
+  const archivePath = path.join(downloadDestinationDirectory, archiveFilename);
+
+  await streamPipeline(response.body, fs.createWriteStream(archivePath));
+
+  const { size } = await fs.promises.stat(archivePath);
+
+  logger.info(`Downloaded ${archivePath} (${formatBytes(size)} bytes).`);
+
+  const isFileATarGzArchive = await isFileTarGzAsync(archivePath);
+
+  if (!isFileATarGzArchive) {
+    logger.info(`Artifact is not a .tar.gz archive, skipping decompression and validation.`);
+    return { artifactPath: archivePath };
+  }
+
+  const extractionDirectory = await fs.promises.mkdtemp(
+    path.join(os.tmpdir(), 'download_artifact-extracted-')
+  );
+  await decompressTarAsync({
+    archivePath,
+    destinationDirectory: extractionDirectory,
+  });
+
+  return { artifactPath: extractionDirectory };
+}

--- a/packages/build-tools/src/steps/functions/uploadArtifact.ts
+++ b/packages/build-tools/src/steps/functions/uploadArtifact.ts
@@ -34,6 +34,12 @@ export function createUploadArtifactBuildFunction(ctx: CustomBuildContext): Buil
         required: false,
         allowedValueTypeName: BuildStepInputValueTypeName.STRING,
       }),
+      BuildStepInput.createProvider({
+        id: 'name',
+        defaultValue: '',
+        required: false,
+        allowedValueTypeName: BuildStepInputValueTypeName.STRING,
+      }),
       /**
        * path inputs expects a list of newline-delimited search paths.
        * Valid examples include:
@@ -97,7 +103,7 @@ export function createUploadArtifactBuildFunction(ctx: CustomBuildContext): Buil
           inputValue: `${inputs.type.value ?? ''}`,
         }),
         paths: artifactPaths,
-        key: inputs.key.value as string,
+        name: (inputs.name.value || inputs.key.value) as string,
       };
 
       try {


### PR DESCRIPTION
# Why

We want to allow users to download artifacts produced by other jobs in a workflow.

# How

Added an `eas/download_artifact` function. It accepts :
- either `name: string`
- or `artifact_id: string`

input. It proceeds to call `api.expo.dev/v2/workflows/:workflowRunId/download-artifact` added in https://github.com/expo/universe/pull/20837. The route then redirects to a signed download URL.

We may need to add more options in the future (downloading multiple artifacts by name prefix, multiple names, disabling unarchiving and stuff), but for now this should be ok.

Note: This pull request allows downloading by `artifact_id`, but it is currently not possible — `eas/upload_artifact` does **not** output an `artifact_id`. Will do in a separate pull request.

This also changes `eas/upload_artifact` to allow both `key` and `name` as options with the preference of `name`.

# Test Plan

<img width="1114" alt="Zrzut ekranu 2025-07-3 o 13 25 15" src="https://github.com/user-attachments/assets/70c6e6f2-bb39-40ae-941a-607445f61dc2" />

Tested end-to-end with:

```yaml
jobs:
  upload:
    outputs:
      artifact_id: ${{ steps.upload.outputs.artifact_id }}
    steps:
      - uses: eas/checkout
      - uses: eas/upload_artifact
        id: upload
        with:
          path: mobile/ios-flow.yaml
          name: maestro flow file
  download:
    needs: [upload]
    steps:
      - uses: eas/download_artifact
        id: download
        with:
          name: maestro flow file
      - run: |
          echo "Downloaded file: ${{ steps.download.outputs.artifact_path }}"
          echo "Contents:"
          cat ${{ steps.download.outputs.artifact_path }}
```