### PR TITLE
[eas-build-job] Add schedule properties to workflow interpolation context

### DIFF
--- a/packages/eas-build-job/src/common.ts
+++ b/packages/eas-build-job/src/common.ts
@@ -190,6 +190,8 @@ export const StaticWorkflowInterpolationContextZ = z.object({
       ref_name: z.string(),
       ref_type: z.string(),
       label: z.string().optional(),
+      repository: z.string().optional(),
+      repository_owner: z.string().optional(),
       event: z
         .object({
           label: z


### PR DESCRIPTION
Added `schedule` as possible `event_name`. Ensured there's only `github.event.schedule` (no `github.schedule`) following the example found in https://github.com/orgs/community/discussions/12269#discussioncomment-3408473.

<img width="429" alt="Zrzut ekranu 2025-07-2 o 21 09 02" src="https://github.com/user-attachments/assets/2f59cdd6-0d28-43c0-b02d-0cdfe8b92687" />
