### PR TITLE
[build-tools] Add support for passing `ANDROID_EMULATOR_EXTRA_ARGS`

### DIFF
--- a/packages/build-tools/src/utils/AndroidEmulatorUtils.ts
+++ b/packages/build-tools/src/utils/AndroidEmulatorUtils.ts
@@ -232,6 +232,9 @@ export namespace AndroidEmulatorUtils {
         '-no-snapshot-save',
         '-avd',
         deviceName,
+        ...(typeof env.ANDROID_EMULATOR_EXTRA_ARGS === 'string'
+          ? env.ANDROID_EMULATOR_EXTRA_ARGS.split(' ')
+          : []),
       ],
       {
         detached: true,


### PR DESCRIPTION
# Why

I want to investigate emulator performance. Maybe there's a flag that would work better in our CI environment?

# How

Added support for optional `ANDROID_EMULATOR_EXTRA_ARGS` environment variables to be passed to `emulator` spawn.

# Test Plan

Land in staging and play with it.