### PR TITLE
[chore] Upgrade TypeScript to 5.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,10 @@
     "eslint-plugin-jest": "28.11.0",
     "lerna": "^7.1.4",
     "prettier": "3.3.1",
-    "typescript": "5.4.5"
+    "typescript": "5.5.4"
+  },
+  "resolutions": {
+    "typescript": "5.5.4"
   },
   "workspaces": [
     "packages/*"

--- a/packages/build-tools/package.json
+++ b/packages/build-tools/package.json
@@ -72,7 +72,7 @@
     "ts-jest": "^29.1.4",
     "ts-mockito": "^2.6.1",
     "tslib": "^2.6.3",
-    "typescript": "^5.4.5",
+    "typescript": "^5.5.4",
     "uuid": "^9.0.1"
   },
   "volta": {

--- a/packages/create-eas-build-function/package.json
+++ b/packages/create-eas-build-function/package.json
@@ -47,7 +47,7 @@
     "ora": "^6.3.1",
     "prompts": "^2.4.2",
     "ts-node": "^10.9.2",
-    "typescript": "^5.4.5",
+    "typescript": "^5.5.4",
     "update-check": "^1.5.4"
   },
   "publishConfig": {

--- a/packages/downloader/package.json
+++ b/packages/downloader/package.json
@@ -28,7 +28,7 @@
     "@types/node": "20.14.2",
     "jest": "^29.7.0",
     "ts-jest": "^29.1.4",
-    "typescript": "^5.3.3"
+    "typescript": "^5.5.4"
   },
   "volta": {
     "node": "20.14.0",

--- a/packages/eas-build-job/package.json
+++ b/packages/eas-build-job/package.json
@@ -23,7 +23,7 @@
     "@types/node": "20.14.2",
     "jest": "^29.7.0",
     "ts-jest": "^29.1.4",
-    "typescript": "^5.3.3"
+    "typescript": "^5.5.4"
   },
   "dependencies": {
     "@expo/logger": "1.0.117",

--- a/packages/local-build-plugin/package.json
+++ b/packages/local-build-plugin/package.json
@@ -48,7 +48,7 @@
     "@types/uuid": "^9.0.7",
     "jest": "^29.7.0",
     "ts-jest": "^29.1.4",
-    "typescript": "^5.4.5"
+    "typescript": "^5.5.4"
   },
   "volta": {
     "node": "20.14.0",

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -27,7 +27,7 @@
     "@types/node": "20.14.2",
     "jest": "^29.7.0",
     "ts-jest": "^29.1.4",
-    "typescript": "^5.4.5"
+    "typescript": "^5.5.4"
   },
   "volta": {
     "node": "20.14.0",

--- a/packages/steps/package.json
+++ b/packages/steps/package.json
@@ -42,7 +42,7 @@
     "ts-jest": "^29.1.4",
     "ts-mockito": "^2.6.1",
     "ts-node": "^10.9.2",
-    "typescript": "^5.4.5"
+    "typescript": "^5.5.4"
   },
   "engines": {
     "node": ">=18"

--- a/packages/template-file/package.json
+++ b/packages/template-file/package.json
@@ -30,7 +30,7 @@
     "@types/node": "20.14.2",
     "jest": "^29.7.0",
     "ts-jest": "^29.1.4",
-    "typescript": "^5.3.3"
+    "typescript": "^5.5.4"
   },
   "volta": {
     "node": "20.14.0",

--- a/packages/turtle-spawn/package.json
+++ b/packages/turtle-spawn/package.json
@@ -27,7 +27,7 @@
     "@types/node": "20.14.2",
     "jest": "^29.7.0",
     "ts-jest": "^29.1.4",
-    "typescript": "^5.4.5"
+    "typescript": "^5.5.4"
   },
   "volta": {
     "node": "20.14.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9988,20 +9988,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@5.4.5, typescript@^5.4.5:
-  version "5.4.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.4.5.tgz#42ccef2c571fdbd0f6718b1d1f5e6e5ef006f611"
-  integrity sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==
-
-"typescript@>=3 < 6":
-  version "5.1.6"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.1.6.tgz#02f8ac202b6dad2c0dd5e0913745b47a37998274"
-  integrity sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==
-
-typescript@^5.3.3:
-  version "5.3.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.3.3.tgz#b3ce6ba258e72e6305ba66f5c9b452aaee3ffe37"
-  integrity sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==
+typescript@5.5.4, "typescript@>=3 < 6", typescript@^5.5.4:
+  version "5.5.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.5.4.tgz#d9852d6c82bad2d2eda4fd74a5762a8f5909e9ba"
+  integrity sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==
 
 uglify-js@^3.1.4:
   version "3.13.3"


### PR DESCRIPTION
# Why

I want to (after all) add https://gql-tada.0no.co/ to `build-tools`. Installation is simpler for TS 5.5+ so let's use this opportunity to ugprade to that.

# How

Upgraded TS to 5.5.4.

Did not upgrade to a more recent version not to have to deal with https://stackoverflow.com/questions/78790943/in-typescript-5-6-buffer-is-not-assignable-to-arraybufferview-or-uint8arr.

# Test Plan

Compared output of `yarn build` for current TS and new TS. The difference seems to be mostly about

<img width="830" height="895" alt="Zrzut ekranu 2025-08-26 o 12 41 24" src="https://github.com/user-attachments/assets/10c95b54-0adc-41f1-9518-84fbeb9bd2ac" />
