### PR TITLE
[eas-build-job] Add `github.triggering_actor`

### DIFF
--- a/packages/eas-build-job/src/common.ts
+++ b/packages/eas-build-job/src/common.ts
@@ -187,6 +187,7 @@ export const StaticWorkflowInterpolationContextZ = z.object({
   inputs: z.record(z.string(), z.union([z.string(), z.number(), z.boolean()])).optional(),
   github: z
     .object({
+      triggering_actor: z.string().optional(),
       event_name: z.enum(['push', 'pull_request', 'workflow_dispatch', 'schedule']),
       sha: z.string(),
       ref: z.string(),


### PR DESCRIPTION
# Why

https://exponent-internal.slack.com/archives/C011ZMXQ6SZ/p1754654248102339?thread_ts=1754652406.612339&cid=C011ZMXQ6SZ

# How

Added `github.triggering_actor`, _not_ `github.actor` because in our case `github.actor` would always be the same as `github.triggering_actor`, at least for now.

<img width="807" height="275" alt="Zrzut ekranu 2025-08-8 o 14 08 26" src="https://github.com/user-attachments/assets/03f44776-9cf5-4b14-b34e-20945eeab3f5" />


# Test Plan

Adjusted test.