### PR TITLE
[build-tools] Move file secrets to `tmpdir`

### DIFF
--- a/packages/build-tools/src/context.ts
+++ b/packages/build-tools/src/context.ts
@@ -387,6 +387,7 @@ export class BuildContext<TJob extends Job = Job> {
     }
 
     const environmentSecretsDirectory = path.join(os.tmpdir(), 'eas-environment-secrets');
+
     const environmentSecrets: Record<string, string> = {};
     for (const { name, type, value } of job.secrets.environmentSecrets) {
       if (type === EnvironmentSecretType.STRING) {


### PR DESCRIPTION
# Why

https://exponent-internal.slack.com/archives/C06EFBQK3B7/p1759498206016129

# How

Instead of putting the file environment variables under working directory, let's try putting them somewhere else — `tmpdir()`.

# Test Plan

Tested manually.

<img width="1254" height="735" alt="Zrzut ekranu 2025-10-3 o 16 46 11" src="https://github.com/user-attachments/assets/2e3dee5a-2d72-42c4-b35a-70dd8395dbe9" />
