### PR TITLE
[builder] accept null archive artifact

### DIFF
--- a/packages/build-tools/src/builders/common.ts
+++ b/packages/build-tools/src/builders/common.ts
@@ -48,9 +48,5 @@ export async function runBuilderWithHooksAsync<T extends BuildJob>(
     throw err;
   }
 
-  if (!ctx.artifacts.APPLICATION_ARCHIVE) {
-    throw new Error('Builder must upload application archive');
-  }
-
   return ctx.artifacts;
 }


### PR DESCRIPTION
# Why

This check prevents the migration of builds to R2 as we no longer need to pass the artifact via the build context

# How

https://github.com/expo/turtle-v2/pull/2282

# Test Plan

Internal testing
