### PR TITLE
[build-tools] Further adjust emulator settings

### DIFF
--- a/packages/build-tools/src/utils/AndroidEmulatorUtils.ts
+++ b/packages/build-tools/src/utils/AndroidEmulatorUtils.ts
@@ -129,12 +129,62 @@ export namespace AndroidEmulatorUtils {
     // Add extra config to the device's ini file.
     const configIniFile = `${env.HOME}/.android/avd/${deviceName}.avd/config.ini`;
     try {
-      logger.info(`Adding extra config to ${configIniFile}.`);
-      const configIniFileContent = await fs.promises.readFile(configIniFile, 'utf-8');
-      await fs.promises.writeFile(
-        configIniFile,
-        `${configIniFileContent}\n${env.ANDROID_EMULATOR_EXTRA_CONFIG ?? ''}\n`
-      );
+      let configIniFileContent = await fs.promises.readFile(configIniFile, 'utf-8');
+
+      logger.info('Setting hw.ramSize to 2048.');
+      configIniFileContent = `${configIniFileContent}\nhw.ramSize=2048\n`;
+
+      const currentDensityString = configIniFileContent.match(/hw.lcd.density=(\d+)/)?.[1];
+      const currentDensity = currentDensityString ? parseInt(currentDensityString, 10) : undefined;
+      const currentHeightString = configIniFileContent.match(/hw.lcd.height=(\d+)/)?.[1];
+      const currentHeight = currentHeightString ? parseInt(currentHeightString, 10) : undefined;
+      const currentWidthString = configIniFileContent.match(/hw.lcd.width=(\d+)/)?.[1];
+      const currentWidth = currentWidthString ? parseInt(currentWidthString, 10) : undefined;
+
+      if (currentDensity && currentDensity > 220) {
+        logger.info(
+          `Current density is ${currentDensity}, which we believe may impact performance.`
+        );
+        if (currentHeight && currentWidth) {
+          const newDensity = 220;
+          logger.info(`Setting hw.lcd.density to ${newDensity}.`);
+          configIniFileContent = `${configIniFileContent}\nhw.lcd.density=${newDensity}\n`;
+
+          const newHeight = Math.round((currentHeight * newDensity) / currentDensity);
+          const newWidth = Math.round((currentWidth * newDensity) / currentDensity);
+          logger.info(
+            `Setting scaled screen resolution: hw.lcd.height to ${newHeight} and hw.lcd.width to ${newWidth}.`
+          );
+          configIniFileContent = `${configIniFileContent}\nhw.lcd.height=${newHeight}\nhw.lcd.width=${newWidth}\n`;
+        } else {
+          logger.info('Could not find current screen resolution, setting to 1170x540 and 220 ppi.');
+          configIniFileContent = `${configIniFileContent}\nhw.lcd.height=${1170}\nhw.lcd.width=${540}\nhw.lcd.density=220\n`;
+        }
+      }
+
+      const heapSizeString = configIniFileContent.match(/vm.heapSize=(\d\w+)/)?.[1];
+      if (!heapSizeString) {
+        logger.info('Setting vm.heapSize to 768 MB.');
+        configIniFileContent = `${configIniFileContent}\nvm.heapSize=768\n`;
+      } else if (heapSizeString) {
+        const heapSize = parseInt(heapSizeString, 10);
+        const lowerCaseHeapSizeString = heapSizeString.toLocaleLowerCase();
+        if (lowerCaseHeapSizeString.includes('g')) {
+          logger.info('vm.heapSize is in GB, skipping adjustment.');
+        } else if (heapSize < 768) {
+          logger.info('Bumping vm.heapSize to 768 MB.');
+          configIniFileContent = `${configIniFileContent}\nvm.heapSize=768\n`;
+        }
+      }
+
+      if (env.ANDROID_EMULATOR_EXTRA_CONFIG) {
+        logger.info(
+          `Adding extra config from $ANDROID_EMULATOR_EXTRA_CONFIG:\n${env.ANDROID_EMULATOR_EXTRA_CONFIG}`
+        );
+        configIniFileContent = `${configIniFileContent}\n${env.ANDROID_EMULATOR_EXTRA_CONFIG}\n`;
+      }
+
+      await fs.promises.writeFile(configIniFile, configIniFileContent);
     } catch (err) {
       logger.warn({ err }, `Failed to add extra config to ${configIniFile}.`);
     }
@@ -242,8 +292,6 @@ export namespace AndroidEmulatorUtils {
         '-no-boot-anim',
         '-writable-system',
         '-noaudio',
-        '-memory',
-        '8192',
         '-no-snapshot-save',
         '-avd',
         deviceName,


### PR DESCRIPTION
# Why

I found:
- reducing screen density and size
- reducing RAM size
- increasing heap size

give the best results when it comes to running my specific Maestro test on our machines.

# How

Added automatic modifying of the device screen to smaller values. Added changing RAM size. Added increasing heap size.

# Test Plan

Ran a single integration test, checked the resulting config.inis and it seemed to do the job both for `pixel_5` and the default (smaller) device.
