### PR TITLE
[eas-build-job] Allow freeform `track` in submission config

### DIFF
--- a/packages/eas-build-job/src/submission-config.ts
+++ b/packages/eas-build-job/src/submission-config.ts
@@ -49,16 +49,9 @@ export namespace SubmissionConfig {
       IN_PROGRESS = 'inProgress',
     }
 
-    export enum ReleaseTrack {
-      PRODUCTION = 'production',
-      BETA = 'beta',
-      ALPHA = 'alpha',
-      INTERNAL = 'internal',
-    }
-
     export const SchemaZ = z
       .object({
-        track: z.nativeEnum(ReleaseTrack),
+        track: z.string(),
         changesNotSentForReview: z.boolean().default(false),
         googleServiceAccountKeyJson: z.string(),
         isVerboseFastlaneEnabled: z.boolean().optional(),


### PR DESCRIPTION
# Why

https://exponent-internal.slack.com/archives/C011ZMXQ6SZ/p1755530483378679

Related — https://github.com/expo/eas-cli/pull/3031

# How

Changed submission config schema to allow any string as `track`, not only `production`/`internal`/`beta`/`alpha`.

# Test Plan

Tested along with all the pull requests in the mix.

<img width="372" height="90" alt="Zrzut ekranu 2025-09-9 o 17 03 38" src="https://github.com/user-attachments/assets/0b260ad2-2379-4597-aa1c-dae8bf86446d" />
<img width="243" height="72" alt="Zrzut ekranu 2025-09-9 o 16 59 37" src="https://github.com/user-attachments/assets/4eef353d-ac7e-4b16-9413-a304a574b685" />
<img width="449" height="110" alt="Zrzut ekranu 2025-09-9 o 17 00 40" src="https://github.com/user-attachments/assets/58a44b7a-16bb-46b4-8d98-f233c196406a" />
<img width="366" height="85" alt="Zrzut ekranu 2025-09-9 o 17 00 35" src="https://github.com/user-attachments/assets/71013cd6-5f5e-4e38-951c-008642fbee8c" />
