### PR TITLE
[build-job] pull request number on interpolation context

### DIFF
--- a/packages/eas-build-job/src/common.ts
+++ b/packages/eas-build-job/src/common.ts
@@ -215,6 +215,7 @@ export const StaticWorkflowInterpolationContextZ = z.object({
               number: z.number(),
             })
             .optional(),
+          number: z.number().optional(),
           schedule: z.string().optional(),
           inputs: z.record(z.string(), z.union([z.string(), z.number(), z.boolean()])).optional(),
         })


### PR DESCRIPTION
# Why

Add the property event.pull_request.number to the context schema

