### PR TITLE
[ios-builder] accept null archive artifact

### DIFF
--- a/packages/build-tools/src/builders/ios.ts
+++ b/packages/build-tools/src/builders/ios.ts
@@ -241,9 +241,6 @@ async function resignAsync(ctx: BuildContext<Ios.Job>): Promise<Artifacts> {
     });
   });
 
-  if (!ctx.artifacts.APPLICATION_ARCHIVE) {
-    throw new Error('Builder must upload application archive');
-  }
   return ctx.artifacts;
 }
 


### PR DESCRIPTION
# Why

Post R2 migration, we no longer need to pass the artifact via the build context. We already removed this for the common builder https://github.com/expo/eas-build/pull/566

# How

Apply same logic to resign builds

# Test Plan

Internal testing
