### PR TITLE
[build-tools] add spawnAsync error log

### DIFF
--- a/packages/build-tools/src/steps/functions/repack.ts
+++ b/packages/build-tools/src/steps/functions/repack.ts
@@ -163,10 +163,19 @@ function createSpawnAsyncStepAdapter({
     args: string[],
     options?: SpawnProcessOptions
   ): SpawnProcessPromise<SpawnProcessResult> {
-    return spawnAsync(command, args, {
+    const promise = spawnAsync(command, args, {
       ...options,
       ...(verbose ? { logger, stdio: 'pipe' } : { logger: undefined }),
     });
+    const child = promise.child;
+    const wrappedPromise = promise.catch((error) => {
+      logger.error(`Error while running command: ${command} ${args.join(' ')}`);
+      logger.error(`stdout: ${error.stdout}`);
+      logger.error(`stderr: ${error.stderr}`);
+      throw error;
+    }) as SpawnProcessPromise<SpawnProcessResult>;
+    wrappedPromise.child = child;
+    return wrappedPromise;
   };
 }
 


### PR DESCRIPTION
# Why

show more information when repack spawnAsync failed.

# How

log stdout and stderr when spawnAsync failed

|before|after|
|-|-|
|
![Screenshot 2025-07-17 at 2.29.19 AM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/BhF1ySaozaWrX9KbwtqY/4bab2c2b-6f37-4768-9c94-365ac321acce.png)|![Screenshot 2025-07-17 at 2.29.26 AM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/BhF1ySaozaWrX9KbwtqY/940dd66a-3781-4a5e-9d98-86ca10c36f70.png)|

# Test Plan

tested repack on sdk 51 project (which doesn't support `npx expo export:embed --bytecode`)
