### PR TITLE
[build-tools] Android Maestro fixes

### DIFF
--- a/packages/build-tools/src/steps/functions/internalMaestroTest.ts
+++ b/packages/build-tools/src/steps/functions/internalMaestroTest.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
+import { setTimeout } from 'node:timers/promises';
 
 import {
   BuildFunction,
@@ -178,6 +179,8 @@ export function createInternalEasMaestroTestFunction(ctx: CustomBuildContext): B
           await spawnAsync('adb', ['-s', serialId, 'emu', 'kill'], {
             stdio: 'pipe',
           });
+          // Waiting for emulator to get killed, see ANDROID_EMULATOR_WAIT_TIME_BEFORE_KILL.
+          await setTimeout(1000);
 
           sourceDeviceIdentifier = avdName;
           break;
@@ -280,7 +283,7 @@ export function createInternalEasMaestroTestFunction(ctx: CustomBuildContext): B
                 logger: stepCtx.logger,
                 artifact: {
                   // TODO(sjchmiela): Add metadata to artifacts so we don't need to encode flow path and attempt in the name.
-                  name: `Screen Recording (${flowPath})`,
+                  name: `Screen Recording (${flowIndex}-${path.basename(flowPath, path.extname(flowPath))})`,
                   paths: [recordingResult.value],
                   type: GenericArtifactType.OTHER,
                 },

--- a/packages/build-tools/src/utils/AndroidEmulatorUtils.ts
+++ b/packages/build-tools/src/utils/AndroidEmulatorUtils.ts
@@ -138,12 +138,21 @@ export namespace AndroidEmulatorUtils {
   }): Promise<void> {
     const cloneIniFile = `${env.HOME}/.android/avd/${destinationDeviceName}.ini`;
 
+    // Clean destination device files
     await fs.promises.rm(`${env.HOME}/.android/avd/${destinationDeviceName}.avd`, {
       recursive: true,
       force: true,
     });
     await fs.promises.rm(cloneIniFile, { force: true });
 
+    // Remove lockfiles from source device
+    const sourceLockfiles = await FastGlob('./**/*.lock', {
+      cwd: `${env.HOME}/.android/avd/${destinationDeviceName}.avd`,
+      absolute: true,
+    });
+    await Promise.all(sourceLockfiles.map((lockfile) => fs.promises.rm(lockfile, { force: true })));
+
+    // Copy source to destination
     await fs.promises.cp(
       `${env.HOME}/.android/avd/${sourceDeviceName}.avd`,
       `${env.HOME}/.android/avd/${destinationDeviceName}.avd`,
@@ -155,6 +164,7 @@ export namespace AndroidEmulatorUtils {
       force: true,
     });
 
+    // Remove lockfiles from destination device
     const lockfiles = await FastGlob('./**/*.lock', {
       cwd: `${env.HOME}/.android/avd/${destinationDeviceName}.avd`,
       absolute: true,


### PR DESCRIPTION
# Why

Android emulator lockfiles are still an issue — https://expo.dev/accounts/affirm-inc/projects/mobile/workflows/0198a2d2-0281-7347-a525-6d7cf6065c41#job-0198a2e3-86eb-7b9f-9417-94adf5d432cf.

# How

I _think_ maybe the error is not coming from _our_ code, but from `fs.cp` instead? Let's remove the lockfiles before copying.

Also, let's wait a second after the original device is killed. Then the emulator should get killed.

Also, let's fix the screen recording names and strip the `/home/expo/..../` part from them.

# Test Plan

Ran a local test.

<img width="1255" height="421" alt="Zrzut ekranu 2025-08-21 o 14 28 31" src="https://github.com/user-attachments/assets/f69e73f9-4395-4edb-af2b-891c5690e8fe" />
