### PR TITLE
[build-tools] Fixes around Android emulator x Maestro tests

### DIFF
--- a/packages/build-tools/src/steps/functions/internalMaestroTest.ts
+++ b/packages/build-tools/src/steps/functions/internalMaestroTest.ts
@@ -437,6 +437,7 @@ async function withCleanDeviceAsync<TResult>({
         sourceDeviceName: sourceDeviceIdentifier as AndroidVirtualDeviceName,
         destinationDeviceName: localDeviceName as AndroidVirtualDeviceName,
         env,
+        logger,
       });
       logger.info(`Starting Android Emulator ${localDeviceName}...`);
       const { serialId } = await AndroidEmulatorUtils.startAsync({

--- a/packages/build-tools/src/steps/functions/internalMaestroTest.ts
+++ b/packages/build-tools/src/steps/functions/internalMaestroTest.ts
@@ -14,7 +14,6 @@ import spawn, { SpawnPromise, SpawnResult } from '@expo/turtle-spawn';
 import { PipeMode, bunyan } from '@expo/logger';
 import { Result, asyncResult, result } from '@expo/results';
 import { GenericArtifactType } from '@expo/eas-build-job';
-import FastGlob from 'fast-glob';
 
 import { CustomBuildContext } from '../../customBuildContext';
 import { IosSimulatorName, IosSimulatorUtils } from '../../utils/IosSimulatorUtils';
@@ -25,7 +24,6 @@ import {
 } from '../../utils/AndroidEmulatorUtils';
 import { PlatformToProperNounMap } from '../../utils/strings';
 import { findMaestroPathsFlowsToExecuteAsync } from '../../utils/findMaestroPathsFlowsToExecuteAsync';
-import { retryAsync } from '../../utils/retry';
 
 export function createInternalEasMaestroTestFunction(ctx: CustomBuildContext): BuildFunction {
   return new BuildFunction({
@@ -180,28 +178,6 @@ export function createInternalEasMaestroTestFunction(ctx: CustomBuildContext): B
           await spawnAsync('adb', ['-s', serialId, 'emu', 'kill'], {
             stdio: 'pipe',
           });
-
-          try {
-            await retryAsync(
-              async () => {
-                const lockfiles = await FastGlob('**/*.lock', {
-                  cwd: `${env.HOME}/.android/avd/${avdName}.avd`,
-                });
-
-                if (lockfiles.length === 0) {
-                  throw new Error(`Android Virtual Device (${avdName}) is still busy.`);
-                }
-              },
-              {
-                retryOptions: {
-                  retries: 20,
-                  retryIntervalMs: 1_000,
-                },
-              }
-            );
-          } catch (err) {
-            stepCtx.logger.warn({ err }, 'Android Virtual Device is still busy.');
-          }
 
           sourceDeviceIdentifier = avdName;
           break;

--- a/packages/build-tools/src/steps/functions/startAndroidEmulator.ts
+++ b/packages/build-tools/src/steps/functions/startAndroidEmulator.ts
@@ -106,6 +106,7 @@ export function createStartAndroidEmulatorBuildFunction(): BuildFunction {
             sourceDeviceName: deviceName,
             destinationDeviceName: cloneIdentifier,
             env,
+            logger,
           });
 
           logger.info('Starting emulator device');

--- a/packages/build-tools/src/steps/functions/startAndroidEmulator.ts
+++ b/packages/build-tools/src/steps/functions/startAndroidEmulator.ts
@@ -1,5 +1,6 @@
 import { BuildFunction, BuildStepInput, BuildStepInputValueTypeName } from '@expo/steps';
 import spawn from '@expo/turtle-spawn';
+import { asyncResult } from '@expo/results';
 
 import { retryAsync } from '../../utils/retry';
 import {
@@ -97,7 +98,8 @@ export function createStartAndroidEmulatorBuildFunction(): BuildFunction {
           env,
         });
         // Waiting for source emulator to shutdown.
-        await emulatorPromise;
+        // We don't care about resolved/rejected.
+        await asyncResult(emulatorPromise);
 
         for (let i = 0; i < count; i++) {
           const cloneIdentifier = `eas-simulator-${i + 1}` as AndroidVirtualDeviceName;

--- a/packages/build-tools/src/utils/AndroidEmulatorUtils.ts
+++ b/packages/build-tools/src/utils/AndroidEmulatorUtils.ts
@@ -4,13 +4,12 @@ import os from 'node:os';
 import { setTimeout } from 'node:timers/promises';
 import path from 'node:path';
 
-// import { PipeMode } from '@expo/logger';
-import spawn, { SpawnPromise, SpawnResult } from '@expo/turtle-spawn';
-import { z } from 'zod';
 import { bunyan } from '@expo/logger';
+import spawn, { SpawnPromise, SpawnResult } from '@expo/turtle-spawn';
+import FastGlob from 'fast-glob';
+import { z } from 'zod';
 
 import { retryAsync } from './retry';
-import FastGlob from 'fast-glob';
 
 /** Android Virtual Device is the device we run. */
 export type AndroidVirtualDeviceName = string & z.BRAND<'AndroidVirtualDeviceName'>;

--- a/packages/build-tools/src/utils/AndroidEmulatorUtils.ts
+++ b/packages/build-tools/src/utils/AndroidEmulatorUtils.ts
@@ -203,7 +203,11 @@ export namespace AndroidEmulatorUtils {
       {
         detached: true,
         stdio: 'inherit',
-        env,
+        env: {
+          ...env,
+          // We don't need to wait for emulator to exit gracefully.
+          ANDROID_EMULATOR_WAIT_TIME_BEFORE_KILL: '1',
+        },
       }
     );
     // If emulator fails to start, throw its error.

--- a/packages/build-tools/src/utils/AndroidEmulatorUtils.ts
+++ b/packages/build-tools/src/utils/AndroidEmulatorUtils.ts
@@ -10,6 +10,7 @@ import { z } from 'zod';
 import { bunyan } from '@expo/logger';
 
 import { retryAsync } from './retry';
+import FastGlob from 'fast-glob';
 
 /** Android Virtual Device is the device we run. */
 export type AndroidVirtualDeviceName = string & z.BRAND<'AndroidVirtualDeviceName'>;
@@ -154,6 +155,13 @@ export namespace AndroidEmulatorUtils {
       verbatimSymlinks: true,
       force: true,
     });
+
+    const lockfiles = await FastGlob('./**/*.lock', {
+      cwd: `${env.HOME}/.android/avd/${destinationDeviceName}.avd`,
+      absolute: true,
+    });
+
+    await Promise.all(lockfiles.map((lockfile) => fs.promises.rm(lockfile, { force: true })));
 
     const filesToReplaceDeviceNameIn = // TODO: Test whether we need to use `spawnAsync` here.
       (

--- a/packages/build-tools/src/utils/__integration-tests__/AndroidEmulatorUtils.test.ts
+++ b/packages/build-tools/src/utils/__integration-tests__/AndroidEmulatorUtils.test.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs';
 import { setTimeout } from 'timers/promises';
 
 import spawn from '@expo/turtle-spawn';
+import { asyncResult } from '@expo/results';
 
 import {
   AndroidDeviceSerialId,
@@ -103,7 +104,7 @@ describe('AndroidEmulatorUtils', () => {
     expect(stdout).toContain('data');
 
     await spawn('adb', ['-s', serialId, 'emu', 'kill'], { env: process.env });
-    await emulatorPromise;
+    await asyncResult(emulatorPromise);
 
     const cloneDeviceName = (deviceName + '-clone') as AndroidVirtualDeviceName;
     await AndroidEmulatorUtils.cloneAsync({
@@ -132,7 +133,7 @@ describe('AndroidEmulatorUtils', () => {
       serialId,
       env: process.env,
     });
-    await emulatorPromiseClone;
+    await asyncResult(emulatorPromiseClone);
   }, 60_000);
 
   it('should work with screen recording', async () => {
@@ -179,6 +180,6 @@ describe('AndroidEmulatorUtils', () => {
       serialId,
       env: process.env,
     });
-    await emulatorPromise;
+    await asyncResult(emulatorPromise);
   }, 60_000);
 });

--- a/packages/build-tools/src/utils/__integration-tests__/AndroidEmulatorUtils.test.ts
+++ b/packages/build-tools/src/utils/__integration-tests__/AndroidEmulatorUtils.test.ts
@@ -8,6 +8,7 @@ import {
   AndroidEmulatorUtils,
   AndroidVirtualDeviceName,
 } from '../AndroidEmulatorUtils';
+import { createMockLogger } from '../../__tests__/utils/logger';
 
 // We need to use real fs for cloning devices to work.
 jest.unmock('fs');
@@ -109,6 +110,7 @@ describe('AndroidEmulatorUtils', () => {
       sourceDeviceName: deviceName,
       destinationDeviceName: cloneDeviceName,
       env: process.env,
+      logger: createMockLogger({ logToConsole: true }),
     });
 
     const { serialId: serialIdClone, emulatorPromise: emulatorPromiseClone } =

--- a/packages/build-tools/src/utils/findMaestroPathsFlowsToExecuteAsync.ts
+++ b/packages/build-tools/src/utils/findMaestroPathsFlowsToExecuteAsync.ts
@@ -166,11 +166,6 @@ async function findAndParseFlowFilesAsync({
   const flowPatterns = workspaceConfig?.flows ?? ['*'];
   logger.info(`Using flow patterns: ${JSON.stringify(flowPatterns)}`);
 
-  logger.info(`Searching for flows with patterns: ${JSON.stringify(flowPatterns)}`, {
-    cwd: dirPath,
-    fg: flowPatterns,
-  });
-
   // Use fast-glob to find matching files
   const matchedFiles = await fg(flowPatterns, {
     cwd: dirPath,


### PR DESCRIPTION
# Why

https://expo.dev/accounts/affirm-inc/projects/mobile/workflows/01988a12-1653-7b3d-a33b-82940ad467cc

# How

We now wait for `.lock` files to be deleted. We also ask `emulator` to kill in 1 second rather than 20.

# Test Plan

Integration tests passed.