### PR TITLE
[build-tools] Enable Android Emulator hardware acceleration

### DIFF
--- a/packages/build-tools/src/utils/AndroidEmulatorUtils.ts
+++ b/packages/build-tools/src/utils/AndroidEmulatorUtils.ts
@@ -232,6 +232,8 @@ export namespace AndroidEmulatorUtils {
         '-no-snapshot-save',
         '-avd',
         deviceName,
+        '-accel',
+        'on',
         ...(typeof env.ANDROID_EMULATOR_EXTRA_ARGS === 'string'
           ? env.ANDROID_EMULATOR_EXTRA_ARGS.split(' ')
           : []),


### PR DESCRIPTION
# Why

This makes Emulators go brrr and we support hardware acceleration in our nested-virtualization VMs.

# How

Ran [a workflow](https://expo.dev/accounts/sjchmiela/projects/expo-affirm/workflows/01991653-e0b7-7be1-9bd0-4e1dbc736659) with `ANDROID_EMULATOR_EXTRA_ARGS: '-accel on'`. The screen recording feels much faster than the one without `-accel on`. It also succeeded a test that otherwise would have always flake.

# Test Plan

Land and observe `maestro_test` success rate not drop. Talk to customers.