### PR TITLE
[eas-build-job] Make `Metadata["trackingContext"]` optional

### DIFF
--- a/packages/eas-build-job/src/metadata.ts
+++ b/packages/eas-build-job/src/metadata.ts
@@ -7,7 +7,7 @@ export type Metadata = {
    * Tracking context
    * It's used to track build process across different Expo services and tools.
    */
-  trackingContext: Record<string, string | number | boolean>;
+  trackingContext?: Record<string, string | number | boolean>;
 
   /**
    * Application version:
@@ -172,9 +172,7 @@ export type Metadata = {
 };
 
 export const MetadataSchema = Joi.object({
-  trackingContext: Joi.object()
-    .pattern(Joi.string(), [Joi.string(), Joi.number(), Joi.boolean()])
-    .required(),
+  trackingContext: Joi.object().pattern(Joi.string(), [Joi.string(), Joi.number(), Joi.boolean()]),
   appVersion: Joi.string(),
   appBuildVersion: Joi.string(),
   cliVersion: Joi.string(),


### PR DESCRIPTION
Somewhat related to https://github.com/expo/workflow-orchestration/pull/407 and https://github.com/expo/turtle-v2/pull/2405.

We're not using `trackingContext` lately. This makes it so it's optional (it's the only property currently _required_ in metadata).