### PR TITLE
[build-tools] Fix `getMaestroVersion` usage

### DIFF
--- a/packages/build-tools/src/steps/functions/installMaestro.ts
+++ b/packages/build-tools/src/steps/functions/installMaestro.ts
@@ -36,7 +36,7 @@ export function createInstallMaestroBuildFunction(): BuildFunction {
     ],
     fn: async ({ logger, global }, { inputs, env, outputs }) => {
       const requestedMaestroVersion = inputs.maestro_version.value as string | undefined;
-      const currentMaestroVersion = await getMaestroVersion({ env });
+      const { value: currentMaestroVersion } = await asyncResult(getMaestroVersion({ env }));
 
       // When not running in EAS Build VM, do not modify local environment.
       if (env.EAS_BUILD_RUNNER !== 'eas-build') {


### PR DESCRIPTION
# Why

`getMaestroVersion` now throws if `maestro` is not installed. We don't want to throw an error from `install_maestro`, we only want to check the version here.

# How

Wrapped with `asyncResult`.

# Test Plan

Tested locally. Removed `maestro` and then ran a workflow like:

```yml
jobs:
  maestro:
    env:
      EAS_BUILD_RUNNER: "eas-build"
    steps:
      - uses: eas/install_maestro

```

<img width="1285" height="485" alt="Zrzut ekranu 2025-08-28 o 12 25 36" src="https://github.com/user-attachments/assets/77adc44e-aa26-438d-a039-c5592c46b9b3" />
