### PR TITLE
[build-tools] Upload project metadata file when missing on builds

### DIFF
--- a/packages/build-tools/src/common/projectSources.ts
+++ b/packages/build-tools/src/common/projectSources.ts
@@ -159,13 +159,13 @@ async function uploadProjectMetadataAsync(
   { projectDirectory }: { projectDirectory: string }
 ): Promise<void> {
   if (!ctx.job.platform) {
-    ctx.logger.info('Not a build - skipping project metadata upload.');
+    // Not a build job, skip.
     return;
   } else if (
     ctx.job.projectArchive.type === ArchiveSourceType.GCS &&
     ctx.job.projectArchive.metadataLocation
   ) {
-    ctx.logger.info('Build already has project metadata - skipping upload.');
+    // Build already has project metadata, skip.
     return;
   }
 

--- a/packages/build-tools/src/common/projectSources.ts
+++ b/packages/build-tools/src/common/projectSources.ts
@@ -8,6 +8,7 @@ import downloadFile from '@expo/downloader';
 import { z } from 'zod';
 import { asyncResult } from '@expo/results';
 import nullthrows from 'nullthrows';
+import { graphql } from 'gql.tada';
 
 import { BuildContext } from '../context';
 import { turtleFetch } from '../utils/turtleFetch';
@@ -44,6 +45,13 @@ export async function prepareProjectSourcesAsync<TJob extends Job>(
       },
       destinationDirectory,
     });
+  }
+
+  const uploadResult = await asyncResult(
+    uploadProjectMetadataAsync(ctx, { projectDirectory: destinationDirectory })
+  );
+  if (!uploadResult.ok) {
+    ctx.logger.warn(`Failed to upload project metadata: ${uploadResult.reason}`);
   }
 }
 
@@ -144,4 +152,111 @@ async function unpackTarGzAsync({
   await spawn('tar', ['-C', destination, '--strip-components', '1', '-zxf', source], {
     logger,
   });
+}
+
+async function uploadProjectMetadataAsync(
+  ctx: BuildContext<Job>,
+  { projectDirectory }: { projectDirectory: string }
+): Promise<void> {
+  if (!ctx.job.platform) {
+    ctx.logger.info('Not a build - skipping project metadata upload.');
+    return;
+  } else if (
+    ctx.job.projectArchive.type === ArchiveSourceType.GCS &&
+    ctx.job.projectArchive.metadataLocation
+  ) {
+    ctx.logger.info('Build already has project metadata - skipping upload.');
+    return;
+  }
+
+  const files: string[] = [];
+
+  async function scanDirectory(dir: string, relativePath = ''): Promise<void> {
+    if (relativePath === '.git') {
+      // Do not include whole `.git` directory in the archive, just that it exists.
+      files.push('.git/...');
+      return;
+    }
+
+    const entries = await fs.readdir(dir, { withFileTypes: true });
+
+    for (const entry of entries) {
+      const fullPath = path.join(dir, entry.name);
+      const relativeFilePath = path.join(relativePath, entry.name);
+
+      if (entry.isDirectory()) {
+        await scanDirectory(fullPath, relativeFilePath);
+      } else {
+        files.push(relativeFilePath);
+      }
+    }
+  }
+
+  await scanDirectory(projectDirectory);
+  const sortedFiles = files
+    .map(
+      // Prepend entries with "project/"
+      (f) => path.join('project', f)
+    )
+    .sort(); // Sort for consistent ordering
+
+  const result = await ctx.graphqlClient
+    .mutation(
+      graphql(`
+        mutation {
+          uploadSession {
+            createUploadSession(type: EAS_BUILD_GCS_PROJECT_METADATA)
+          }
+        }
+      `),
+      {}
+    )
+    .toPromise();
+
+  if (result.error) {
+    throw result.error;
+  }
+
+  const uploadSession = result.data!.uploadSession.createUploadSession as {
+    url: string;
+    bucketKey: string;
+    headers: Record<string, string>;
+  };
+
+  await fetch(uploadSession.url, {
+    method: 'PUT',
+    body: JSON.stringify({ archiveContent: sortedFiles }),
+    headers: uploadSession.headers,
+  });
+
+  const updateMetadataResult = await ctx.graphqlClient
+    .mutation(
+      graphql(`
+        mutation UpdateTurtleBuildMetadataMutation(
+          $buildId: ID!
+          $projectMetadataFile: ProjectMetadataFileInput!
+        ) {
+          build {
+            updateBuildMetadata(
+              buildId: $buildId
+              metadata: { projectMetadataFile: $projectMetadataFile }
+            ) {
+              id
+            }
+          }
+        }
+      `),
+      {
+        buildId: ctx.env.EAS_BUILD_ID,
+        projectMetadataFile: {
+          type: 'GCS',
+          bucketKey: uploadSession.bucketKey,
+        },
+      }
+    )
+    .toPromise();
+
+  if (updateMetadataResult.error) {
+    throw updateMetadataResult.error;
+  }
 }


### PR DESCRIPTION
# Why

Having the ability to look inside project archive when debugging users' problems is helpful.

So far, GitHub and workflow builds did not contain project metadata file because it was only being created in `eas-cli` on `build`.

# How

Context — the way EAS works is:
- a worker starts
- it receives information about the job to run from the orchestrator
- if it is a non-custom build:
  - it [prepares project sources](https://github.com/expo/eas-build/blob/15184f0fb293e3b6b4001574bf9eb01c3edf841f/packages/build-tools/src/common/projectSources.ts#L18)
- if it is a custom build or a non-build:
  - it prepares project sources inside "project source directory" ([link](https://github.com/expo/eas-build/blob/39473145241909a647ee6643ee5281476c910d5b/packages/build-tools/src/generic.ts#L18))
  - most often it has a "checkout" step which moves sources from "project source directory" to "project target directory" ([`eas/checkout`](https://github.com/expo/eas-build/blob/17a88c545c8eedc2dae3aaab7b9edda848e86c67/packages/build-tools/src/steps/functions/checkout.ts#L15-L21)).

`prepareProjectSourcesAsync` looks like a good place to ensure project metadata file exists. We're inspecting the whole directory tree under `projectDirectory`, saving all filepaths in an array, requesting an upload URL from `www`, uploading the file there and then updating build metadata with the new file source.

# Test Plan

Tested manually.