### PR TITLE
[build-tools] locate packager root directory

### DIFF
--- a/packages/build-tools/src/builders/android.ts
+++ b/packages/build-tools/src/builders/android.ts
@@ -28,6 +28,7 @@ import { prepareExecutableAsync } from '../utils/prepareBuildExecutable';
 import { eagerBundleAsync, shouldUseEagerBundle } from '../common/eagerBundle';
 import { decompressCacheAsync, downloadCacheAsync } from '../steps/functions/restoreCache';
 import { compressCacheAsync, uploadCacheAsync } from '../steps/functions/saveCache';
+import { findPackagerRootDir } from '../utils/packageManager';
 
 import { runBuilderWithHooksAsync } from './common';
 import { runCustomBuildAsync } from './custom';
@@ -293,8 +294,9 @@ endif()
 async function generateCacheKeyAsync(workingDirectory: string): Promise<string> {
   // This will resolve which package manager and use the relevant lock file
   // The lock file hash is the key and ensures cache is fresh
-  const manager = PackageManagerUtils.createForProject(workingDirectory);
-  const lockPath = path.join(workingDirectory, manager.lockFile);
+  const packagerRunDir = findPackagerRootDir(workingDirectory);
+  const manager = PackageManagerUtils.createForProject(packagerRunDir);
+  const lockPath = path.join(packagerRunDir, manager.lockFile);
 
   try {
     const key = await hashFiles([lockPath]);

--- a/packages/build-tools/src/builders/ios.ts
+++ b/packages/build-tools/src/builders/ios.ts
@@ -30,10 +30,10 @@ import { getParentAndDescendantProcessPidsAsync } from '../utils/processes';
 import { eagerBundleAsync, shouldUseEagerBundle } from '../common/eagerBundle';
 import { uploadCacheAsync, compressCacheAsync } from '../steps/functions/saveCache';
 import { downloadCacheAsync, decompressCacheAsync } from '../steps/functions/restoreCache';
+import { findPackagerRootDir } from '../utils/packageManager';
 
 import { runBuilderWithHooksAsync } from './common';
 import { runCustomBuildAsync } from './custom';
-import { findPackagerRootDir } from '../utils/packageManager';
 
 const INSTALL_PODS_WARN_TIMEOUT_MS = 15 * 60 * 1000; // 15 minutes
 const INSTALL_PODS_KILL_TIMEOUT_MS = 30 * 60 * 1000; // 30 minutes

--- a/packages/build-tools/src/builders/ios.ts
+++ b/packages/build-tools/src/builders/ios.ts
@@ -33,6 +33,7 @@ import { downloadCacheAsync, decompressCacheAsync } from '../steps/functions/res
 
 import { runBuilderWithHooksAsync } from './common';
 import { runCustomBuildAsync } from './custom';
+import { findPackagerRootDir } from '../utils/packageManager';
 
 const INSTALL_PODS_WARN_TIMEOUT_MS = 15 * 60 * 1000; // 15 minutes
 const INSTALL_PODS_KILL_TIMEOUT_MS = 30 * 60 * 1000; // 30 minutes
@@ -403,8 +404,9 @@ async function runInstallPodsAsync(ctx: BuildContext<Ios.Job>): Promise<void> {
 async function generateCacheKeyAsync(workingDirectory: string): Promise<string> {
   // This will resolve which package manager and use the relevant lock file
   // The lock file hash is the key and ensures cache is fresh
-  const manager = PackageManagerUtils.createForProject(workingDirectory);
-  const lockPath = path.join(workingDirectory, manager.lockFile);
+  const packagerRunDir = findPackagerRootDir(workingDirectory);
+  const manager = PackageManagerUtils.createForProject(packagerRunDir);
+  const lockPath = path.join(packagerRunDir, manager.lockFile);
 
   try {
     const key = await hashFiles([lockPath]);


### PR DESCRIPTION
# Why

Support builds for Apps in monorepo's with multiple workspaces. This will now locate the root package manager and use the respective lockfile as the cache key.

# How

generate cache key now leverages packageManager's findPackagerRootDir function instead of assuming root

# Test Plan


in root
<img width="1160" height="638" alt="Screenshot 2025-10-03 at 4 47 22 PM" src="https://github.com/user-attachments/assets/181b2f39-963b-49e6-9741-d60ff115e994" />

from a monorepo, nested app
<img width="734" height="299" alt="Screenshot 2025-10-06 at 9 49 20 AM" src="https://github.com/user-attachments/assets/d6f9b1e3-4d49-4683-bac0-891673332f8a" />


<img width="1141" height="740" alt="Screenshot 2025-10-06 at 9 52 58 AM" src="https://github.com/user-attachments/assets/e9e5b627-fb23-4104-b181-ff79ea9e7755" />

