### PR TITLE
[build-tools] Do not use `getenv` in `build-tools`

### DIFF
--- a/packages/build-tools/package.json
+++ b/packages/build-tools/package.json
@@ -45,7 +45,6 @@
     "@urql/core": "^6.0.1",
     "fast-glob": "^3.3.2",
     "fs-extra": "^11.2.0",
-    "getenv": "^2.0.0",
     "gql.tada": "^1.8.13",
     "joi": "^17.13.1",
     "lodash": "^4.17.21",
@@ -64,7 +63,6 @@
   "devDependencies": {
     "@expo/repack-app": "~0.2.5",
     "@types/fs-extra": "^11.0.4",
-    "@types/getenv": "^1.0.3",
     "@types/jest": "^29.5.12",
     "@types/lodash": "^4.17.4",
     "@types/node": "20.14.2",

--- a/packages/build-tools/src/utils/AndroidEmulatorUtils.ts
+++ b/packages/build-tools/src/utils/AndroidEmulatorUtils.ts
@@ -8,7 +8,6 @@ import { bunyan } from '@expo/logger';
 import spawn, { SpawnPromise, SpawnResult } from '@expo/turtle-spawn';
 import FastGlob from 'fast-glob';
 import { z } from 'zod';
-import getenv from 'getenv';
 
 import { retryAsync } from './retry';
 
@@ -135,7 +134,8 @@ export namespace AndroidEmulatorUtils {
       logger.info('Setting hw.ramSize to 2048.');
       configIniFileContent = `${configIniFileContent}\nhw.ramSize=2048\n`;
 
-      const shouldResizeScreen = getenv.boolish('ANDROID_EMULATOR_ADJUST_SCREEN', false);
+      const shouldResizeScreen =
+        env.ANDROID_EMULATOR_ADJUST_SCREEN === 'true' || env.ANDROID_EMULATOR_ADJUST_SCREEN === '1';
       if (shouldResizeScreen) {
         const currentDensityString = configIniFileContent.match(/hw.lcd.density=(\d+)/)?.[1];
         const currentDensity = currentDensityString
@@ -170,7 +170,9 @@ export namespace AndroidEmulatorUtils {
         }
       }
 
-      const shouldAdjustHeapSize = getenv.boolish('ANDROID_EMULATOR_ADJUST_HEAP_SIZE', true);
+      const shouldAdjustHeapSize =
+        env.ANDROID_EMULATOR_ADJUST_HEAP_SIZE !== 'false' &&
+        env.ANDROID_EMULATOR_ADJUST_HEAP_SIZE !== '0';
       if (shouldAdjustHeapSize) {
         const heapSizeString = configIniFileContent.match(/vm.heapSize=(\d\w+)/)?.[1];
         if (!heapSizeString) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1826,13 +1826,6 @@
     "@types/jsonfile" "*"
     "@types/node" "*"
 
-"@types/getenv@^1.0.3":
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/@types/getenv/-/getenv-1.0.3.tgz#9fe071e4143f249309bbea99644ed139ded246ba"
-  integrity sha512-aCe60hc2U/xtdnGYbcZBFm6Xkm/MFuWqKMbhupcGt7DJ1QojADIXFKthtlgTwyXkEi6vr8lMXtOI218Ua9qx6w==
-  dependencies:
-    "@types/node" "*"
-
 "@types/graceful-fs@^4.1.3":
   version "4.1.6"
   resolved "https://registry.yarnpkg.com/@types/graceful-fs/-/graceful-fs-4.1.6.tgz#e14b2576a1c25026b7f02ede1de3b84c3a1efeae"
@@ -4930,11 +4923,6 @@ getenv@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/getenv/-/getenv-1.0.0.tgz#874f2e7544fbca53c7a4738f37de8605c3fcfc31"
   integrity sha512-7yetJWqbS9sbn0vIfliPsFgoXMKn/YMF+Wuiog97x+urnSRRRZ7xB+uVkwGKzRgq9CDFfMQnE9ruL5DHv9c6Xg==
-
-getenv@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/getenv/-/getenv-2.0.0.tgz#b1698c7b0f29588f4577d06c42c73a5b475c69e0"
-  integrity sha512-VilgtJj/ALgGY77fiLam5iD336eSWi96Q15JSAG1zi8NRBysm3LXKdGnHb4m5cuyxvOLQQKWpBZAT6ni4FI2iQ==
 
 git-raw-commits@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
# Why

I mistakenly used `getenv` to check "user environment variables". `getenv` uses `process.env` which does not have current environment variables.

# How

Replaced use of `getenv` with a plain `true` / `1` checks.

# Test Plan

CI should pass.