### PR TITLE
[build-tools] Support yarn workspaces focus to install scoped dependencies

### DIFF
--- a/packages/build-tools/src/common/installDependencies.ts
+++ b/packages/build-tools/src/common/installDependencies.ts
@@ -36,7 +36,7 @@ export async function installDependenciesAsync({
       const isModernYarnVersion = await isUsingModernYarnVersion(cwd);
       if (isModernYarnVersion) {
         if (env['EAS_YARN_FOCUS_WORKSPACE']) {
-          args = ['workspaces', 'focus', env['EAS_YARN_FOCUS_WORKSPACE'], '--production'];
+          args = ['workspaces', 'focus', env['EAS_YARN_FOCUS_WORKSPACE']];
         } else {
           args = ['install', '--inline-builds', useFrozenLockfile ? '--immutable' : '--no-immutable'];
         }


### PR DESCRIPTION
# Why

I have monorepo with multiple expo apps (+ web apps). I want to use `yarn workspaces focus my-app`, so node_modules is slimmer and yarn install faster ([see workspaces focus](https://yarnpkg.com/cli/workspaces/focus)). 

By using workspaces focus I would only install dependencies used by a single app, and without this change on EAS I would get inconsistent fingerprint between local and server envs.

# How

Added custom flag which would override install dependencies command, so by running:
```
EAS_YARN_FOCUS_WORKSPACE='my-app` eas build
```
The dependencies would be installed with `yarn workspaces focus my-app` command.

# Test Plan

I have run eas-build locally with those changes.
