### PR TITLE
[eas-build-job] ArchiveSourceType supports R2

### DIFF
--- a/packages/eas-build-job/src/common.ts
+++ b/packages/eas-build-job/src/common.ts
@@ -39,7 +39,7 @@ export enum BuildTrigger {
 export type ArchiveSource =
   | { type: ArchiveSourceType.NONE }
   | { type: ArchiveSourceType.GCS; bucketKey: string; metadataLocation?: string }
-  | { type: ArchiveSourceType.R2; bucketKey: string; }
+  | { type: ArchiveSourceType.R2; bucketKey: string }
   | { type: ArchiveSourceType.URL; url: string }
   | { type: ArchiveSourceType.PATH; path: string }
   | {

--- a/packages/eas-build-job/src/common.ts
+++ b/packages/eas-build-job/src/common.ts
@@ -28,7 +28,7 @@ export enum ArchiveSourceType {
   PATH = 'PATH',
   GCS = 'GCS',
   GIT = 'GIT',
-  R2  = 'R2',
+  R2 = 'R2',
 }
 
 export enum BuildTrigger {

--- a/packages/eas-build-job/src/common.ts
+++ b/packages/eas-build-job/src/common.ts
@@ -28,6 +28,7 @@ export enum ArchiveSourceType {
   PATH = 'PATH',
   GCS = 'GCS',
   GIT = 'GIT',
+  R2  = 'R2',
 }
 
 export enum BuildTrigger {
@@ -38,6 +39,7 @@ export enum BuildTrigger {
 export type ArchiveSource =
   | { type: ArchiveSourceType.NONE }
   | { type: ArchiveSourceType.GCS; bucketKey: string; metadataLocation?: string }
+  | { type: ArchiveSourceType.R2; bucketKey: string; }
   | { type: ArchiveSourceType.URL; url: string }
   | { type: ArchiveSourceType.PATH; path: string }
   | {


### PR DESCRIPTION
# Why

Support Cloudflares R2 as an Archive source type

