### PR TITLE
[build-tools] Expose artifact ID from `eas/upload_artifact`

### DIFF
--- a/packages/build-tools/src/customBuildContext.ts
+++ b/packages/build-tools/src/customBuildContext.ts
@@ -22,7 +22,9 @@ const platformToBuildRuntimePlatform: Record<Platform, BuildRuntimePlatform> = {
 };
 
 export interface BuilderRuntimeApi {
-  uploadArtifact: (spec: { artifact: ArtifactToUpload; logger: bunyan }) => Promise<void>;
+  uploadArtifact: (spec: { artifact: ArtifactToUpload; logger: bunyan }) => Promise<{
+    artifactId: string | null;
+  }>;
 }
 
 export class CustomBuildContext<TJob extends Job = Job> implements ExternalBuildContextProvider {

--- a/packages/local-build-plugin/src/android.ts
+++ b/packages/local-build-plugin/src/android.ts
@@ -28,7 +28,7 @@ export async function buildAndroidAsync(
       } else if (artifact.type === ManagedArtifactType.BUILD_ARTIFACTS) {
         return await prepareArtifacts(artifact.paths, logger);
       } else {
-        return null;
+        return { filename: null };
       }
     },
     env,

--- a/packages/local-build-plugin/src/artifacts.ts
+++ b/packages/local-build-plugin/src/artifacts.ts
@@ -6,7 +6,10 @@ import * as tar from 'tar';
 
 import config from './config';
 
-export async function prepareArtifacts(artifactPaths: string[], logger?: bunyan): Promise<string> {
+export async function prepareArtifacts(
+  artifactPaths: string[],
+  logger?: bunyan
+): Promise<{ filename: string }> {
   const l = logger?.child({ phase: 'PREPARE_ARTIFACTS' });
   l?.info('Preparing artifacts');
   let suffix;
@@ -39,7 +42,7 @@ export async function prepareArtifacts(artifactPaths: string[], logger?: bunyan)
   const destPath = config.artifactPath ?? path.join(config.artifactsDir, artifactName);
   await fs.copy(localPath, destPath);
   l?.info({ phase: 'PREPARE_ARTIFACTS' }, `Writing artifacts to ${destPath}`);
-  return destPath;
+  return { filename: destPath };
 }
 
 function getCommonParentDir(path1: string, path2: string): string {

--- a/packages/local-build-plugin/src/ios.ts
+++ b/packages/local-build-plugin/src/ios.ts
@@ -28,7 +28,7 @@ export async function buildIosAsync(
       } else if (artifact.type === ManagedArtifactType.BUILD_ARTIFACTS) {
         return await prepareArtifacts(artifact.paths, logger);
       } else {
-        return null;
+        return { filename: null };
       }
     },
     env,


### PR DESCRIPTION
## Why

Users want to download test report of specific jobs in a workflow run.

## How

By exposing `artifact_id`, we let them do:
```yaml
steps:
  - uses: eas/download_artifact
    with:
      artifact_id: ${{ after.maestro_ios.outputs.test_report_artifact_id }}
```

## Test Plan

- [x] Tested manually.

<img width="1818" height="1441" alt="Zrzut ekranu 2025-10-2 o 11 54 46" src="https://github.com/user-attachments/assets/209c375b-9234-4d37-abcd-3c5d8512cec2" />

```yaml
jobs:
  custom_test:
    outputs:
      artifact_id: ${{ steps.upload.outputs.artifact_id }}
    steps:
      - run: echo "hello" > test.txt
      - uses: eas/upload_artifact
        id: upload
        with:
          path: test.txt
  download_artifact:
    needs: [custom_test]
    steps:
      - uses: eas/download_artifact
        id: download
        with:
          artifact_id: ${{ needs.custom_test.outputs.artifact_id }}
      - run: |
          echo "Artifact downloaded: ${{ steps.download.outputs.artifact_path }}"
          cat "${{ steps.download.outputs.artifact_path }}"
```