### PR TITLE
[eas-build-job] Remove fingerprint info from job's metadata

### DIFF
--- a/packages/build-tools/schema.graphql
+++ b/packages/build-tools/schema.graphql
@@ -6573,6 +6573,7 @@ type WorkflowJobApprovalMutation {
 
 type WorkflowRevisionMutation {
   validateWorkflowYamlConfig(yamlConfig: String!, appId: ID!): Boolean!
+  getOrCreateWorkflowRevisionFromGitRef(fileName: String!, gitRef: String!, appId: ID!): WorkflowRevision!
 }
 
 input WorkflowRevisionInput {
@@ -6599,6 +6600,7 @@ input WorkflowRunInput {
 
 type WorkflowRunMutation {
   createWorkflowRun(appId: ID!, workflowRevisionInput: WorkflowRevisionInput!, workflowRunInput: WorkflowRunInput!): WorkflowRun!
+  createWorkflowRunFromGitRef(workflowRevisionId: ID!, gitRef: String!, inputs: JSONObject): WorkflowRun!
   retryWorkflowRun(workflowRunId: ID!, fromFailedJobs: Boolean): WorkflowRun!
   cancelWorkflowRun(workflowRunId: ID!): WorkflowRun!
 }

--- a/packages/eas-build-job/src/__tests__/metadata.test.ts
+++ b/packages/eas-build-job/src/__tests__/metadata.test.ts
@@ -1,4 +1,4 @@
-import { FingerprintSourceType, Metadata, MetadataSchema } from '../metadata';
+import { Metadata, MetadataSchema } from '../metadata';
 
 const validMetadata: Metadata = {
   appName: 'testapp',
@@ -70,58 +70,5 @@ describe('MetadataSchema', () => {
     expect(error?.message).toEqual(
       '"credentialsSource" must be one of [local, remote]. "gitCommitHash" length must be 40 characters long. "gitCommitHash" must only contain hexadecimal characters. "gitCommitMessage" length must be less than or equal to 4096 characters long. "message" length must be less than or equal to 1024 characters long'
     );
-  });
-
-  test('Allows correct fingerprint', () => {
-    const metadata: Metadata = {
-      ...validMetadata,
-      fingerprintSource: {
-        type: FingerprintSourceType.GCS,
-        bucketKey:
-          'development/8a9c5554-cfbe-4b4c-814c-c476a1047db9/fd6f8af4-7293-46bd-bec7-3fe639f4fd3e',
-        isDebugFingerprint: true,
-      },
-    };
-    const { value, error } = MetadataSchema.validate(metadata, {
-      stripUnknown: true,
-      convert: true,
-      abortEarly: false,
-    });
-    expect(error).toBeFalsy();
-    expect(value).toEqual(metadata);
-  });
-
-  test('Validates incorrect fingerprint type', () => {
-    const metadata: Metadata = {
-      ...validMetadata,
-      fingerprintSource: {
-        type: 'BOO' as any,
-        bucketKey:
-          'development/8a9c5554-cfbe-4b4c-814c-c476a1047db9/fd6f8af4-7293-46bd-bec7-3fe639f4fd3e',
-      },
-    };
-    const { error } = MetadataSchema.validate(metadata, {
-      stripUnknown: true,
-      convert: true,
-      abortEarly: false,
-    });
-    expect(error?.message).toEqual('"fingerprintSource.type" must be one of [GCS, PATH, URL]');
-  });
-
-  test('Validates incorrect fingerprint key', () => {
-    const metadata: Metadata = {
-      ...validMetadata,
-      fingerprintSource: {
-        type: FingerprintSourceType.GCS,
-        // @ts-expect-error TypeScript is too smart. Need to ignore this for the failing test
-        url: 'development/8a9c5554-cfbe-4b4c-814c-c476a1047db9/fd6f8af4-7293-46bd-bec7-3fe639f4fd3e',
-      },
-    };
-    const { error } = MetadataSchema.validate(metadata, {
-      stripUnknown: true,
-      convert: true,
-      abortEarly: false,
-    });
-    expect(error?.message).toEqual('"fingerprintSource.bucketKey" is required');
   });
 });

--- a/packages/eas-build-job/src/index.ts
+++ b/packages/eas-build-job/src/index.ts
@@ -15,7 +15,7 @@ export {
   Cache,
   WorkflowInterpolationContext,
 } from './common';
-export { Metadata, sanitizeMetadata, FingerprintSource, FingerprintSourceType } from './metadata';
+export { Metadata, sanitizeMetadata } from './metadata';
 export * from './job';
 export * from './logs';
 export * as errors from './errors';

--- a/packages/eas-build-job/src/metadata.ts
+++ b/packages/eas-build-job/src/metadata.ts
@@ -2,18 +2,6 @@ import Joi from 'joi';
 
 import { Workflow } from './common';
 
-export enum FingerprintSourceType {
-  'GCS' = 'GCS',
-  'PATH' = 'PATH',
-  'URL' = 'URL',
-}
-
-export type FingerprintSource = { isDebugFingerprint?: boolean } & (
-  | { type: FingerprintSourceType.GCS; bucketKey: string }
-  | { type: FingerprintSourceType.PATH; path: string }
-  | { type: FingerprintSourceType.URL; url: string }
-);
-
 export type Metadata = {
   /**
    * Tracking context
@@ -70,11 +58,6 @@ export type Metadata = {
    * Fingerprint hash of a project's native dependencies
    */
   fingerprintHash?: string;
-
-  /**
-   * The location of the fingerprint file if one exists
-   */
-  fingerprintSource?: FingerprintSource;
 
   /**
    * Version of the react-native package used in the project.
@@ -188,31 +171,6 @@ export type Metadata = {
   environment?: 'production' | 'preview' | 'development';
 };
 
-const FingerprintSourceSchema = Joi.object<FingerprintSource>({
-  type: Joi.string()
-    .valid(...Object.values(FingerprintSourceType))
-    .required(),
-  isDebugFingerprint: Joi.boolean(),
-})
-  .when(Joi.object({ type: FingerprintSourceType.GCS }).unknown(), {
-    then: Joi.object({
-      type: Joi.string().valid(FingerprintSourceType.GCS).required(),
-      bucketKey: Joi.string().required(),
-    }),
-  })
-  .when(Joi.object({ type: FingerprintSourceType.PATH }).unknown(), {
-    then: Joi.object({
-      type: Joi.string().valid(FingerprintSourceType.PATH).required(),
-      path: Joi.string().required(),
-    }),
-  })
-  .when(Joi.object({ type: FingerprintSourceType.URL }).unknown(), {
-    then: Joi.object({
-      type: Joi.string().valid(FingerprintSourceType.URL).required(),
-      url: Joi.string().uri().required(),
-    }),
-  });
-
 export const MetadataSchema = Joi.object({
   trackingContext: Joi.object()
     .pattern(Joi.string(), [Joi.string(), Joi.number(), Joi.boolean()])
@@ -226,7 +184,6 @@ export const MetadataSchema = Joi.object({
   sdkVersion: Joi.string(),
   runtimeVersion: Joi.string(),
   fingerprintHash: Joi.string(),
-  fingerprintSource: FingerprintSourceSchema,
   reactNativeVersion: Joi.string(),
   channel: Joi.string(),
   appName: Joi.string(),


### PR DESCRIPTION
# Why

Since https://github.com/expo/eas-build/pull/587 we're not using this information.

# How

Removed fingerprint types, schema and metadata definition.

After this is merged going to bump the package in `www` and remove related code there too.

# Test Plan

CI should pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes fingerprint metadata types/validation/exports and related tests; adds GraphQL mutations to create workflow revisions and runs from git refs.
> 
> - **GraphQL Schema**:
>   - Add `workflowRevision.getOrCreateWorkflowRevisionFromGitRef(fileName, gitRef, appId)`.
>   - Add `workflowRun.createWorkflowRunFromGitRef(workflowRevisionId, gitRef, inputs)`.
> - **eas-build-job**:
>   - Remove fingerprint metadata support: delete `FingerprintSourceType`, `FingerprintSource`, `fingerprintSource` from `Metadata`, and `FingerprintSourceSchema` from `MetadataSchema`.
>   - Stop exporting `FingerprintSource` and `FingerprintSourceType` from `src/index.ts`.
>   - Delete fingerprint-related validation tests in `src/__tests__/metadata.test.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1473cc7e19558ceeb4598ced62e847bfa397eddf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->