### PR TITLE
[build-tools] integrate spawnAsyncVerbose for repack

### DIFF
--- a/packages/build-tools/src/steps/functions/repack.ts
+++ b/packages/build-tools/src/steps/functions/repack.ts
@@ -77,6 +77,10 @@ export function createRepackBuildFunction(): BuildFunction {
       }
 
       const repackSpawnAsync = createSpawnAsyncStepAdapter({ verbose, logger: stepsCtx.logger });
+      const repackSpawnAsyncVerbose = createSpawnAsyncStepAdapter({
+        verbose: true,
+        logger: stepsCtx.logger,
+      });
 
       const tmpDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), `repack-`));
       const workingDirectory = path.join(tmpDir, 'working-directory');
@@ -113,6 +117,7 @@ export function createRepackBuildFunction(): BuildFunction {
             }),
             logger: stepsCtx.logger,
             spawnAsync: repackSpawnAsync,
+            spawnAsyncVerbose: repackSpawnAsyncVerbose,
             verbose,
             env: {
               ...COMMON_FASTLANE_ENV,


### PR DESCRIPTION
# Why

draft pr for the https://github.com/expo/repack-app/pull/32 integration

# How

integrate with the `spawnAsyncVerbose`

# Test Plan

ci passed
