### PR TITLE
[build-tools] Allow customizing emulator with `ANDROID_EMULATOR_EXTRA_CONFIG`

### DIFF
--- a/packages/build-tools/src/steps/functions/startAndroidEmulator.ts
+++ b/packages/build-tools/src/steps/functions/startAndroidEmulator.ts
@@ -77,6 +77,7 @@ export function createStartAndroidEmulatorBuildFunction(): BuildFunction {
         systemImagePackage,
         deviceIdentifier: deviceIdentifier ?? null,
         env,
+        logger,
       });
 
       logger.info('Starting emulator device');

--- a/packages/build-tools/src/utils/__integration-tests__/AndroidEmulatorUtils.test.ts
+++ b/packages/build-tools/src/utils/__integration-tests__/AndroidEmulatorUtils.test.ts
@@ -66,6 +66,7 @@ describe('AndroidEmulatorUtils', () => {
         systemImagePackage: AndroidEmulatorUtils.defaultSystemImagePackage,
         deviceIdentifier: null,
         env: process.env,
+        logger: createMockLogger({ logToConsole: true }),
       });
       ({ serialId } = await AndroidEmulatorUtils.startAsync({
         deviceName,
@@ -88,6 +89,7 @@ describe('AndroidEmulatorUtils', () => {
       systemImagePackage: AndroidEmulatorUtils.defaultSystemImagePackage,
       deviceIdentifier: null,
       env: process.env,
+      logger: createMockLogger({ logToConsole: true }),
     });
     const { serialId, emulatorPromise } = await AndroidEmulatorUtils.startAsync({
       deviceName,
@@ -143,6 +145,7 @@ describe('AndroidEmulatorUtils', () => {
       systemImagePackage: AndroidEmulatorUtils.defaultSystemImagePackage,
       deviceIdentifier: null,
       env: process.env,
+      logger: createMockLogger({ logToConsole: true }),
     });
 
     const { serialId, emulatorPromise } = await AndroidEmulatorUtils.startAsync({


### PR DESCRIPTION
# Why

I and Claude think the problem with performance when using `pixel_X` devices on EAS is increased screen density. I want to play with running `pixel_X` devices, but with lower screen density. Supposedly, going from the default device (640x360@ 160 dpi) to Pixel 4 (2280x1080 @ 440 dpi) may have great performance impact.

# How

Added support for adding extra lines to `config.ini` through `ANDROID_EMULATOR_EXTRA_CONFIG`.

# Test Plan

Planning to land this in production and test a bit.