### PR TITLE
[build-tools] Wrap removing lockfiles with `try`-`catch`

### DIFF
--- a/packages/build-tools/src/utils/AndroidEmulatorUtils.ts
+++ b/packages/build-tools/src/utils/AndroidEmulatorUtils.ts
@@ -146,11 +146,17 @@ export namespace AndroidEmulatorUtils {
     await fs.promises.rm(cloneIniFile, { force: true });
 
     // Remove lockfiles from source device
-    const sourceLockfiles = await FastGlob('./**/*.lock', {
-      cwd: `${env.HOME}/.android/avd/${destinationDeviceName}.avd`,
-      absolute: true,
-    });
-    await Promise.all(sourceLockfiles.map((lockfile) => fs.promises.rm(lockfile, { force: true })));
+    try {
+      const sourceLockfiles = await FastGlob('./**/*.lock', {
+        cwd: `${env.HOME}/.android/avd/${sourceDeviceName}.avd`,
+        absolute: true,
+      });
+      await Promise.all(
+        sourceLockfiles.map((lockfile) => fs.promises.rm(lockfile, { force: true }))
+      );
+    } catch (err) {
+      logger.warn({ err }, `Failed to remove lockfiles from source device ${sourceDeviceName}.`);
+    }
 
     // Copy source to destination
     await fs.promises.cp(
@@ -165,12 +171,18 @@ export namespace AndroidEmulatorUtils {
     });
 
     // Remove lockfiles from destination device
-    const lockfiles = await FastGlob('./**/*.lock', {
-      cwd: `${env.HOME}/.android/avd/${destinationDeviceName}.avd`,
-      absolute: true,
-    });
-
-    await Promise.all(lockfiles.map((lockfile) => fs.promises.rm(lockfile, { force: true })));
+    try {
+      const lockfiles = await FastGlob('./**/*.lock', {
+        cwd: `${env.HOME}/.android/avd/${destinationDeviceName}.avd`,
+        absolute: true,
+      });
+      await Promise.all(lockfiles.map((lockfile) => fs.promises.rm(lockfile, { force: true })));
+    } catch (err) {
+      logger.warn(
+        { err },
+        `Failed to remove lockfiles from destination device ${destinationDeviceName}.`
+      );
+    }
 
     const filesToReplaceDeviceNameIn = // TODO: Test whether we need to use `spawnAsync` here.
       (

--- a/packages/build-tools/src/utils/AndroidEmulatorUtils.ts
+++ b/packages/build-tools/src/utils/AndroidEmulatorUtils.ts
@@ -138,15 +138,19 @@ export namespace AndroidEmulatorUtils {
   }): Promise<void> {
     const cloneIniFile = `${env.HOME}/.android/avd/${destinationDeviceName}.ini`;
 
-    // Clean destination device files
-    await fs.promises.rm(`${env.HOME}/.android/avd/${destinationDeviceName}.avd`, {
-      recursive: true,
-      force: true,
-    });
-    await fs.promises.rm(cloneIniFile, { force: true });
-
-    // Remove lockfiles from source device
     try {
+      // Clean destination device files
+      await fs.promises.rm(`${env.HOME}/.android/avd/${destinationDeviceName}.avd`, {
+        recursive: true,
+        force: true,
+      });
+      await fs.promises.rm(cloneIniFile, { force: true });
+    } catch (err) {
+      logger.warn({ err }, `Failed to remove destination device files ${destinationDeviceName}.`);
+    }
+
+    try {
+      // Remove lockfiles from source device
       const sourceLockfiles = await FastGlob('./**/*.lock', {
         cwd: `${env.HOME}/.android/avd/${sourceDeviceName}.avd`,
         absolute: true,


### PR DESCRIPTION
# Why

Cloning emulator still fails with ENOENT on lockfile.

# How

Worked with Claude:
- it found I was removing lockfiles from destination directory before copying the source to destination
- it suggested wrapping removing stuff with `try`-`catch`.

# Test Plan

Ran an Android Maestro test locally and it looks like it did clone the Emulator properly.