### PR TITLE
[ios-builder] support save and restore ccache for builds and workflows

### DIFF
--- a/packages/build-tools/src/builders/ios.ts
+++ b/packages/build-tools/src/builders/ios.ts
@@ -78,7 +78,7 @@ async function buildAsync(ctx: BuildContext<Ios.Job>): Promise<void> {
       });
     });
 
-    if (ctx.env.EAS_BUILD_RUNNER == 'eas-build') {
+    if (ctx.env.EAS_BUILD_RUNNER === 'eas-build') {
       await ctx.runBuildPhase(BuildPhase.RESTORE_CACHE, async () => {
         const workingDirectory = ctx.getReactNativeProjectDirectory();
         const paths = [path.join(ctx.env.HOME, 'Library/Caches/ccache')];
@@ -95,26 +95,29 @@ async function buildAsync(ctx: BuildContext<Ios.Job>): Promise<void> {
         } catch (err) {
           ctx.logger.warn({ err }, 'Failed to read package files for cache key generation');
         }
-        ctx.logger.info("RESTORE - ", keyData)
+        ctx.logger.info('RESTORE - ', keyData);
         const cacheKey = `ios-cache-${createHash('sha256').update(keyData).digest('hex').substring(0, 16)}`;
 
         let jobRunId;
-        if(ctx.env.EAS_BUILD_ID){
-          jobRunId = ctx.env.EAS_BUILD_ID
+        if (ctx.env.EAS_BUILD_ID) {
+          jobRunId = ctx.env.EAS_BUILD_ID;
         } else {
-          jobRunId = nullthrows(ctx.env.__WORKFLOW_JOB_ID, 'EAS_BUILD_ID or __WORKFLOW_JOB_ID is not set');
+          jobRunId = nullthrows(
+            ctx.env.__WORKFLOW_JOB_ID,
+            'EAS_BUILD_ID or __WORKFLOW_JOB_ID is not set'
+          );
         }
         const robotAccessToken = nullthrows(
           ctx.job.secrets?.robotAccessToken,
           'Robot access token is required for cache operations'
         );
 
-        ctx.logger.info("key - ", cacheKey)
-        ctx.logger.info("paths - ", paths)
+        ctx.logger.info('key - ', cacheKey);
+        ctx.logger.info('paths - ', paths);
         try {
           const { archivePath } = await downloadCacheAsync({
             logger: ctx.logger,
-            buildId:jobRunId,
+            buildId: jobRunId,
             expoApiServerURL: ctx.env.__API_SERVER_URL ?? 'https://exp.host',
             robotAccessToken,
             paths,
@@ -135,7 +138,7 @@ async function buildAsync(ctx: BuildContext<Ios.Job>): Promise<void> {
           ctx.logger.warn({ err }, 'Failed to restore cache');
         }
       });
-  }
+    }
 
     await ctx.runBuildPhase(BuildPhase.INSTALL_PODS, async () => {
       await runInstallPodsAsync(ctx);
@@ -248,14 +251,17 @@ async function buildAsync(ctx: BuildContext<Ios.Job>): Promise<void> {
       } catch (err) {
         ctx.logger.warn({ err }, 'Failed to read package files for cache key generation');
       }
-      ctx.logger.info("SAVE - ", keyData)
+      ctx.logger.info('SAVE - ', keyData);
       const cacheKey = `ios-cache-${createHash('sha256').update(keyData).digest('hex').substring(0, 16)}`;
 
       let jobRunId;
-      if(ctx.env.EAS_BUILD_ID){
-        jobRunId = ctx.env.EAS_BUILD_ID
+      if (ctx.env.EAS_BUILD_ID) {
+        jobRunId = ctx.env.EAS_BUILD_ID;
       } else {
-        jobRunId = nullthrows(ctx.env.__WORKFLOW_JOB_ID, 'EAS_BUILD_ID or __WORKFLOW_JOB_ID is not set');
+        jobRunId = nullthrows(
+          ctx.env.__WORKFLOW_JOB_ID,
+          'EAS_BUILD_ID or __WORKFLOW_JOB_ID is not set'
+        );
       }
       const robotAccessToken = nullthrows(
         ctx.job.secrets?.robotAccessToken,
@@ -274,7 +280,7 @@ async function buildAsync(ctx: BuildContext<Ios.Job>): Promise<void> {
 
         await uploadCacheAsync({
           logger: ctx.logger,
-          buildId:jobRunId,
+          buildId: jobRunId,
           expoApiServerURL: ctx.env.__API_SERVER_URL ?? 'https://exp.host',
           robotAccessToken,
           archivePath,

--- a/packages/build-tools/src/builders/ios.ts
+++ b/packages/build-tools/src/builders/ios.ts
@@ -180,6 +180,7 @@ async function buildAsync(ctx: BuildContext<Ios.Job>): Promise<void> {
 
     const packageJsonPath = path.join(workingDirectory, 'package.json');
     const podfileLockPath = path.join(workingDirectory, 'ios/Podfile.lock');
+    const yarnLockPath = path.join(workingDirectory, 'yarn.lock');
 
     let keyData = 'ios-cache';
     try {
@@ -188,10 +189,21 @@ async function buildAsync(ctx: BuildContext<Ios.Job>): Promise<void> {
         keyData +=
           JSON.stringify(packageJson.dependencies || {}) +
           JSON.stringify(packageJson.devDependencies || {});
+
+        if (packageJson.dependencies?.expo) {
+          keyData += `expo:${packageJson.dependencies.expo}`;
+        }
+        if (packageJson.devDependencies?.['@expo/cli']) {
+          keyData += `expo-cli:${packageJson.devDependencies['@expo/cli']}`;
+        }
       }
       if (await fs.pathExists(podfileLockPath)) {
         const podfileLock = await fs.readFile(podfileLockPath, 'utf8');
         keyData += podfileLock;
+      }
+      if (await fs.pathExists(yarnLockPath)) {
+        const yarnLock = await fs.readFile(yarnLockPath, 'utf8');
+        keyData += yarnLock;
       }
     } catch (err) {
       ctx.logger.warn({ err }, 'Failed to read package files for cache key generation');

--- a/packages/build-tools/src/builders/ios.ts
+++ b/packages/build-tools/src/builders/ios.ts
@@ -79,10 +79,9 @@ async function buildAsync(ctx: BuildContext<Ios.Job>): Promise<void> {
 
     await ctx.runBuildPhase(BuildPhase.RESTORE_CACHE, async () => {
       const workingDirectory = ctx.getReactNativeProjectDirectory();
-      const paths = ['node_modules'];//, 'ios/Pods'];
+      const paths = ['node_modules'];
 
       const packageJsonPath = path.join(workingDirectory, 'package.json');
-      // const podfileLockPath = path.join(workingDirectory, 'ios/Podfile.lock');
       const yarnLockPath = path.join(workingDirectory, 'yarn.lock');
 
       let keyData = 'ios-cache';
@@ -100,10 +99,6 @@ async function buildAsync(ctx: BuildContext<Ios.Job>): Promise<void> {
             keyData += `expo-cli:${packageJson.devDependencies['@expo/cli']}`;
           }
         }
-        // if (await fs.pathExists(podfileLockPath)) {
-        //   const podfileLock = await fs.readFile(podfileLockPath, 'utf8');
-        //   keyData += podfileLock;
-        // }
         if (await fs.pathExists(yarnLockPath)) {
           const yarnLock = await fs.readFile(yarnLockPath, 'utf8');
           keyData += yarnLock;
@@ -150,7 +145,7 @@ async function buildAsync(ctx: BuildContext<Ios.Job>): Promise<void> {
         ctx.logger.warn({ err }, 'Failed to restore cache');
       }
     });
-    
+
     await ctx.runBuildPhase(BuildPhase.INSTALL_PODS, async () => {
       await runInstallPodsAsync(ctx);
     });
@@ -247,10 +242,9 @@ async function buildAsync(ctx: BuildContext<Ios.Job>): Promise<void> {
 
   await ctx.runBuildPhase(BuildPhase.SAVE_CACHE, async () => {
     const workingDirectory = ctx.getReactNativeProjectDirectory();
-    const paths = ['node_modules'];//, 'ios/Pods'];
+    const paths = ['node_modules'];
 
     const packageJsonPath = path.join(workingDirectory, 'package.json');
-    // const podfileLockPath = path.join(workingDirectory, 'ios/Podfile.lock');
     const yarnLockPath = path.join(workingDirectory, 'yarn.lock');
 
     let keyData = 'ios-cache';
@@ -268,10 +262,6 @@ async function buildAsync(ctx: BuildContext<Ios.Job>): Promise<void> {
           keyData += `expo-cli:${packageJson.devDependencies['@expo/cli']}`;
         }
       }
-      // if (await fs.pathExists(podfileLockPath)) {
-      //   const podfileLock = await fs.readFile(podfileLockPath, 'utf8');
-      //   keyData += podfileLock;
-      // }
       if (await fs.pathExists(yarnLockPath)) {
         const yarnLock = await fs.readFile(yarnLockPath, 'utf8');
         keyData += yarnLock;

--- a/packages/build-tools/src/builders/ios.ts
+++ b/packages/build-tools/src/builders/ios.ts
@@ -84,16 +84,8 @@ async function buildAsync(ctx: BuildContext<Ios.Job>): Promise<void> {
         const paths = [path.join(ctx.env.HOME, 'Library/Caches/ccache')];
 
         const cacheKey = await generateCacheKeyAsync(ctx, workingDirectory);
+        const jobId = nullthrows(ctx.env.EAS_BUILD_ID, 'EAS_BUILD_ID is not set');
 
-        let jobId;
-        if (ctx.env.EAS_BUILD_ID) {
-          jobId = ctx.env.EAS_BUILD_ID;
-        } else {
-          jobId = nullthrows(
-            ctx.env.__WORKFLOW_JOB_ID,
-            'EAS_BUILD_ID or __WORKFLOW_JOB_ID is not set'
-          );
-        }
         const robotAccessToken = nullthrows(
           ctx.job.secrets?.robotAccessToken,
           'Robot access token is required for cache operations'
@@ -225,16 +217,8 @@ async function buildAsync(ctx: BuildContext<Ios.Job>): Promise<void> {
       const paths = [path.join(ctx.env.HOME, 'Library/Caches/ccache')];
 
       const cacheKey = await generateCacheKeyAsync(ctx, workingDirectory);
+      const jobId = nullthrows(ctx.env.EAS_BUILD_ID, 'EAS_BUILD_ID is not set');
 
-      let jobId;
-      if (ctx.env.EAS_BUILD_ID) {
-        jobId = ctx.env.EAS_BUILD_ID;
-      } else {
-        jobId = nullthrows(
-          ctx.env.__WORKFLOW_JOB_ID,
-          'EAS_BUILD_ID or __WORKFLOW_JOB_ID is not set'
-        );
-      }
       const robotAccessToken = nullthrows(
         ctx.job.secrets?.robotAccessToken,
         'Robot access token is required for cache operations'

--- a/packages/build-tools/src/builders/ios.ts
+++ b/packages/build-tools/src/builders/ios.ts
@@ -234,7 +234,7 @@ async function buildAsync(ctx: BuildContext<Ios.Job>): Promise<void> {
     });
   });
 
-  if (ctx.env.EAS_BUILD_RUNNER == 'eas-build') {
+  if (ctx.env.EAS_BUILD_RUNNER === 'eas-build') {
     await ctx.runBuildPhase(BuildPhase.SAVE_CACHE, async () => {
       const workingDirectory = ctx.getReactNativeProjectDirectory();
       const paths = [path.join(ctx.env.HOME, 'Library/Caches/ccache')];

--- a/packages/build-tools/src/builders/ios.ts
+++ b/packages/build-tools/src/builders/ios.ts
@@ -81,6 +81,7 @@ async function buildAsync(ctx: BuildContext<Ios.Job>): Promise<void> {
     await ctx.runBuildPhase(BuildPhase.RESTORE_CACHE, async () => {
       if (ctx.env.EAS_USE_CACHE !== 'true') {
         ctx.logger.info('EAS_USE_CACHE is not enabled');
+        return;
       }
       const workingDirectory = ctx.getReactNativeProjectDirectory();
       const paths = [path.join(ctx.env.HOME, 'Library/Caches/ccache')];
@@ -112,7 +113,7 @@ async function buildAsync(ctx: BuildContext<Ios.Job>): Promise<void> {
         await decompressCacheAsync({
           archivePath,
           workingDirectory,
-          verbose: true,
+          verbose: ctx.logger.debug(),
           logger: ctx.logger,
         });
 
@@ -219,6 +220,7 @@ async function buildAsync(ctx: BuildContext<Ios.Job>): Promise<void> {
   await ctx.runBuildPhase(BuildPhase.SAVE_CACHE, async () => {
     if (ctx.env.EAS_USE_CACHE !== 'true') {
       ctx.logger.info('EAS_USE_CACHE is not enabled');
+      return;
     }
     const workingDirectory = ctx.getReactNativeProjectDirectory();
     const paths = [path.join(ctx.env.HOME, 'Library/Caches/ccache')];
@@ -236,7 +238,7 @@ async function buildAsync(ctx: BuildContext<Ios.Job>): Promise<void> {
       const { archivePath } = await compressCacheAsync({
         paths,
         workingDirectory,
-        verbose: true,
+        verbose: ctx.logger.debug(),
         logger: ctx.logger,
       });
 

--- a/packages/build-tools/src/builders/ios.ts
+++ b/packages/build-tools/src/builders/ios.ts
@@ -80,7 +80,6 @@ async function buildAsync(ctx: BuildContext<Ios.Job>): Promise<void> {
 
     await ctx.runBuildPhase(BuildPhase.RESTORE_CACHE, async () => {
       if (ctx.env.EAS_USE_CACHE !== 'true') {
-        ctx.logger.info('EAS_USE_CACHE is not enabled');
         return;
       }
       const workingDirectory = ctx.getReactNativeProjectDirectory();
@@ -219,7 +218,6 @@ async function buildAsync(ctx: BuildContext<Ios.Job>): Promise<void> {
 
   await ctx.runBuildPhase(BuildPhase.SAVE_CACHE, async () => {
     if (ctx.env.EAS_USE_CACHE !== 'true') {
-      ctx.logger.info('EAS_USE_CACHE is not enabled');
       return;
     }
     const workingDirectory = ctx.getReactNativeProjectDirectory();

--- a/packages/build-tools/src/builders/ios.ts
+++ b/packages/build-tools/src/builders/ios.ts
@@ -131,6 +131,7 @@ async function buildAsync(ctx: BuildContext<Ios.Job>): Promise<void> {
           paths,
           key: cacheKey,
           keyPrefixes: [],
+          platform: ctx.job.platform,
         });
 
         await decompressCacheAsync({
@@ -302,6 +303,7 @@ async function buildAsync(ctx: BuildContext<Ios.Job>): Promise<void> {
         key: cacheKey,
         paths,
         size,
+        platform: ctx.job.platform,
       });
     } catch (err) {
       ctx.logger.warn({ err }, 'Failed to save cache');

--- a/packages/build-tools/src/builders/ios.ts
+++ b/packages/build-tools/src/builders/ios.ts
@@ -80,7 +80,7 @@ async function buildAsync(ctx: BuildContext<Ios.Job>): Promise<void> {
     });
 
     await ctx.runBuildPhase(BuildPhase.RESTORE_CACHE, async () => {
-      if (ctx.env.EAS_USE_CACHE !== 'true') {
+      if (ctx.env.EAS_USE_CACHE !== '1') {
         return;
       }
       const workingDirectory = ctx.getReactNativeProjectDirectory();
@@ -218,7 +218,7 @@ async function buildAsync(ctx: BuildContext<Ios.Job>): Promise<void> {
   });
 
   await ctx.runBuildPhase(BuildPhase.SAVE_CACHE, async () => {
-    if (ctx.env.EAS_USE_CACHE !== 'true') {
+    if (ctx.env.EAS_USE_CACHE !== '1') {
       return;
     }
     const workingDirectory = ctx.getReactNativeProjectDirectory();

--- a/packages/build-tools/src/steps/functions/restoreCache.ts
+++ b/packages/build-tools/src/steps/functions/restoreCache.ts
@@ -72,12 +72,15 @@ export function createRestoreCacheFunction(): BuildFunction {
           .filter((key) => key !== '');
 
         const jobId = nullthrows(env.EAS_BUILD_ID, 'EAS_BUILD_ID is not set');
+        const robotAccessToken = nullthrows(
+          stepsCtx.global.staticContext.job.secrets?.robotAccessToken
+        );
 
         const { archivePath, matchedKey } = await downloadCacheAsync({
           logger,
           jobId,
           expoApiServerURL: stepsCtx.global.staticContext.expoApiServerURL,
-          robotAccessToken: stepsCtx.global.staticContext.job.secrets?.robotAccessToken ?? null,
+          robotAccessToken,
           paths,
           key,
           keyPrefixes: restoreKeys,

--- a/packages/build-tools/src/steps/functions/restoreCache.ts
+++ b/packages/build-tools/src/steps/functions/restoreCache.ts
@@ -71,11 +71,11 @@ export function createRestoreCacheFunction(): BuildFunction {
           .parse(((inputs.restore_keys.value ?? '') as string).split(/[\r\n]+/))
           .filter((key) => key !== '');
 
-        const taskId = nullthrows(env.EAS_BUILD_ID, 'EAS_BUILD_ID is not set');
+        const jobId = nullthrows(env.EAS_BUILD_ID, 'EAS_BUILD_ID is not set');
 
         const { archivePath, matchedKey } = await downloadCacheAsync({
           logger,
-          buildId: taskId,
+          jobId,
           expoApiServerURL: stepsCtx.global.staticContext.expoApiServerURL,
           robotAccessToken: stepsCtx.global.staticContext.job.secrets?.robotAccessToken ?? null,
           paths,
@@ -104,7 +104,7 @@ export function createRestoreCacheFunction(): BuildFunction {
 
 export async function downloadCacheAsync({
   logger,
-  buildId,
+  jobId,
   expoApiServerURL,
   robotAccessToken,
   paths,
@@ -113,7 +113,7 @@ export async function downloadCacheAsync({
   platform,
 }: {
   logger: bunyan;
-  buildId: string;
+  jobId: string;
   expoApiServerURL: string;
   robotAccessToken: string;
   paths: string[];
@@ -126,13 +126,13 @@ export async function downloadCacheAsync({
     method: 'POST',
     body: platform
       ? JSON.stringify({
-          buildId,
+          buildId: jobId,
           key,
           version: getCacheVersion(paths),
           keyPrefixes,
         })
       : JSON.stringify({
-          jobRunId: buildId,
+          jobRunId: jobId,
           key,
           version: getCacheVersion(paths),
           keyPrefixes,
@@ -143,7 +143,6 @@ export async function downloadCacheAsync({
     },
   });
 
-  logger.info('version - ', getCacheVersion(paths));
   if (!response.ok) {
     if (response.status === 404) {
       throw new Error(

--- a/packages/build-tools/src/steps/functions/restoreCache.ts
+++ b/packages/build-tools/src/steps/functions/restoreCache.ts
@@ -21,6 +21,7 @@ import { Platform } from '@expo/eas-build-job';
 import { retryOnDNSFailure } from '../../utils/retryOnDNSFailure';
 import { formatBytes } from '../../utils/artifacts';
 import { getCacheVersion } from '../utils/cache';
+import { turtleFetch } from '../../utils/turtleFetch';
 
 const streamPipeline = promisify(stream.pipeline);
 
@@ -125,21 +126,20 @@ export async function downloadCacheAsync({
   platform: Platform | undefined;
 }): Promise<{ archivePath: string; matchedKey: string }> {
   const routerURL = platform ? 'v2/turtle-builds/caches/download' : 'v2/turtle-caches/download';
-  const response = await retryOnDNSFailure(fetch)(new URL(routerURL, expoApiServerURL), {
-    method: 'POST',
-    body: platform
-      ? JSON.stringify({
+  const response = await turtleFetch(new URL(routerURL, expoApiServerURL).toString(), 'POST', {
+    json: platform
+      ? {
           buildId: jobId,
           key,
           version: getCacheVersion(paths),
           keyPrefixes,
-        })
-      : JSON.stringify({
+        }
+      : {
           jobRunId: jobId,
           key,
           version: getCacheVersion(paths),
           keyPrefixes,
-        }),
+        },
     headers: {
       Authorization: `Bearer ${robotAccessToken}`,
       'Content-Type': 'application/json',

--- a/packages/build-tools/src/steps/functions/restoreCache.ts
+++ b/packages/build-tools/src/steps/functions/restoreCache.ts
@@ -74,7 +74,8 @@ export function createRestoreCacheFunction(): BuildFunction {
 
         const jobId = nullthrows(env.EAS_BUILD_ID, 'EAS_BUILD_ID is not set');
         const robotAccessToken = nullthrows(
-          stepsCtx.global.staticContext.job.secrets?.robotAccessToken
+          stepsCtx.global.staticContext.job.secrets?.robotAccessToken,
+          'robotAccessToken is not set'
         );
 
         const { archivePath, matchedKey } = await downloadCacheAsync({
@@ -126,6 +127,7 @@ export async function downloadCacheAsync({
   platform: Platform | undefined;
 }): Promise<{ archivePath: string; matchedKey: string }> {
   const routerURL = platform ? 'v2/turtle-builds/caches/download' : 'v2/turtle-caches/download';
+
   const response = await turtleFetch(new URL(routerURL, expoApiServerURL).toString(), 'POST', {
     json: platform
       ? {
@@ -144,7 +146,8 @@ export async function downloadCacheAsync({
       Authorization: `Bearer ${robotAccessToken}`,
       'Content-Type': 'application/json',
     },
-    shouldThrowOnNotOk: false,
+    retries: 2,
+    shouldThrowOnNotOk: true,
   });
 
   if (!response.ok) {

--- a/packages/build-tools/src/steps/functions/restoreCache.ts
+++ b/packages/build-tools/src/steps/functions/restoreCache.ts
@@ -21,7 +21,7 @@ import { Platform } from '@expo/eas-build-job';
 import { retryOnDNSFailure } from '../../utils/retryOnDNSFailure';
 import { formatBytes } from '../../utils/artifacts';
 import { getCacheVersion } from '../utils/cache';
-import { turtleFetch } from '../../utils/turtleFetch';
+import { turtleFetch, TurtleFetchError } from '../../utils/turtleFetch';
 
 const streamPipeline = promisify(stream.pipeline);
 
@@ -128,68 +128,74 @@ export async function downloadCacheAsync({
 }): Promise<{ archivePath: string; matchedKey: string }> {
   const routerURL = platform ? 'v2/turtle-builds/caches/download' : 'v2/turtle-caches/download';
 
-  const response = await turtleFetch(new URL(routerURL, expoApiServerURL).toString(), 'POST', {
-    json: platform
-      ? {
-          buildId: jobId,
-          key,
-          version: getCacheVersion(paths),
-          keyPrefixes,
-        }
-      : {
-          jobRunId: jobId,
-          key,
-          version: getCacheVersion(paths),
-          keyPrefixes,
-        },
-    headers: {
-      Authorization: `Bearer ${robotAccessToken}`,
-      'Content-Type': 'application/json',
-    },
-    retries: 2,
-    shouldThrowOnNotOk: true,
-  });
+  try {
+    const response = await turtleFetch(new URL(routerURL, expoApiServerURL).toString(), 'POST', {
+      json: platform
+        ? {
+            buildId: jobId,
+            key,
+            version: getCacheVersion(paths),
+            keyPrefixes,
+          }
+        : {
+            jobRunId: jobId,
+            key,
+            version: getCacheVersion(paths),
+            keyPrefixes,
+          },
+      headers: {
+        Authorization: `Bearer ${robotAccessToken}`,
+        'Content-Type': 'application/json',
+      },
+      // It's ok to retry POST caches/download, because we're only retrying signing a download URL.
+      retries: 2,
+      shouldThrowOnNotOk: true,
+    });
 
-  if (!response.ok) {
-    if (response.status === 404) {
+    const result = await asyncResult(response.json());
+    if (!result.ok) {
+      throw new Error(`Unexpected response from server (${response.status}): ${result.reason}`);
+    }
+
+    const { matchedKey, downloadUrl } = result.value.data;
+
+    logger.info(`Matched cache key: ${matchedKey}. Downloading...`);
+
+    const downloadDestinationDirectory = await fs.promises.mkdtemp(
+      path.join(os.tmpdir(), 'restore-cache-')
+    );
+
+    const downloadResponse = await retryOnDNSFailure(fetch)(downloadUrl);
+    if (!downloadResponse.ok) {
       throw new Error(
-        `No cache found for this key, ensure it was created with eas/save_cache (${response.status})`
+        `Unexpected response from cache server (${downloadResponse.status}): ${downloadResponse.statusText}`
       );
     }
-    const textResult = await asyncResult(response.text());
-    throw new Error(`Unexpected response from server (${response.status}): ${textResult.value}`);
+
+    // URL may contain percent-encoded characters, e.g. my%20file.apk
+    // this replaces all non-alphanumeric characters (excluding dot) with underscore
+    const archiveFilename = path
+      .basename(new URL(downloadUrl).pathname)
+      .replace(/([^a-z0-9.-]+)/gi, '_');
+    const archivePath = path.join(downloadDestinationDirectory, archiveFilename);
+
+    await streamPipeline(downloadResponse.body, fs.createWriteStream(archivePath));
+
+    return { archivePath, matchedKey };
+  } catch (err: any) {
+    if (err instanceof TurtleFetchError) {
+      if (err.response.status === 404) {
+        throw new Error(
+          `No cache found for this key, ensure it was created with eas/save_cache (${err.response.status})`
+        );
+      }
+      const textResult = await asyncResult(err.response.text());
+      throw new Error(
+        `Unexpected response from server (${err.response.status}): ${textResult.value}`
+      );
+    }
+    throw err;
   }
-
-  const result = await asyncResult(response.json());
-  if (!result.ok) {
-    throw new Error(`Unexpected response from server (${response.status}): ${result.reason}`);
-  }
-
-  const { matchedKey, downloadUrl } = result.value.data;
-
-  logger.info(`Matched cache key: ${matchedKey}. Downloading...`);
-
-  const downloadDestinationDirectory = await fs.promises.mkdtemp(
-    path.join(os.tmpdir(), 'restore-cache-')
-  );
-
-  const downloadResponse = await retryOnDNSFailure(fetch)(downloadUrl);
-  if (!downloadResponse.ok) {
-    throw new Error(
-      `Unexpected response from cache server (${downloadResponse.status}): ${downloadResponse.statusText}`
-    );
-  }
-
-  // URL may contain percent-encoded characters, e.g. my%20file.apk
-  // this replaces all non-alphanumeric characters (excluding dot) with underscore
-  const archiveFilename = path
-    .basename(new URL(downloadUrl).pathname)
-    .replace(/([^a-z0-9.-]+)/gi, '_');
-  const archivePath = path.join(downloadDestinationDirectory, archiveFilename);
-
-  await streamPipeline(downloadResponse.body, fs.createWriteStream(archivePath));
-
-  return { archivePath, matchedKey };
 }
 
 export async function decompressCacheAsync({

--- a/packages/build-tools/src/steps/functions/restoreCache.ts
+++ b/packages/build-tools/src/steps/functions/restoreCache.ts
@@ -74,7 +74,7 @@ export function createRestoreCacheFunction(): BuildFunction {
 
         const { archivePath, matchedKey } = await downloadCacheAsync({
           logger,
-          jobRunId: taskId,
+          buildId: taskId,
           expoApiServerURL: stepsCtx.global.staticContext.expoApiServerURL,
           robotAccessToken: stepsCtx.global.staticContext.job.secrets?.robotAccessToken ?? null,
           paths,
@@ -102,7 +102,7 @@ export function createRestoreCacheFunction(): BuildFunction {
 
 export async function downloadCacheAsync({
   logger,
-  jobRunId,
+  buildId,
   expoApiServerURL,
   robotAccessToken,
   paths,
@@ -110,7 +110,7 @@ export async function downloadCacheAsync({
   keyPrefixes,
 }: {
   logger: bunyan;
-  jobRunId: string;
+  buildId: string;
   expoApiServerURL: string;
   robotAccessToken: string;
   paths: string[];
@@ -118,11 +118,11 @@ export async function downloadCacheAsync({
   keyPrefixes: string[];
 }): Promise<{ archivePath: string; matchedKey: string }> {
   const response = await retryOnDNSFailure(fetch)(
-    new URL('v2/turtle-caches/download', expoApiServerURL),
+    new URL('v2/turtle-builds/caches/download', expoApiServerURL),
     {
       method: 'POST',
       body: JSON.stringify({
-        jobRunId,
+        buildId,
         key,
         version: getCacheVersion(paths),
         keyPrefixes,
@@ -134,6 +134,7 @@ export async function downloadCacheAsync({
     }
   );
 
+  logger.info('version - ', getCacheVersion(paths))
   if (!response.ok) {
     if (response.status === 404) {
       throw new Error(

--- a/packages/build-tools/src/steps/functions/restoreCache.ts
+++ b/packages/build-tools/src/steps/functions/restoreCache.ts
@@ -144,6 +144,7 @@ export async function downloadCacheAsync({
       Authorization: `Bearer ${robotAccessToken}`,
       'Content-Type': 'application/json',
     },
+    shouldThrowOnNotOk: false,
   });
 
   if (!response.ok) {

--- a/packages/build-tools/src/steps/functions/restoreCache.ts
+++ b/packages/build-tools/src/steps/functions/restoreCache.ts
@@ -22,7 +22,6 @@ import { retryOnDNSFailure } from '../../utils/retryOnDNSFailure';
 import { formatBytes } from '../../utils/artifacts';
 import { getCacheVersion } from '../utils/cache';
 
-
 const streamPipeline = promisify(stream.pipeline);
 
 export function createRestoreCacheFunction(): BuildFunction {

--- a/packages/build-tools/src/steps/functions/saveCache.ts
+++ b/packages/build-tools/src/steps/functions/saveCache.ts
@@ -118,6 +118,7 @@ export async function uploadCacheAsync({
       Authorization: `Bearer ${robotAccessToken}`,
       'Content-Type': 'application/json',
     },
+    shouldThrowOnNotOk: false,
   });
   if (!response.ok) {
     if (response.status === 409) {

--- a/packages/build-tools/src/steps/functions/saveCache.ts
+++ b/packages/build-tools/src/steps/functions/saveCache.ts
@@ -43,6 +43,9 @@ export function createSaveCacheFunction(): BuildFunction {
           .filter((path) => path.length > 0);
         const key = z.string().parse(inputs.key.value);
         const jobId = nullthrows(env.EAS_BUILD_ID, 'EAS_BUILD_ID is not set');
+        const robotAccessToken = nullthrows(
+          stepsCtx.global.staticContext.job.secrets?.robotAccessToken
+        );
 
         const { archivePath } = await compressCacheAsync({
           paths,
@@ -57,7 +60,7 @@ export function createSaveCacheFunction(): BuildFunction {
           logger,
           jobId,
           expoApiServerURL: stepsCtx.global.staticContext.expoApiServerURL,
-          robotAccessToken: stepsCtx.global.staticContext.job.secrets?.robotAccessToken ?? '',
+          robotAccessToken,
           archivePath,
           key,
           paths,
@@ -116,7 +119,6 @@ export async function uploadCacheAsync({
       'Content-Type': 'application/json',
     },
   });
-  logger.info('version - ', getCacheVersion(paths));
   if (!response.ok) {
     if (response.status === 409) {
       logger.info(`Cache already exists, skipping upload`);

--- a/packages/build-tools/src/steps/functions/saveCache.ts
+++ b/packages/build-tools/src/steps/functions/saveCache.ts
@@ -15,6 +15,7 @@ import { Platform } from '@expo/eas-build-job';
 import { retryOnDNSFailure } from '../../utils/retryOnDNSFailure';
 import { formatBytes } from '../../utils/artifacts';
 import { getCacheVersion } from '../utils/cache';
+import { turtleFetch } from '../../utils/turtleFetch';
 
 export function createSaveCacheFunction(): BuildFunction {
   return new BuildFunction({
@@ -99,21 +100,20 @@ export async function uploadCacheAsync({
     ? 'v2/turtle-builds/caches/upload-sessions'
     : 'v2/turtle-caches/upload-sessions';
 
-  const response = await retryOnDNSFailure(fetch)(new URL(routerURL, expoApiServerURL), {
-    method: 'POST',
-    body: platform
-      ? JSON.stringify({
+  const response = await turtleFetch(new URL(routerURL, expoApiServerURL).toString(), 'POST', {
+    json: platform
+      ? {
           buildId: jobId,
           key,
           version: getCacheVersion(paths),
           size,
-        })
-      : JSON.stringify({
+        }
+      : {
           jobRunId: jobId,
           key,
           version: getCacheVersion(paths),
           size,
-        }),
+        },
     headers: {
       Authorization: `Bearer ${robotAccessToken}`,
       'Content-Type': 'application/json',

--- a/packages/build-tools/src/steps/functions/saveCache.ts
+++ b/packages/build-tools/src/steps/functions/saveCache.ts
@@ -42,7 +42,7 @@ export function createSaveCacheFunction(): BuildFunction {
           .parse(((inputs.path.value ?? '') as string).split(/[\r\n]+/))
           .filter((path) => path.length > 0);
         const key = z.string().parse(inputs.key.value);
-        const taskId = nullthrows(env.EAS_BUILD_ID, 'EAS_BUILD_ID is not set');
+        const jobId = nullthrows(env.EAS_BUILD_ID, 'EAS_BUILD_ID is not set');
 
         const { archivePath } = await compressCacheAsync({
           paths,
@@ -55,7 +55,7 @@ export function createSaveCacheFunction(): BuildFunction {
 
         await uploadCacheAsync({
           logger,
-          buildId: taskId,
+          jobId,
           expoApiServerURL: stepsCtx.global.staticContext.expoApiServerURL,
           robotAccessToken: stepsCtx.global.staticContext.job.secrets?.robotAccessToken ?? '',
           archivePath,
@@ -73,7 +73,7 @@ export function createSaveCacheFunction(): BuildFunction {
 
 export async function uploadCacheAsync({
   logger,
-  buildId,
+  jobId,
   expoApiServerURL,
   robotAccessToken,
   paths,
@@ -83,7 +83,7 @@ export async function uploadCacheAsync({
   platform,
 }: {
   logger: bunyan;
-  buildId: string;
+  jobId: string;
   expoApiServerURL: string;
   robotAccessToken: string;
   paths: string[];
@@ -100,13 +100,13 @@ export async function uploadCacheAsync({
     method: 'POST',
     body: platform
       ? JSON.stringify({
-          buildId,
+          buildId: jobId,
           key,
           version: getCacheVersion(paths),
           size,
         })
       : JSON.stringify({
-          jobRunId: buildId,
+          jobRunId: jobId,
           key,
           version: getCacheVersion(paths),
           size,

--- a/packages/build-tools/src/steps/functions/saveCache.ts
+++ b/packages/build-tools/src/steps/functions/saveCache.ts
@@ -10,11 +10,11 @@ import z from 'zod';
 import nullthrows from 'nullthrows';
 import fetch from 'node-fetch';
 import { asyncResult } from '@expo/results';
+import { Platform } from '@expo/eas-build-job';
 
 import { retryOnDNSFailure } from '../../utils/retryOnDNSFailure';
 import { formatBytes } from '../../utils/artifacts';
 import { getCacheVersion } from '../utils/cache';
-import { Platform } from '@expo/eas-build-job';
 
 export function createSaveCacheFunction(): BuildFunction {
   return new BuildFunction({
@@ -92,31 +92,31 @@ export async function uploadCacheAsync({
   size: number;
   platform: Platform | undefined;
 }): Promise<void> {
-  const routerURL = platform ? 'v2/turtle-builds/caches/upload-sessions' : 'v2/turtle-caches/upload-sessions'
+  const routerURL = platform
+    ? 'v2/turtle-builds/caches/upload-sessions'
+    : 'v2/turtle-caches/upload-sessions';
 
-  const response = await retryOnDNSFailure(fetch)(
-    new URL(routerURL, expoApiServerURL),
-    {
-      method: 'POST',
-      body: platform ? JSON.stringify({
-        buildId,
-        key,
-        version: getCacheVersion(paths),
-        size,
-      })
+  const response = await retryOnDNSFailure(fetch)(new URL(routerURL, expoApiServerURL), {
+    method: 'POST',
+    body: platform
+      ? JSON.stringify({
+          buildId,
+          key,
+          version: getCacheVersion(paths),
+          size,
+        })
       : JSON.stringify({
-        jobRunId:buildId,
-        key,
-        version: getCacheVersion(paths),
-        size,
-      }),
-      headers: {
-        Authorization: `Bearer ${robotAccessToken}`,
-        'Content-Type': 'application/json',
-      },
-    }
-  );
-  logger.info('version - ', getCacheVersion(paths))
+          jobRunId: buildId,
+          key,
+          version: getCacheVersion(paths),
+          size,
+        }),
+    headers: {
+      Authorization: `Bearer ${robotAccessToken}`,
+      'Content-Type': 'application/json',
+    },
+  });
+  logger.info('version - ', getCacheVersion(paths));
   if (!response.ok) {
     if (response.status === 409) {
       logger.info(`Cache already exists, skipping upload`);


### PR DESCRIPTION
# Why

Provide support for utilizing ccache with the recently added `save` and `restore` cache functions for ios Builds and Workflows. This is intended to reduce job times by relying on our provided cache for redundant work, subsequently leading to efficient jobs and queues.

# How
A cache router has been defined for both builds and workflows. The caching steps are only enabled for builds that run on our workers, denoted with EAS_BUILD_RUNNER. The worker sets relevant environment variables that enables Fastlane to apply ccache https://github.com/expo/turtle-v2/pull/2398

# Test Plan
Validated with local build and workflow runs. Observed Fastlane runtime improvement from 3min to ~50 seconds, ensured ccache was successfully restored, used, and saved
<img width="1210" height="505" alt="Screenshot 2025-09-22 at 10 50 41 PM" src="https://github.com/user-attachments/assets/850c2d53-1c07-4e13-8036-ff2fe2e61221" />
Restore step matches key based off package manager diff and checks against cache route in www 
<img width="903" height="445" alt="Screenshot 2025-09-23 at 12 52 24 AM" src="https://github.com/user-attachments/assets/d30278f2-54b8-48ca-84eb-ada7cb665bcb" />
Save performs the same diff 
<img width="922" height="701" alt="Screenshot 2025-09-23 at 12 53 10 AM" src="https://github.com/user-attachments/assets/620e609e-bc89-4808-852a-fc8b1187acc3" />

```
➜  ccache -sv
Cache directory:    /Users/mustafa/Library/Caches/ccache
Config file:        /Users/mustafa/Library/Preferences/ccache/ccache.conf
System config file: /opt/homebrew/etc/ccache.conf
Stats updated:      never
Local storage:
  Cache size (GiB): 0.0 / 5.0 ( 0.00%)
  Files:              0
  Hits:               0
  Misses:             0
  Reads:              0
  Writes:             0
➜  ccache -sv
Cache directory:      /Users/mustafa/Library/Caches/ccache
Config file:          /Users/mustafa/Library/Preferences/ccache/ccache.conf
System config file:   /opt/homebrew/etc/ccache.conf
Stats updated:        Mon Sep 22 21:12:43 2025
Cacheable calls:      10128 / 10136 (99.92%)
  Hits:                7596 / 10128 (75.00%)
    Direct:            7596 /  7596 (100.0%)
    Preprocessed:         0 /  7596 ( 0.00%)
  Misses:              2532 / 10128 (25.00%)
Uncacheable calls:        8 / 10136 ( 0.08%)
  Called for linking:     8 /     8 (100.0%)
Successful lookups:
  Direct:              7596 / 10128 (75.00%)
  Preprocessed:           0
Local storage:
  Cache size (GiB):     0.9 /   5.0 (18.44%)
  Files:               7596
  Hits:                7596 / 10128 (75.00%)
  Misses:              2532 / 10128 (25.00%)
  Reads:              17724
  Writes:              5064
```
