### PR TITLE
[eas-build-job] remove z.codec for v4 supported transform

### DIFF
--- a/packages/build-tools/schema.graphql
+++ b/packages/build-tools/schema.graphql
@@ -6050,7 +6050,6 @@ type SubmissionMutation {
 
 input CreateIosSubmissionInput {
   appId: ID!
-  archiveUrl: String
   archiveSource: SubmissionArchiveSourceInput
   config: IosSubmissionConfigInput!
   submittedBuildId: ID
@@ -6058,7 +6057,6 @@ input CreateIosSubmissionInput {
 
 input CreateAndroidSubmissionInput {
   appId: ID!
-  archiveUrl: String
   archiveSource: SubmissionArchiveSourceInput
   config: AndroidSubmissionConfigInput!
   submittedBuildId: ID
@@ -6074,7 +6072,6 @@ input IosSubmissionConfigInput {
   appleAppSpecificPassword: String
   ascApiKey: AscApiKeyInput
   ascApiKeyId: String
-  archiveUrl: String
   appleIdUsername: String
   ascAppIdentifier: String!
   isVerboseFastlaneEnabled: Boolean
@@ -6087,7 +6084,6 @@ scalar SubmissionAndroidTrack
 input AndroidSubmissionConfigInput {
   googleServiceAccountKeyId: String
   googleServiceAccountKeyJson: String
-  archiveUrl: String
   applicationIdentifier: String
   track: SubmissionAndroidTrack!
   releaseStatus: SubmissionAndroidReleaseStatus

--- a/packages/eas-build-job/src/step.ts
+++ b/packages/eas-build-job/src/step.ts
@@ -129,10 +129,7 @@ export const ShellStepZ = CommonStepZ.extend({
     .array(
       z.union([
         // We allow a shorthand for outputs
-        z.codec(z.string(), z.object({ name: z.string(), required: z.boolean().default(false) }), {
-          decode: (name) => ({ name, required: false }),
-          encode: (output) => output.name,
-        }),
+        z.string().transform((name) => ({ name, required: false })),
         z.object({
           name: z.string(),
           required: z.boolean().optional(),


### PR DESCRIPTION
# Why
yarn fails to build after upgrading zod
```
   ✖  @expo/eas-build-job:build
$ tsc
       src/step.ts(132,11): error TS2339: Property 'codec' does not exist on type 'typeof import("/Users/mustafa/Source/eas-build/node_modules/zod/lib/external")'.
       src/step.ts(133,20): error TS7006: Parameter 'name' implicitly has an 'any' type.
       src/step.ts(134,20): error TS7006: Parameter 'output' implicitly has an 'any' type.
error Command failed with exit code 2.
```

# How

The package is using zod version ^4.1.3, but z.codec() was removed in zod v3. This code needs to be updated to use the modern zod API. The z.codec() should be replaced with z.transform()

# Test Plan

Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
