### PR TITLE
fix(build-tools): Add `--include=dev` to `npm ci`

### DIFF
--- a/packages/build-tools/src/common/installDependencies.ts
+++ b/packages/build-tools/src/common/installDependencies.ts
@@ -25,7 +25,7 @@ export async function installDependenciesAsync({
   let args: string[];
   switch (packageManager) {
     case PackageManager.NPM: {
-      args = [useFrozenLockfile ? 'ci' : 'install'];
+      args = useFrozenLockfile ? ['ci', '--include=dev'] : ['install'];
       break;
     }
     case PackageManager.PNPM: {


### PR DESCRIPTION
# Why

`npm ci` omits `devDependencies` by default when `NODE_ENV=production` is set. This is a discrepancy compared to all of our other installations.

https://docs.npmjs.com/cli/v10/commands/npm-ci

# How

- Switch to add `--include=dev` to `npm ci`

# Test Plan

- Created a new test project and ran `NODE_ENV=production npm ci --include=dev` (and without) to validate whether npm's docs are accurate
